### PR TITLE
Validate release branch does not exist before bumping action

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -18,18 +18,20 @@ module Fastlane
         changelog_path = params[:changelog_path]
         editor = params[:editor]
 
-        Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump(branch, github_pr_token)
-
         UI.important("Current version is #{version_number}")
 
         # Ask for new version number
         new_version_number = UI.input("New version number: ")
 
+        new_branch_name = "release/#{new_version_number}"
+
+        Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump(branch, new_branch_name, github_pr_token)
+
         generated_contents = Helper::RevenuecatInternalHelper.auto_generate_changelog(repo_name, github_token, rate_limit_sleep)
         Helper::RevenuecatInternalHelper.edit_changelog(generated_contents, changelog_latest_path, editor)
         changelog = File.read(changelog_latest_path)
 
-        Helper::RevenuecatInternalHelper.create_and_checkout_new_branch("release/#{new_version_number}")
+        Helper::RevenuecatInternalHelper.create_and_checkout_new_branch(new_branch_name)
         Helper::RevenuecatInternalHelper.replace_version_number(version_number,
                                                                 new_version_number,
                                                                 files_to_update,

--- a/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
@@ -13,12 +13,12 @@ module Fastlane
         files_to_update_without_prerelease_modifiers = params[:files_to_update_without_prerelease_modifiers]
         branch = params[:branch]
 
-        Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump(branch, github_pr_token)
-
         next_version_snapshot = Helper::RevenuecatInternalHelper.calculate_next_snapshot_version(previous_version_number)
-        branch_name = "bump/#{next_version_snapshot}"
+        new_branch_name = "bump/#{next_version_snapshot}"
 
-        Helper::RevenuecatInternalHelper.create_and_checkout_new_branch(branch_name)
+        Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump(branch, new_branch_name, github_pr_token)
+
+        Helper::RevenuecatInternalHelper.create_and_checkout_new_branch(new_branch_name)
 
         Helper::RevenuecatInternalHelper.replace_version_number(previous_version_number,
                                                                 next_version_snapshot,

--- a/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
+++ b/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
@@ -16,7 +16,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
       allow(FastlaneCore::UI).to receive(:input).with('New version number: ').and_return(new_version)
       allow(File).to receive(:read).with(mock_changelog_latest_path).and_return(edited_changelog)
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:validate_local_config_status_for_bump)
-        .with(branch, mock_github_pr_token)
+        .with(branch, 'release/1.13.0', mock_github_pr_token)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:auto_generate_changelog)
         .with(mock_repo_name, mock_github_token, 3)

--- a/spec/actions/create_next_snapshot_version_action_spec.rb
+++ b/spec/actions/create_next_snapshot_version_action_spec.rb
@@ -8,7 +8,7 @@ describe Fastlane::Actions::CreateNextSnapshotVersionAction do
 
     it 'calls all the appropriate methods with appropriate parameters' do
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:validate_local_config_status_for_bump)
-        .with(branch, github_pr_token)
+        .with(branch, "bump/#{next_version}", github_pr_token)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:calculate_next_snapshot_version)
         .with(current_version)


### PR DESCRIPTION
As suggested by @taquitos here: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/pull/2#discussion_r923988972, we will now validate that the release branch does not exist before continuing with the bump action. This makes sense to ensure we don't reuse an existing branch by mistake.
