### PR TITLE
Create commit_current_changes action

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A plugin including commonly used automation logic for RevenueCat SDKs.
 - `create_next_snapshot_version`: This action creates bumps the version to the next minor with a `-SNAPSHOT` suffix and creates a PR with the changes.
 - `create_github_release`: This action will create a github release with the given version number as name and tag and the contents of the CHANGELOG.latest.md file as description. It can also upload files to the release if needed.
 - `replace_text_in_files`: This action will replace all the occurences of the old text with new text in the list of given paths to files.
+- `commit_current_changes`: This action will commit all currently modified files into the current branch in the local repository. (This will not include untracked files)
 
 ## Example
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -51,3 +51,9 @@ lane :sample_replace_text_in_files_action do |options|
     paths_of_files_to_update: ['./test-file1.txt', './test-file2.rb']
   )
 end
+
+lane :sample_commit_current_changes_action do |options|
+  commit_current_changes(
+    commit_message: 'Sample commit message'
+  )
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/commit_current_changes_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/commit_current_changes_action.rb
@@ -1,0 +1,37 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require 'fastlane_core/ui/ui'
+require_relative '../helper/revenuecat_internal_helper'
+
+module Fastlane
+  module Actions
+    class CommitCurrentChangesAction < Action
+      def self.run(params)
+        commit_message = params[:commit_message]
+
+        Helper::RevenuecatInternalHelper.commit_current_changes(commit_message)
+      end
+
+      def self.description
+        "Commits changes in local repository to current branch. This will not include untracked files."
+      end
+
+      def self.authors
+        ["Toni Rico"]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :commit_message,
+                                       description: "Commit message",
+                                       optional: false,
+                                       type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/replace_text_in_files_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/replace_text_in_files_action.rb
@@ -10,12 +10,14 @@ module Fastlane
         previous_text = params[:previous_text]
         new_text = params[:new_text]
         paths_of_files_to_update = params[:paths_of_files_to_update]
+        allow_empty = params[:allow_empty]
 
         paths_of_files_to_update.each do |path|
           Helper::RevenuecatInternalHelper.replace_in(
             previous_text,
             new_text,
-            path
+            path,
+            allow_empty
           )
         end
       end
@@ -41,7 +43,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :paths_of_files_to_update,
                                        description: "List of paths of files where we will perform the replace",
                                        optional: false,
-                                       type: Array)
+                                       type: Array),
+          FastlaneCore::ConfigItem.new(key: :allow_empty,
+                                       description: "Allows for the new_text to be empty",
+                                       optional: true,
+                                       default_value: false,
+                                       is_string: false)
         ]
       end
 

--- a/lib/fastlane/plugin/revenuecat_internal/actions/replace_text_in_files_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/replace_text_in_files_action.rb
@@ -17,7 +17,7 @@ module Fastlane
             previous_text,
             new_text,
             path,
-            allow_empty
+            allow_empty: allow_empty
           )
         end
       end
@@ -45,7 +45,7 @@ module Fastlane
                                        optional: false,
                                        type: Array),
           FastlaneCore::ConfigItem.new(key: :allow_empty,
-                                       description: "Allows for the new_text to be empty",
+                                       description: "Allows for the new_text parameter to be empty",
                                        optional: true,
                                        default_value: false,
                                        is_string: false)

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -121,8 +121,7 @@ module Fastlane
       end
 
       def self.commmit_changes_and_push_current_branch(commit_message)
-        Actions.sh('git add -u')
-        Actions.sh("git commit -m '#{commit_message}'")
+        commit_current_changes(commit_message)
         Actions::PushToGitRemoteAction.run(remote: 'origin')
       end
 
@@ -184,6 +183,11 @@ module Fastlane
         original_text = File.read(path)
         replaced_text = original_text.gsub(previous_text, new_text)
         File.write(path, replaced_text)
+      end
+
+      def self.commit_current_changes(commit_message)
+        Actions.sh('git add -u')
+        Actions.sh("git commit -m '#{commit_message}'")
       end
 
       private_class_method def self.ensure_new_branch_local_remote(new_branch)

