### PR TITLE
Add replace_text_in_files action to plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A plugin including commonly used automation logic for RevenueCat SDKs.
 - `replace_version_number`: This action asks for a new version number and updates all occurences of the old version number (passed as a parameter) in the list of files to update (also passed as a parameter).
 - `create_next_snapshot_version`: This action creates bumps the version to the next minor with a `-SNAPSHOT` suffix and creates a PR with the changes.
 - `create_github_release`: This action will create a github release with the given version number as name and tag and the contents of the CHANGELOG.latest.md file as description. It can also upload files to the release if needed.
+- `replace_text_in_files`: This action will replace all the occurences of the old text with new text in the list of given paths to files.
 
 ## Example
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -43,3 +43,11 @@ lane :sample_create_github_release_action do |options|
     upload_assets: ['./file-to-upload.txt', './file-to-upload-2.rb']
   )
 end
+
+lane :sample_replace_text_in_files_action do |options|
+  replace_text_in_files(
+    previous_text: 'previous text',
+    new_text: 'new text',
+    paths_of_files_to_update: ['./test-file1.txt', './test-file2.rb']
+  )
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/replace_text_in_files_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/replace_text_in_files_action.rb
@@ -1,0 +1,53 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require 'fastlane_core/ui/ui'
+require_relative '../helper/revenuecat_internal_helper'
+
+module Fastlane
+  module Actions
+    class ReplaceTextInFilesAction < Action
+      def self.run(params)
+        previous_text = params[:previous_text]
+        new_text = params[:new_text]
+        paths_of_files_to_update = params[:paths_of_files_to_update]
+
+        paths_of_files_to_update.each do |path|
+          Helper::RevenuecatInternalHelper.replace_in(
+            previous_text,
+            new_text,
+            path
+          )
+        end
+      end
+
+      def self.description
+        "Replaces all occurences of previous text with new text in the given list of files"
+      end
+
+      def self.authors
+        ["Toni Rico"]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :previous_text,
+                                       description: "Previous text to replace",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :new_text,
+                                       description: "New text to replace",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :paths_of_files_to_update,
+                                       description: "List of paths of files where we will perform the replace",
+                                       optional: false,
+                                       type: Array)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -177,7 +177,7 @@ module Fastlane
         )
       end
 
-      private_class_method def self.replace_in(previous_text, new_text, path, allow_empty: false)
+      def self.replace_in(previous_text, new_text, path, allow_empty: false)
         if new_text.to_s.strip.empty? && !allow_empty
           UI.user_error!("Missing `new_text` in call to `replace_in`, looking for replacement for #{previous_text} 😵.")
         end

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -183,7 +183,7 @@ module Fastlane
         end
         sed_regex = "s|#{previous_text.sub('.', '\\.')}|#{new_text}|"
         backup_extension = '.bck'
-        Actions.sh("sed", '-i', backup_extension, sed_regex, path)
+        Actions.sh("sed", "-i#{backup_extension}", sed_regex, path)
       end
 
       private_class_method def self.ensure_new_branch_local_remote(new_branch)

--- a/spec/actions/replace_text_in_files_action_spec.rb
+++ b/spec/actions/replace_text_in_files_action_spec.rb
@@ -1,0 +1,34 @@
+describe Fastlane::Actions::ReplaceTextInFilesAction do
+  describe '#run' do
+    it 'calls appropriate helper with correct parameters for each given path' do
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_in)
+        .with('old_text', 'new_text', './test_file.sh')
+        .once
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_in)
+        .with('old_text', 'new_text', './test_file2.rb')
+        .once
+      Fastlane::Actions::ReplaceTextInFilesAction.run(
+        previous_text: 'old_text',
+        new_text: 'new_text',
+        paths_of_files_to_update: ['./test_file.sh', './test_file2.rb']
+      )
+    end
+
+    it 'works when passing only 1 path' do
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_in)
+        .with('old_text', 'new_text', './test_file.sh')
+        .once
+      Fastlane::Actions::ReplaceTextInFilesAction.run(
+        previous_text: 'old_text',
+        new_text: 'new_text',
+        paths_of_files_to_update: ['./test_file.sh']
+      )
+    end
+  end
+
+  describe '#available_options' do
+    it 'has correct number of options' do
+      expect(Fastlane::Actions::ReplaceTextInFilesAction.available_options.size).to eq(3)
+    end
+  end
+end

