### PR TITLE
Add create_next_snapshot_version action to plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A plugin including commonly used automation logic for RevenueCat SDKs.
 
 - `bump_version_update_changelog_create_pr`: This action asks for a new version number and updates all occurences of the old version number (passed as a parameter) in the list of files to update (also passed as a parameter). It also fetches the list of commits since the last tag in the given repo and generates a changelog using those, allowing the user to edit the result. Finally, it creates a release branch in the form of `release/NEW_VERSION_NUMBER`, commits and pushes all changes to `origin` and creates a release PR.
 - `replace_version_number`: This action asks for a new version number and updates all occurences of the old version number (passed as a parameter) in the list of files to update (also passed as a parameter).
+- `create_next_snapshot_version`: This action creates bumps the version to the next minor with a `-SNAPSHOT` suffix and creates a PR with the changes.
 
 ## Example
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,3 +22,14 @@ lane :sample_replace_version_number_action do |options|
     files_to_update_without_prerelease_modifiers: []
   )
 end
+
+lane :sample_create_next_snapshot_version_action do |options|
+  create_next_snapshot_version(
+    current_version: 'current_version_number',
+    repo_name: 'repo-name',
+    github_pr_token: 'github-api-token', # This can also be obtained from ENV GITHUB_PULL_REQUEST_API_TOKEN
+    files_to_update: ['./file-containing-version-1.txt', './file-containing-version-2.rb'],
+    files_to_update_without_prerelease_modifiers: [],
+    branch: 'main'
+  )
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -18,14 +18,7 @@ module Fastlane
         changelog_path = params[:changelog_path]
         editor = params[:editor]
 
-        # Ensure GitHub API token is set
-        if github_pr_token.nil? || github_pr_token.empty?
-          UI.error("A github_pr_token parameter or an environment variable GITHUB_PULL_REQUEST_API_TOKEN is required to create a pull request")
-          UI.error("Please make a fastlane/.env file from the fastlane/.env.SAMPLE template")
-          UI.user_error!("Could not find value for GITHUB_PULL_REQUEST_API_TOKEN")
-        end
-
-        Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump(branch)
+        Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump(branch, github_pr_token)
 
         UI.important("Current version is #{version_number}")
 
@@ -36,14 +29,14 @@ module Fastlane
         Helper::RevenuecatInternalHelper.edit_changelog(generated_contents, changelog_latest_path, editor)
         changelog = File.read(changelog_latest_path)
 
-        Helper::RevenuecatInternalHelper.create_new_release_branch(new_version_number)
+        Helper::RevenuecatInternalHelper.create_and_checkout_new_branch("release/#{new_version_number}")
         Helper::RevenuecatInternalHelper.replace_version_number(version_number,
                                                                 new_version_number,
                                                                 files_to_update,
                                                                 files_to_update_without_prerelease_modifiers)
         Helper::RevenuecatInternalHelper.attach_changelog_to_master(new_version_number, changelog_latest_path, changelog_path)
         Helper::RevenuecatInternalHelper.commmit_changes_and_push_current_branch("Version bump for #{new_version_number}")
-        Helper::RevenuecatInternalHelper.create_release_pr(new_version_number, changelog, repo_name, github_pr_token)
+        Helper::RevenuecatInternalHelper.create_pr_to_main("Release/#{new_version_number}", changelog, repo_name, github_pr_token)
       end
 
       def self.description

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -36,7 +36,9 @@ module Fastlane
                                                                 files_to_update_without_prerelease_modifiers)
         Helper::RevenuecatInternalHelper.attach_changelog_to_master(new_version_number, changelog_latest_path, changelog_path)
         Helper::RevenuecatInternalHelper.commmit_changes_and_push_current_branch("Version bump for #{new_version_number}")
-        Helper::RevenuecatInternalHelper.create_pr_to_main("Release/#{new_version_number}", changelog, repo_name, github_pr_token)
+
+        pr_title = "Release/#{new_version_number}"
+        Helper::RevenuecatInternalHelper.create_pr_to_main(pr_title, changelog, repo_name, github_pr_token)
       end
 
       def self.description