--- a/spec/actions/commit_current_changes_action_spec.rb
+++ b/spec/actions/commit_current_changes_action_spec.rb
@@ -1,0 +1,17 @@
+describe Fastlane::Actions::CommitCurrentChangesAction do
+  describe '#run' do
+    it 'calls appropriate actions with expected parameters' do
+      expect(Fastlane::Actions).to receive(:sh).with('git add -u').once
+      expect(Fastlane::Actions).to receive(:sh).with("git commit -m 'fake-commit-message'").once
+      Fastlane::Actions::CommitCurrentChangesAction.run(
+        commit_message: 'fake-commit-message'
+      )
+    end
+  end
+
+  describe '#available_options' do
+    it 'has correct number of options' do
+      expect(Fastlane::Actions::CommitCurrentChangesAction.available_options.size).to eq(1)
+    end
+  end
+end

--- a/spec/actions/replace_text_in_files_action_spec.rb
+++ b/spec/actions/replace_text_in_files_action_spec.rb
@@ -2,10 +2,10 @@ describe Fastlane::Actions::ReplaceTextInFilesAction do
   describe '#run' do
     it 'calls appropriate helper with correct parameters for each given path' do
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_in)
-        .with('old_text', 'new_text', './test_file.sh', true)
+        .with('old_text', 'new_text', './test_file.sh', allow_empty: true)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_in)
-        .with('old_text', 'new_text', './test_file2.rb', true)
+        .with('old_text', 'new_text', './test_file2.rb', allow_empty: true)
         .once
       Fastlane::Actions::ReplaceTextInFilesAction.run(
         previous_text: 'old_text',
@@ -17,7 +17,7 @@ describe Fastlane::Actions::ReplaceTextInFilesAction do
 
     it 'works when passing only 1 path' do
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_in)
-        .with('old_text', 'new_text', './test_file.sh', false)
+        .with('old_text', 'new_text', './test_file.sh', allow_empty: false)
         .once
       Fastlane::Actions::ReplaceTextInFilesAction.run(
         previous_text: 'old_text',

--- a/spec/actions/replace_text_in_files_action_spec.rb
+++ b/spec/actions/replace_text_in_files_action_spec.rb
@@ -2,33 +2,35 @@ describe Fastlane::Actions::ReplaceTextInFilesAction do
   describe '#run' do
     it 'calls appropriate helper with correct parameters for each given path' do
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_in)
-        .with('old_text', 'new_text', './test_file.sh')
+        .with('old_text', 'new_text', './test_file.sh', true)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_in)
-        .with('old_text', 'new_text', './test_file2.rb')
+        .with('old_text', 'new_text', './test_file2.rb', true)
         .once
       Fastlane::Actions::ReplaceTextInFilesAction.run(
         previous_text: 'old_text',
         new_text: 'new_text',
-        paths_of_files_to_update: ['./test_file.sh', './test_file2.rb']
+        paths_of_files_to_update: ['./test_file.sh', './test_file2.rb'],
+        allow_empty: true
       )
     end
 
     it 'works when passing only 1 path' do
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_in)
-        .with('old_text', 'new_text', './test_file.sh')
+        .with('old_text', 'new_text', './test_file.sh', false)
         .once
       Fastlane::Actions::ReplaceTextInFilesAction.run(
         previous_text: 'old_text',
         new_text: 'new_text',
-        paths_of_files_to_update: ['./test_file.sh']
+        paths_of_files_to_update: ['./test_file.sh'],
+        allow_empty: false
       )
     end
   end
 
   describe '#available_options' do
     it 'has correct number of options' do
-      expect(Fastlane::Actions::ReplaceTextInFilesAction.available_options.size).to eq(3)
+      expect(Fastlane::Actions::ReplaceTextInFilesAction.available_options.size).to eq(4)
     end
   end
 end

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -486,4 +486,12 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       expect(File.read(tmp_test_file_path)).to eq(contents)
     end
   end
+
+  describe '.commit_current_changes' do
+    it 'calls appropriate actions with correct parameters' do
+      expect(Fastlane::Actions).to receive(:sh).with('git add -u').once
+      expect(Fastlane::Actions).to receive(:sh).with("git commit -m 'fake-commit-message'").once
+      Fastlane::Helper::RevenuecatInternalHelper.commit_current_changes('fake-commit-message')
+    end
+  end
 end


### PR DESCRIPTION
Created new `commit_current_changes` action so it can be used by SDKs.
Also modified `replace_text_in_files` so it supports another parameter indicating whether new text can be empty or not.