### PR TITLE
Improve replace_in functionality so it's not platform dependant and make it more legible

### DIFF
--- a/fastlane-plugin-revenuecat_internal.gemspec
+++ b/fastlane-plugin-revenuecat_internal.gemspec
@@ -30,7 +30,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rspec_junit_formatter')
   spec.add_development_dependency('rubocop', '1.31.1')
   spec.add_development_dependency('rubocop-performance')
+  spec.add_development_dependency('rubocop-rake')
   spec.add_development_dependency('rubocop-require_tools')
+  spec.add_development_dependency('rubocop-rspec')
   spec.add_development_dependency('simplecov')
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -183,7 +183,6 @@ module Fastlane
         end
         original_text = File.read(path)
         replaced_text = original_text.gsub(previous_text, new_text)
-        File.write("#{path}.bck", original_text)
         File.write(path, replaced_text)
       end
 

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -181,9 +181,10 @@ module Fastlane
         if new_text.to_s.strip.empty? && !allow_empty
           UI.user_error!("Missing `new_text` in call to `replace_in`, looking for replacement for #{previous_text} 😵.")
         end
-        sed_regex = "s|#{previous_text.sub('.', '\\.')}|#{new_text}|"
-        backup_extension = '.bck'
-        Actions.sh("sed", "-i#{backup_extension}", sed_regex, path)
+        original_text = File.read(path)
+        replaced_text = original_text.gsub(previous_text, new_text)
+        File.write("#{path}.bck", original_text)
+        File.write(path, replaced_text)
       end
 
       private_class_method def self.ensure_new_branch_local_remote(new_branch)

--- a/spec/actions/replace_version_number_action_spec.rb
+++ b/spec/actions/replace_version_number_action_spec.rb
@@ -1,65 +1,13 @@
 describe Fastlane::Actions::ReplaceVersionNumberAction do
   describe '#run' do
-    it 'replaces old version with new version in passed files' do
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file.sh').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file2.rb').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file3.kt').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file4.swift').once
+    it 'calls appropriate helper with correct parameters' do
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_version_number)
+        .with('1.12.0', '1.13.0', ['./test_file.sh', './test_file2.rb'], ['./test_file3.kt', './test_file4.swift']).once
       Fastlane::Actions::ReplaceVersionNumberAction.run(
         current_version: '1.12.0',
         new_version_number: '1.13.0',
         files_to_update: ['./test_file.sh', './test_file2.rb'],
         files_to_update_without_prerelease_modifiers: ['./test_file3.kt', './test_file4.swift']
-      )
-    end
-
-    it 'replaces old version with new version in passed files including prerelease modifiers and no prerelease modifiers' do
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0-SNAPSHOT|1.13.0-SNAPSHOT|', './test_file.sh').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0-SNAPSHOT|1.13.0-SNAPSHOT|', './test_file2.rb').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file3.kt').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file4.swift').once
-      Fastlane::Actions::ReplaceVersionNumberAction.run(
-        current_version: '1.12.0-SNAPSHOT',
-        new_version_number: '1.13.0-SNAPSHOT',
-        files_to_update: ['./test_file.sh', './test_file2.rb'],
-        files_to_update_without_prerelease_modifiers: ['./test_file3.kt', './test_file4.swift']
-      )
-    end
-
-    it 'replaces old version with new version in passed files when old version has prerelease modifiers' do
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0-SNAPSHOT|1.13.0|', './test_file.sh').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0-SNAPSHOT|1.13.0|', './test_file2.rb').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file3.kt').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file4.swift').once
-      Fastlane::Actions::ReplaceVersionNumberAction.run(
-        current_version: '1.12.0-SNAPSHOT',
-        new_version_number: '1.13.0',
-        files_to_update: ['./test_file.sh', './test_file2.rb'],
-        files_to_update_without_prerelease_modifiers: ['./test_file3.kt', './test_file4.swift']
-      )
-    end
-
-    it 'replaces old version with new version in passed files when new version has prerelease modifiers' do
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0-SNAPSHOT|', './test_file.sh').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0-SNAPSHOT|', './test_file2.rb').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file3.kt').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0|', './test_file4.swift').once
-      Fastlane::Actions::ReplaceVersionNumberAction.run(
-        current_version: '1.12.0',
-        new_version_number: '1.13.0-SNAPSHOT',
-        files_to_update: ['./test_file.sh', './test_file2.rb'],
-        files_to_update_without_prerelease_modifiers: ['./test_file3.kt', './test_file4.swift']
-      )
-    end
-
-    it 'replaces old version with new version in passed files when files to update without prerelease modifiers is empty' do
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0-SNAPSHOT|', './test_file.sh').once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.12.0|1.13.0-SNAPSHOT|', './test_file2.rb').once
-      Fastlane::Actions::ReplaceVersionNumberAction.run(
-        current_version: '1.12.0',
-        new_version_number: '1.13.0-SNAPSHOT',
-        files_to_update: ['./test_file.sh', './test_file2.rb'],
-        files_to_update_without_prerelease_modifiers: []
       )
     end
   end

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -485,12 +485,5 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       Fastlane::Helper::RevenuecatInternalHelper.replace_in('4.1.3', '4.4.0-SNAPSHOT', tmp_test_file_path)
       expect(File.read(tmp_test_file_path)).to eq(contents)
     end