--- a/spec/actions/replace_version_number_action_spec.rb
+++ b/spec/actions/replace_version_number_action_spec.rb
@@ -1,10 +1,10 @@
 describe Fastlane::Actions::ReplaceVersionNumberAction do
   describe '#run' do
     it 'replaces old version with new version in passed files' do
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0|1.13.0|', './test_file.sh').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0|1.13.0|', './test_file2.rb').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0|1.13.0|', './test_file3.kt').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0|1.13.0|', './test_file4.swift').once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file.sh').once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file2.rb').once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file3.kt').once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file4.swift').once
       Fastlane::Actions::ReplaceVersionNumberAction.run(
         current_version: '1.12.0',
         new_version_number: '1.13.0',
@@ -14,10 +14,10 @@ describe Fastlane::Actions::ReplaceVersionNumberAction do
     end
 
     it 'replaces old version with new version in passed files including prerelease modifiers and no prerelease modifiers' do
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0-SNAPSHOT|1.13.0-SNAPSHOT|', './test_file.sh').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0-SNAPSHOT|1.13.0-SNAPSHOT|', './test_file2.rb').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0|1.13.0|', './test_file3.kt').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0|1.13.0|', './test_file4.swift').once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0-SNAPSHOT|1.13.0-SNAPSHOT|', './test_file.sh').once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0-SNAPSHOT|1.13.0-SNAPSHOT|', './test_file2.rb').once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file3.kt').once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file4.swift').once
       Fastlane::Actions::ReplaceVersionNumberAction.run(
         current_version: '1.12.0-SNAPSHOT',
         new_version_number: '1.13.0-SNAPSHOT',
@@ -27,10 +27,10 @@ describe Fastlane::Actions::ReplaceVersionNumberAction do
     end
 
     it 'replaces old version with new version in passed files when old version has prerelease modifiers' do
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0-SNAPSHOT|1.13.0|', './test_file.sh').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0-SNAPSHOT|1.13.0|', './test_file2.rb').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0|1.13.0|', './test_file3.kt').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0|1.13.0|', './test_file4.swift').once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0-SNAPSHOT|1.13.0|', './test_file.sh').once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0-SNAPSHOT|1.13.0|', './test_file2.rb').once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file3.kt').once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file4.swift').once
       Fastlane::Actions::ReplaceVersionNumberAction.run(
         current_version: '1.12.0-SNAPSHOT',
         new_version_number: '1.13.0',
@@ -40,10 +40,10 @@ describe Fastlane::Actions::ReplaceVersionNumberAction do
     end
 
     it 'replaces old version with new version in passed files when new version has prerelease modifiers' do
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0|1.13.0-SNAPSHOT|', './test_file.sh').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0|1.13.0-SNAPSHOT|', './test_file2.rb').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0|1.13.0|', './test_file3.kt').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0|1.13.0|', './test_file4.swift').once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0-SNAPSHOT|', './test_file.sh').once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0-SNAPSHOT|', './test_file2.rb').once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file3.kt').once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file4.swift').once
       Fastlane::Actions::ReplaceVersionNumberAction.run(
         current_version: '1.12.0',
         new_version_number: '1.13.0-SNAPSHOT',
@@ -53,8 +53,8 @@ describe Fastlane::Actions::ReplaceVersionNumberAction do
     end
 
     it 'replaces old version with new version in passed files when files to update without prerelease modifiers is empty' do
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0|1.13.0-SNAPSHOT|', './test_file.sh').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0|1.13.0-SNAPSHOT|', './test_file2.rb').once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0-SNAPSHOT|', './test_file.sh').once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0-SNAPSHOT|', './test_file2.rb').once
       Fastlane::Actions::ReplaceVersionNumberAction.run(
         current_version: '1.12.0',
         new_version_number: '1.13.0-SNAPSHOT',

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -408,4 +408,25 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       )
     end
   end
