### PR TITLE
Add create_github_release action to plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A plugin including commonly used automation logic for RevenueCat SDKs.
 - `bump_version_update_changelog_create_pr`: This action asks for a new version number and updates all occurences of the old version number (passed as a parameter) in the list of files to update (also passed as a parameter). It also fetches the list of commits since the last tag in the given repo and generates a changelog using those, allowing the user to edit the result. Finally, it creates a release branch in the form of `release/NEW_VERSION_NUMBER`, commits and pushes all changes to `origin` and creates a release PR.
 - `replace_version_number`: This action asks for a new version number and updates all occurences of the old version number (passed as a parameter) in the list of files to update (also passed as a parameter).
 - `create_next_snapshot_version`: This action creates bumps the version to the next minor with a `-SNAPSHOT` suffix and creates a PR with the changes.
+- `create_github_release`: This action will create a github release with the given version number as name and tag and the contents of the CHANGELOG.latest.md file as description. It can also upload files to the release if needed.
 
 ## Example
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,3 +33,13 @@ lane :sample_create_next_snapshot_version_action do |options|
     branch: 'main'
   )
 end
+
+lane :sample_create_github_release_action do |options|
+  create_github_release(
+    version: 'release_version_number',
+    repo_name: 'repo-name',
+    github_api_token: 'github-api-token', # This can also be obtained from ENV RC_INTERNAL_GITHUB_TOKEN
+    changelog_latest_path: './path-to/CHANGELOG.latest.md',
+    upload_assets: ['./file-to-upload.txt', './file-to-upload-2.rb']
+  )
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/create_github_release_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/create_github_release_action.rb
@@ -29,7 +29,7 @@ module Fastlane
       end
 
       def self.description
-        "Bumps minor version and adds -SNAPSHOT suffix to version. Creates a PR with the changes"
+        "Creates a github release with the given version number using the CHANGELOG.latest.md file as description and tagging the latest commit of the current branch"
       end
 
       def self.authors

--- a/lib/fastlane/plugin/revenuecat_internal/actions/create_github_release_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/create_github_release_action.rb
@@ -1,0 +1,72 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require 'fastlane_core/ui/ui'
+require_relative '../helper/revenuecat_internal_helper'
+
+module Fastlane
+  module Actions
+    class CreateGithubReleaseAction < Action
+      def self.run(params)
+        release_version = params[:version]
+        repo_name = params[:repo_name]
+        github_api_token = params[:github_api_token]
+        changelog_latest_path = params[:changelog_latest_path]
+        upload_assets = params[:upload_assets]
+
+        begin
+          changelog = File.read(changelog_latest_path)
+        rescue StandardError
+          UI.user_error!("Please add a CHANGELOG.latest.md file before calling this lane")
+        end
+
+        Helper::RevenuecatInternalHelper.create_github_release(
+          release_version,
+          changelog,
+          upload_assets,
+          repo_name,
+          github_api_token
+        )
+      end
+
+      def self.description
+        "Bumps minor version and adds -SNAPSHOT suffix to version. Creates a PR with the changes"
+      end
+
+      def self.authors
+        ["Toni Rico"]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       description: "Version of the SDK to release",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :repo_name,
+                                       env_name: "RC_INTERNAL_REPO_NAME",
+                                       description: "Name of the repo of the SDK",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :github_api_token,
+                                       env_name: "RC_INTERNAL_GITHUB_TOKEN",
+                                       description: "Github token to use to create the release",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :changelog_latest_path,
+                                       description: "Path to CHANGELOG.latest.md file",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :upload_assets,
+                                       description: "Array of paths to assets to upload in the release",
+                                       optional: true,
+                                       default_value: [],
+                                       type: Array)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -180,7 +180,8 @@ module Fastlane
           commitish: commit_hash,
           upload_assets: upload_assets,
           is_draft: false,
-          is_prerelease: is_prerelease
+          is_prerelease: is_prerelease,
+          server_url: 'https://api.github.com'
         )
       end
     end

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -5,6 +5,7 @@ require 'fastlane/actions/push_to_git_remote'
 require 'fastlane/actions/create_pull_request'
 require 'fastlane/actions/ensure_git_branch'
 require 'fastlane/actions/ensure_git_status_clean'
+require 'fastlane/actions/set_github_release'
 
 module Fastlane
   UI = FastlaneCore::UI unless Fastlane.const_defined?(:UI)
@@ -164,6 +165,23 @@ module Fastlane
         minor = version_split[1]
         next_version = "#{major}.#{minor.to_i + 1}.0"
         "#{next_version}-SNAPSHOT"
+      end
+
+      def self.create_github_release(release_version, release_description, upload_assets, repo_name, github_api_token)
+        commit_hash = Actions.last_git_commit_dict[:commit_hash]
+        is_prerelease = release_version.include?("-")
+
+        Actions::SetGithubReleaseAction.run(
+          repository_name: "RevenueCat/#{repo_name}",
+          api_token: github_api_token,
+          name: release_version,
+          tag_name: release_version,
+          description: release_description,
+          commitish: commit_hash,
+          upload_assets: upload_assets,
+          is_draft: false,
+          is_prerelease: is_prerelease
+        )
       end
     end
   end