-
-    it 'creates backup file with old contents' do
-      File.write(tmp_test_file_path, 'Testing changing text=4.1.3-SNAPSHOT')
-      Fastlane::Helper::RevenuecatInternalHelper.replace_in('4.1.3-SNAPSHOT', '4.1.3', tmp_test_file_path)
-      expect(File.read(tmp_test_file_path)).to eq('Testing changing text=4.1.3')
-      expect(File.read("#{tmp_test_file_path}.bck")).to eq('Testing changing text=4.1.3-SNAPSHOT')
-    end
   end
 end

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -1,15 +1,25 @@
 describe Fastlane::Helper::RevenuecatInternalHelper do
   describe '.replace_version_number' do
-    let(:file_to_update_1) { './test_files/file_to_update_1.txt' }
-    let(:file_to_update_2) { './test_files/file_to_update_2.txt' }
-    let(:file_to_update_without_prerelease_modifiers_3) { './test_files/file_to_update_3.txt' }
-    let(:file_to_update_without_prerelease_modifiers_4) { './test_files/file_to_update_4.txt' }
+    require 'fileutils'
+
+    let(:file_to_update_1) { './tmp_test_files/file_to_update_1.txt' }
+    let(:file_to_update_2) { './tmp_test_files/file_to_update_2.txt' }
+    let(:file_to_update_without_prerelease_modifiers_3) { './tmp_test_files/file_to_update_3.txt' }
+    let(:file_to_update_without_prerelease_modifiers_4) { './tmp_test_files/file_to_update_4.txt' }
+
+    before(:each) do
+      Dir.mkdir('./tmp_test_files')
+    end
+
+    after(:each) do
+      FileUtils.rm_rf('./tmp_test_files')
+    end
 
     it 'updates previous version number with new version number when no prerelease modifiers are passed' do
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0|', file_to_update_1).once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0|', file_to_update_2).once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0|', file_to_update_without_prerelease_modifiers_3).once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0|', file_to_update_without_prerelease_modifiers_4).once
+      File.write(file_to_update_1, 'Contains version: 1.11.0')
+      File.write(file_to_update_2, 'Contains version: 1.11.0 and other version: 1.11.1')
+      File.write(file_to_update_without_prerelease_modifiers_3, 'Contains version: 1.11.0')
+      File.write(file_to_update_without_prerelease_modifiers_4, 'Contains version: 1.11.0')
 
       Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
         '1.11.0',
@@ -17,13 +27,18 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
         [file_to_update_1, file_to_update_2],
         [file_to_update_without_prerelease_modifiers_3, file_to_update_without_prerelease_modifiers_4]
       )
+
+      expect(File.read(file_to_update_1)).to eq('Contains version: 1.12.0')
+      expect(File.read(file_to_update_2)).to eq('Contains version: 1.12.0 and other version: 1.11.1')
+      expect(File.read(file_to_update_without_prerelease_modifiers_3)).to eq('Contains version: 1.12.0')
+      expect(File.read(file_to_update_without_prerelease_modifiers_4)).to eq('Contains version: 1.12.0')
     end
 
     it 'updates previous version number with new version number when current version has prerelease modifiers' do
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0-SNAPSHOT|1.12.0|', file_to_update_1).once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0-SNAPSHOT|1.12.0|', file_to_update_2).once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0|', file_to_update_without_prerelease_modifiers_3).once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0|', file_to_update_without_prerelease_modifiers_4).once
+      File.write(file_to_update_1, 'Contains version: 1.11.0 and version with snapshot: 1.11.0-SNAPSHOT')
+      File.write(file_to_update_2, 'Contains version: 1.11.0-SNAPSHOT and other version: 1.11.1')
+      File.write(file_to_update_without_prerelease_modifiers_3, 'Contains version: 1.11.0')
+      File.write(file_to_update_without_prerelease_modifiers_4, 'Contains version: 1.11.0')
 
       Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
         '1.11.0-SNAPSHOT',