--- a/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
@@ -1,0 +1,81 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require_relative '../helper/revenuecat_internal_helper'
+
+module Fastlane
+  module Actions
+    class CreateNextSnapshotVersionAction < Action
+      def self.run(params)
+        previous_version_number = params[:current_version]
+        repo_name = params[:repo_name]
+        github_pr_token = params[:github_pr_token]
+        files_to_update = params[:files_to_update]
+        files_to_update_without_prerelease_modifiers = params[:files_to_update_without_prerelease_modifiers]
+        branch = params[:branch]
+
+        Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump(branch, github_pr_token)
+
+        next_version_snapshot = Helper::RevenuecatInternalHelper.calculate_next_snapshot_version(previous_version_number)
+        branch_name = "bump/#{next_version_snapshot}"
+
+        Helper::RevenuecatInternalHelper.create_and_checkout_new_branch(branch_name)
+
+        Helper::RevenuecatInternalHelper.replace_version_number(previous_version_number,
+                                                                next_version_snapshot,
+                                                                files_to_update,
+                                                                files_to_update_without_prerelease_modifiers)
+
+        Helper::RevenuecatInternalHelper.commmit_changes_and_push_current_branch('Preparing for next version')
+
+        Helper::RevenuecatInternalHelper.create_pr_to_main("Prepare next version: #{next_version_snapshot}", nil, repo_name, github_pr_token)
+      end
+
+      def self.description
+        "Bumps minor version and adds -SNAPSHOT suffix to version. Creates a PR with the changes"
+      end
+
+      def self.authors
+        ["Toni Rico"]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :current_version,
+                                       description: "Current version of the sdk",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :repo_name,
+                                       env_name: "RC_INTERNAL_REPO_NAME",
+                                       description: "Name of the repo of the SDK",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :github_pr_token,
+                                       env_name: "GITHUB_PULL_REQUEST_API_TOKEN",
+                                       description: "Github token to use to create the release PR",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :files_to_update,
+                                       env_name: "RC_INTERNAL_FILES_TO_UPDATE_VERSION",
+                                       description: "Files that contain the version number and need to have it updated",
+                                       optional: false,
+                                       type: Array),
+          FastlaneCore::ConfigItem.new(key: :files_to_update_without_prerelease_modifiers,
+                                       env_name: "RC_INTERNAL_FILES_TO_UPDATE_VERSION_WITHOUT_PRERELEASE_MODIFIERS",
+                                       description: "Files that contain the version number without release modifiers and need to have it updated",
+                                       optional: true,
+                                       default_value: [],
+                                       type: Array),
+          FastlaneCore::ConfigItem.new(key: :branch,
+                                       description: "Allows to execute the action from the given branch",
+                                       optional: true,
+                                       default_value: "main",
+                                       type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/spec/actions/create_next_snapshot_version_action_spec.rb
+++ b/spec/actions/create_next_snapshot_version_action_spec.rb
@@ -1,0 +1,45 @@
+describe Fastlane::Actions::CreateNextSnapshotVersionAction do
+  describe '#run' do
+    let(:github_pr_token) { 'fake-github-pr-token' }
+    let(:repo_name) { 'fake-repo-name' }
+    let(:branch) { 'branch' }
+    let(:current_version) { '1.12.0' }
+    let(:next_version) { '1.13.0-SNAPSHOT' }
+
+    it 'calls all the appropriate methods with appropriate parameters' do
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:validate_local_config_status_for_bump)
+        .with(branch, github_pr_token)
+        .once
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:calculate_next_snapshot_version)
+        .with(current_version)
+        .and_return(next_version)
+        .once
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_and_checkout_new_branch)
+        .with('bump/1.13.0-SNAPSHOT')
+        .once
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_version_number)
+        .with(current_version, next_version, ['./test_file.sh', './test_file2.rb'], ['./test_file4.swift', './test_file5.kt'])
+        .once
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:commmit_changes_and_push_current_branch)
+        .with('Preparing for next version')
+        .once
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
+        .with('Prepare next version: 1.13.0-SNAPSHOT', nil, repo_name, github_pr_token)
+        .once
+      Fastlane::Actions::CreateNextSnapshotVersionAction.run(
+        current_version: current_version,
+        repo_name: repo_name,
+        github_pr_token: github_pr_token,
+        files_to_update: ['./test_file.sh', './test_file2.rb'],
+        files_to_update_without_prerelease_modifiers: ['./test_file4.swift', './test_file5.kt'],
+        branch: branch
+      )
+    end
+  end
+
+  describe '#available_options' do
+    it 'has correct number of options' do
+      expect(Fastlane::Actions::CreateNextSnapshotVersionAction.available_options.size).to eq(6)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new action to the fastlane plugin, `create_next_snapshot_version`. This action will bump the version to the next minor with a `-SNAPSHOT` version and create a PR with the changes.

### TODO
- [x] Hold until #2 is merged