--- a/spec/actions/create_github_release_action_spec.rb
+++ b/spec/actions/create_github_release_action_spec.rb
@@ -1,0 +1,47 @@
+describe Fastlane::Actions::CreateGithubReleaseAction do
+  describe '#run' do
+    let(:github_api_token) { 'fake-github-api-token' }
+    let(:repo_name) { 'fake-repo-name' }
+    let(:branch) { 'branch' }
+    let(:release_version) { '1.12.0' }
+    let(:changelog) { 'fake-changelog' }
+    let(:changelog_latest_path) { './fake-changelog-latest-path/CHANGELOG.latest.md' }
+    let(:upload_assets) { ['./path-to/upload-asset-1.txt', './path-to/upload-asset-2.rb'] }
+
+    before(:each) do
+      allow(File).to receive(:read).with(changelog_latest_path).and_return(changelog)
+    end
+
+    it 'calls all the appropriate methods with appropriate parameters' do
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_github_release)
+        .with(release_version, changelog, upload_assets, repo_name, github_api_token)
+        .once
+      Fastlane::Actions::CreateGithubReleaseAction.run(
+        version: release_version,
+        repo_name: repo_name,
+        github_api_token: github_api_token,
+        changelog_latest_path: changelog_latest_path,
+        upload_assets: upload_assets
+      )
+    end
+
+    it 'fails if can not read CHANGELOG.latest.md file' do
+      allow(File).to receive(:read).with(changelog_latest_path).and_raise(StandardError)
+      expect do
+        Fastlane::Actions::CreateGithubReleaseAction.run(
+          version: release_version,
+          repo_name: repo_name,
+          github_api_token: github_api_token,
+          changelog_latest_path: changelog_latest_path,
+          upload_assets: upload_assets
+        )
+      end.to raise_exception(StandardError)
+    end
+  end
+
+  describe '#available_options' do
+    it 'has correct number of options' do
+      expect(Fastlane::Actions::CreateGithubReleaseAction.available_options.size).to eq(5)
+    end
+  end
+end

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -353,6 +353,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
     let(:github_api_token) { 'fake-github-api-token' }
     let(:no_prerelease_version) { '1.11.0' }
     let(:prerelease_version) { '1.11.0-SNAPSHOT' }
+    let(:server_url) { 'https://api.github.com' }
 
     before(:each) do
       allow(Fastlane::Actions).to receive(:last_git_commit_dict).and_return(commit_hash: commit_hash)
@@ -368,7 +369,8 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
         commitish: commit_hash,
         upload_assets: upload_assets,
         is_draft: false,
-        is_prerelease: false
+        is_prerelease: false,
+        server_url: server_url
       )
       Fastlane::Helper::RevenuecatInternalHelper.create_github_release(
         no_prerelease_version,
@@ -389,7 +391,8 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
         commitish: commit_hash,
         upload_assets: upload_assets,
         is_draft: false,
-        is_prerelease: true
+        is_prerelease: true,
+        server_url: server_url
       )
       Fastlane::Helper::RevenuecatInternalHelper.create_github_release(
         prerelease_version,

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -344,4 +344,60 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       end.to raise_exception(StandardError)
     end
   end
+
+  describe '.create_github_release' do
+    let(:commit_hash) { 'fake-commit-hash' }
+    let(:release_description) { 'fake-description' }
+    let(:upload_assets) { ['./path-to/upload-asset-1.txt', './path-to/upload-asset-2.rb'] }
+    let(:repo_name) { 'fake-repo-name' }
+    let(:github_api_token) { 'fake-github-api-token' }
+    let(:no_prerelease_version) { '1.11.0' }
+    let(:prerelease_version) { '1.11.0-SNAPSHOT' }
+
+    before(:each) do
+      allow(Fastlane::Actions).to receive(:last_git_commit_dict).and_return(commit_hash: commit_hash)
+    end
+
+    it 'calls SetGithubReleaseAction with appropriate parameters for non-prerelease version' do
+      expect(Fastlane::Actions::SetGithubReleaseAction).to receive(:run).with(
+        repository_name: "RevenueCat/fake-repo-name",
+        api_token: github_api_token,
+        name: no_prerelease_version,
+        tag_name: no_prerelease_version,
+        description: release_description,
+        commitish: commit_hash,
+        upload_assets: upload_assets,
+        is_draft: false,
+        is_prerelease: false
+      )
+      Fastlane::Helper::RevenuecatInternalHelper.create_github_release(
+        no_prerelease_version,
+        release_description,
+        upload_assets,
+        repo_name,
+        github_api_token
+      )
+    end
+
+    it 'calls SetGithubReleaseAction with appropriate parameters for prerelease version' do
+      expect(Fastlane::Actions::SetGithubReleaseAction).to receive(:run).with(
+        repository_name: "RevenueCat/fake-repo-name",
+        api_token: github_api_token,
+        name: prerelease_version,
+        tag_name: prerelease_version,
+        description: release_description,
+        commitish: commit_hash,
+        upload_assets: upload_assets,
+        is_draft: false,
+        is_prerelease: true
+      )
+      Fastlane::Helper::RevenuecatInternalHelper.create_github_release(
+        prerelease_version,
+        release_description,
+        upload_assets,
+        repo_name,
+        github_api_token
+      )
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a new action to the fastlane plugin, `create_github_release`. This action will create a github release with the given version number as name and tag and the contents of the CHANGELOG.latest.md file as description. It can also upload files to the release if needed.

### TODO
- [x] Hold until #3  has been merged
