### PR TITLE
Not validate current branch when creating next snapshot

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
@@ -11,12 +11,11 @@ module Fastlane
         github_pr_token = params[:github_pr_token]
         files_to_update = params[:files_to_update]
         files_to_update_without_prerelease_modifiers = params[:files_to_update_without_prerelease_modifiers]
-        branch = params[:branch]
 
         next_version_snapshot = Helper::RevenuecatInternalHelper.calculate_next_snapshot_version(previous_version_number)
         new_branch_name = "bump/#{next_version_snapshot}"
 
-        Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump(branch, new_branch_name, github_pr_token)
+        Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump(nil, new_branch_name, github_pr_token)
 
         Helper::RevenuecatInternalHelper.create_new_branch_and_checkout(new_branch_name)
 
@@ -64,12 +63,7 @@ module Fastlane
                                        description: "Files that contain the version number without release modifiers and need to have it updated",
                                        optional: true,
                                        default_value: [],
-                                       type: Array),
-          FastlaneCore::ConfigItem.new(key: :branch,
-                                       description: "Allows to execute the action from the given branch",
-                                       optional: true,
-                                       default_value: "main",
-                                       type: String)
+                                       type: Array)
         ]
       end
 

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -137,7 +137,7 @@ module Fastlane
         )
       end
 
-      def self.validate_local_config_status_for_bump(branch, new_branch, github_pr_token)
+      def self.validate_local_config_status_for_bump(current_branch, new_branch, github_pr_token)
         # Ensure GitHub API token is set
         if github_pr_token.nil? || github_pr_token.empty?
           UI.error("A github_pr_token parameter or an environment variable GITHUB_PULL_REQUEST_API_TOKEN is required to create a pull request")
@@ -145,7 +145,7 @@ module Fastlane
           UI.user_error!("Could not find value for GITHUB_PULL_REQUEST_API_TOKEN")
         end
         ensure_new_branch_local_remote(new_branch)
-        Actions::EnsureGitBranchAction.run(branch: branch)
+        Actions::EnsureGitBranchAction.run(branch: current_branch) unless current_branch.nil?
         Actions::EnsureGitStatusCleanAction.run({})
       end
 

--- a/spec/actions/create_next_snapshot_version_action_spec.rb
+++ b/spec/actions/create_next_snapshot_version_action_spec.rb
@@ -2,13 +2,12 @@ describe Fastlane::Actions::CreateNextSnapshotVersionAction do
   describe '#run' do
     let(:github_pr_token) { 'fake-github-pr-token' }
     let(:repo_name) { 'fake-repo-name' }
-    let(:branch) { 'branch' }
     let(:current_version) { '1.12.0' }
     let(:next_version) { '1.13.0-SNAPSHOT' }
 
     it 'calls all the appropriate methods with appropriate parameters' do
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:validate_local_config_status_for_bump)
-        .with(branch, "bump/#{next_version}", github_pr_token)
+        .with(nil, "bump/#{next_version}", github_pr_token)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:calculate_next_snapshot_version)
         .with(current_version)
@@ -31,15 +30,14 @@ describe Fastlane::Actions::CreateNextSnapshotVersionAction do
         repo_name: repo_name,
         github_pr_token: github_pr_token,
         files_to_update: ['./test_file.sh', './test_file2.rb'],
-        files_to_update_without_prerelease_modifiers: ['./test_file4.swift', './test_file5.kt'],
-        branch: branch
+        files_to_update_without_prerelease_modifiers: ['./test_file4.swift', './test_file5.kt']
       )
     end
   end
 
   describe '#available_options' do
     it 'has correct number of options' do
-      expect(Fastlane::Actions::CreateNextSnapshotVersionAction.available_options.size).to eq(6)
+      expect(Fastlane::Actions::CreateNextSnapshotVersionAction.available_options.size).to eq(5)
     end
   end
 end

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -340,6 +340,11 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       Fastlane::Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump('fake-branch', 'new-branch', 'fake-github-pr-token')
     end
 
+    it 'does not check repo is in specific branch if none passed' do
+      expect(Fastlane::Actions::EnsureGitBranchAction).not_to receive(:run)
+      Fastlane::Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump(nil, 'new-branch', 'fake-github-pr-token')
+    end
+
     it 'ensures repo is in a clean state' do
       expect(Fastlane::Actions::EnsureGitStatusCleanAction).to receive(:run).with({}).once
       Fastlane::Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump('fake-branch', 'new-branch', 'fake-github-pr-token')


### PR DESCRIPTION
This should help dealing with: https://revenuecats.atlassian.net/browse/SDKONCALL-84

With the plugin, I added a validation for the current branch to the action that creates the next prerelease version PR. This validation didn't exist before, and caused the issue that we see in this ticket. This PR removes that validation from that action. After this is merged, I will update the SDKs to use the new version of the plugin