### PR TITLE
Splits changelog in sections depending on label

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -42,7 +42,7 @@ module Fastlane
         commits = body["commits"].reverse
 
         supported_types = ["breaking", "build", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test"]
-        changelog_sections = { :breaking_changes => [], :fixes => [], :new_features => [], :other => [] }
+        changelog_sections = { breaking_changes: [], fixes: [], new_features: [], other: [] }
 
         commits.map do |commit|
           if rate_limit_sleep > 0
@@ -70,39 +70,39 @@ module Fastlane
             message = "#{item['title']} (##{item['number']})"
             username = item["user"]["login"]
 
-            change_types = item["labels"].map{ |label_info| label_info["name"] }.select { |label| supported_types.include? label }.uniq
+            change_types = item["labels"].map { |label_info| label_info["name"] }.select { |label| supported_types.include?(label) }.uniq
 
-            if change_types.include? "breaking"
+            if change_types.include?("breaking")
               section = :breaking_changes
-            elsif change_types.include? "feat"
+            elsif change_types.include?("feat")
               section = :new_features
-            elsif change_types.include? "fix"
+            elsif change_types.include?("fix")
               section = :fixes
             else
               section = :other
             end
 
             line = "* #{message} via #{name} (@#{username})"
-            changelog_sections[section].push(line)   
+            changelog_sections[section].push(line)
           else
             UI.user_error!("Cannot generate changelog. Multiple commits found for #{sha}")
           end
         end
 
-        formatted = changelog_sections.reject{ |k, v| v.empty? }.map do |section_name, prs|
-          if prs.size > 0
-            case section_name
-            when :breaking_changes
-              title = "## Breaking Changes"
-            when :fixes
-              title = "## Bugfixes"
-            when :new_features
-              title = "## New Features"
-            when :other
-              title = "## Other Changes"
-            end
-            "#{title}\n#{prs.join("\n")}"
+        formatted = changelog_sections.reject { |k, v| v.empty? }.map do |section_name, prs|
+          next unless prs.size > 0
+
+          case section_name
+          when :breaking_changes
+            title = "## Breaking Changes"
+          when :fixes
+            title = "## Bugfixes"
+          when :new_features
+            title = "## New Features"
+          when :other
+            title = "## Other Changes"
           end
+          "#{title}\n#{prs.join("\n")}"
         end.join("\n")
       end
 

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -41,7 +41,7 @@ module Fastlane
         body = JSON.parse(resp[:body])
         commits = body["commits"].reverse
 
-        supported_types = ["breaking", "build", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test"]
+        supported_types = ["breaking", "build", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test"].to_set
         changelog_sections = { breaking_changes: [], fixes: [], new_features: [], other: [] }
 
         commits.map do |commit|
@@ -68,7 +68,7 @@ module Fastlane
             types_of_change = item["labels"]
                               .map { |label_info| label_info["name"] }
                               .select { |label| supported_types.include?(label) }
-                              .uniq
+                              .to_set
 
             section = get_section_depending_on_types_of_change(types_of_change)
 

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -100,7 +100,8 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
         'mock-github-token',
         0
       )
-      expect(changelog).to eq("* Prepare next version: 4.8.0-SNAPSHOT (#1750) via RevenueCat Releases (@revenuecat-ops)\n" \
+      expect(changelog).to eq("## Other Changes\n" \
+                              "* Prepare next version: 4.8.0-SNAPSHOT (#1750) via RevenueCat Releases (@revenuecat-ops)\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)")
     end
@@ -113,7 +114,8 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
         'mock-github-token',
         3
       )
-      expect(changelog).to eq("* Prepare next version: 4.8.0-SNAPSHOT (#1750) via RevenueCat Releases (@revenuecat-ops)\n" \
+      expect(changelog).to eq("## Other Changes\n" \
+                              "* Prepare next version: 4.8.0-SNAPSHOT (#1750) via RevenueCat Releases (@revenuecat-ops)\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)")
     end

--- a/spec/test_files/breaking_get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json
+++ b/spec/test_files/breaking_get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json
@@ -44,11 +44,11 @@
                     "description": ""
                 },
                 {
-                    "id": 4352868124,
-                    "node_id": "LA_kwDOBnB8hc8AAAACA3N_HQ",
-                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/feat",
-                    "name": "feat",
-                    "color": "8B3E6B",
+                    "id": 4352868120,
+                    "node_id": "LA_kwDOBnB8hc8AAAACA3N_HD",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/breaking",
+                    "name": "breaking",
+                    "color": "8B3E6C",
                     "default": false,
                     "description": ""
                 }

--- a/spec/test_files/get_commit_sha_0e67cdb1c7582ce3e2fd00367acc24db6242c6d6.json
+++ b/spec/test_files/get_commit_sha_0e67cdb1c7582ce3e2fd00367acc24db6242c6d6.json
@@ -33,7 +33,17 @@
                 "type": "User",
                 "site_admin": false
             },
-            "labels": [],
+            "labels": [
+                {
+                    "id": 4352868120,
+                    "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/fix",
+                    "name": "fix",
+                    "color": "8E3E6B",
+                    "default": false,
+                    "description": ""
+                }
+            ],
             "state": "closed",
             "locked": false,
             "assignee": null,


### PR DESCRIPTION
This was originally developed in https://github.com/RevenueCat/purchases-ios/pull/1769 but now we have tests and we can share across all repos 👏 