@@ -31,13 +46,18 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
         [file_to_update_1, file_to_update_2],
         [file_to_update_without_prerelease_modifiers_3, file_to_update_without_prerelease_modifiers_4]
       )
+
+      expect(File.read(file_to_update_1)).to eq('Contains version: 1.11.0 and version with snapshot: 1.12.0')
+      expect(File.read(file_to_update_2)).to eq('Contains version: 1.12.0 and other version: 1.11.1')
+      expect(File.read(file_to_update_without_prerelease_modifiers_3)).to eq('Contains version: 1.12.0')
+      expect(File.read(file_to_update_without_prerelease_modifiers_4)).to eq('Contains version: 1.12.0')
     end
 
     it 'updates previous version number with new version number when new version has prerelease modifiers' do
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0-SNAPSHOT|', file_to_update_1).once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0-SNAPSHOT|', file_to_update_2).once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0|', file_to_update_without_prerelease_modifiers_3).once
-      expect(Fastlane::Actions).to receive(:sh).with('sed', '-i.bck', 's|1\\.11.0|1.12.0|', file_to_update_without_prerelease_modifiers_4).once
+      File.write(file_to_update_1, 'Contains version: 1.11.0')
+      File.write(file_to_update_2, 'Contains version: 1.11.0 and other version: 1.11.1')
+      File.write(file_to_update_without_prerelease_modifiers_3, 'Contains version: 1.11.0')
+      File.write(file_to_update_without_prerelease_modifiers_4, 'Contains version: 1.11.0')
 
       Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
         '1.11.0',
@@ -45,6 +65,11 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
         [file_to_update_1, file_to_update_2],
         [file_to_update_without_prerelease_modifiers_3, file_to_update_without_prerelease_modifiers_4]
       )
+
+      expect(File.read(file_to_update_1)).to eq('Contains version: 1.12.0-SNAPSHOT')
+      expect(File.read(file_to_update_2)).to eq('Contains version: 1.12.0-SNAPSHOT and other version: 1.11.1')
+      expect(File.read(file_to_update_without_prerelease_modifiers_3)).to eq('Contains version: 1.12.0')
+      expect(File.read(file_to_update_without_prerelease_modifiers_4)).to eq('Contains version: 1.12.0')
     end
   end
 
@@ -415,12 +440,10 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
     let(:tmp_test_file_path) { './tmp_test_files/test_file.txt' }
 
     before(:each) do
-      ENV["FORCE_SH_DURING_TESTS"] = 'true'
       Dir.mkdir('tmp_test_files')
     end
 
     after(:each) do
-      ENV["FORCE_SH_DURING_TESTS"] = nil
       FileUtils.rm_rf('tmp_test_files')
     end
 
@@ -443,6 +466,12 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       expect(File.read(tmp_test_file_path)).to eq('Testing changing text=4.1.3')
     end
 
+    it 'changes multiple occurences of old string with new string' do
+      File.write(tmp_test_file_path, "Testing changing text=4.1.3-SNAPSHOT and also\nversion=4.1.3-SNAPSHOT\nand again without spaces4.1.3-SNAPSHOT")
+      Fastlane::Helper::RevenuecatInternalHelper.replace_in('4.1.3-SNAPSHOT', '4.1.3', tmp_test_file_path)
+      expect(File.read(tmp_test_file_path)).to eq("Testing changing text=4.1.3 and also\nversion=4.1.3\nand again without spaces4.1.3")
+    end
+
     it 'does not change any text if old text not present in file' do
       contents = 'Testing 4.1.4'
       File.write(tmp_test_file_path, contents)
@@ -455,6 +484,13 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       File.write(tmp_test_file_path, '55413C0025B778E00ECCA5A')
       Fastlane::Helper::RevenuecatInternalHelper.replace_in('4.1.3', '4.4.0-SNAPSHOT', tmp_test_file_path)
       expect(File.read(tmp_test_file_path)).to eq(contents)
+    end
+
+    it 'creates backup file with old contents' do
+      File.write(tmp_test_file_path, 'Testing changing text=4.1.3-SNAPSHOT')
+      Fastlane::Helper::RevenuecatInternalHelper.replace_in('4.1.3-SNAPSHOT', '4.1.3', tmp_test_file_path)
+      expect(File.read(tmp_test_file_path)).to eq('Testing changing text=4.1.3')
+      expect(File.read("#{tmp_test_file_path}.bck")).to eq('Testing changing text=4.1.3-SNAPSHOT')
     end
   end
 end


### PR DESCRIPTION
During the previous PR (#6 ) I noticed that the `sed` is platform dependent (it works differently in macosx and linux) which caused issues with circleci. This PR changes the implementation to use a ruby implementation instead of a command-line based implementation, which should help with legibility and make it platform agnostic.