+
+  describe '.replace_in' do
+    let(:tmp_test_file_path) { './tmp_test_files/test_file.txt' }
+
+    it 'fails if new string is empty and allow_empty false' do
+      expect(Fastlane::Actions).not_to receive(:sh)
+      expect do
+        Fastlane::Helper::RevenuecatInternalHelper.replace_in('1.11.0', '', tmp_test_file_path, allow_empty: false)
+      end.to raise_exception(StandardError)
+    end
+
+    it 'changes old string with empty new string if allow_empty is true' do
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.11.0||', tmp_test_file_path)
+      Fastlane::Helper::RevenuecatInternalHelper.replace_in('1.11.0', '', tmp_test_file_path, allow_empty: true)
+    end
+
+    it 'changes old string occurences with new string' do
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.12.0|1.13.0|', tmp_test_file_path)
+      Fastlane::Helper::RevenuecatInternalHelper.replace_in('1.12.0', '1.13.0', tmp_test_file_path)
+    end
+  end
 end

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -6,10 +6,10 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
     let(:file_to_update_without_prerelease_modifiers_4) { './test_files/file_to_update_4.txt' }
 
     it 'updates previous version number with new version number when no prerelease modifiers are passed' do
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.11.0|1.12.0|', file_to_update_1).once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.11.0|1.12.0|', file_to_update_2).once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.11.0|1.12.0|', file_to_update_without_prerelease_modifiers_3).once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.11.0|1.12.0|', file_to_update_without_prerelease_modifiers_4).once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0|', file_to_update_1).once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0|', file_to_update_2).once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0|', file_to_update_without_prerelease_modifiers_3).once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0|', file_to_update_without_prerelease_modifiers_4).once
 
       Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
         '1.11.0',
@@ -20,10 +20,10 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
     end
 
     it 'updates previous version number with new version number when current version has prerelease modifiers' do
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.11.0-SNAPSHOT|1.12.0|', file_to_update_1).once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.11.0-SNAPSHOT|1.12.0|', file_to_update_2).once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.11.0|1.12.0|', file_to_update_without_prerelease_modifiers_3).once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.11.0|1.12.0|', file_to_update_without_prerelease_modifiers_4).once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0-SNAPSHOT|1.12.0|', file_to_update_1).once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0-SNAPSHOT|1.12.0|', file_to_update_2).once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0|', file_to_update_without_prerelease_modifiers_3).once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0|', file_to_update_without_prerelease_modifiers_4).once
 
       Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
         '1.11.0-SNAPSHOT',
@@ -34,10 +34,10 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
     end
 
     it 'updates previous version number with new version number when new version has prerelease modifiers' do
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.11.0|1.12.0-SNAPSHOT|', file_to_update_1).once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.11.0|1.12.0-SNAPSHOT|', file_to_update_2).once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.11.0|1.12.0|', file_to_update_without_prerelease_modifiers_3).once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i', '.bck', 's|1\\.11.0|1.12.0|', file_to_update_without_prerelease_modifiers_4).once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0-SNAPSHOT|', file_to_update_1).once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0-SNAPSHOT|', file_to_update_2).once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0|', file_to_update_without_prerelease_modifiers_3).once
+      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0|', file_to_update_without_prerelease_modifiers_4).once
 
       Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
         '1.11.0',


### PR DESCRIPTION
https://revenuecats.atlassian.net/browse/CSDK-310

This PR adds a new action to the plugin `replace_text_in_files`. This can be used by the SDKs to automate things like replacing API keys in the project or similar tasks. Each SDK would need to implement a lane that uses this action.
