### PR TITLE
Change title level of generated changelog sections

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -240,13 +240,13 @@ module Fastlane
 
           case section_name
           when :breaking_changes
-            title = "## Breaking Changes"
+            title = "### Breaking Changes"
           when :fixes
-            title = "## Bugfixes"
+            title = "### Bugfixes"
           when :new_features
-            title = "## New Features"
+            title = "### New Features"
           when :other
-            title = "## Other Changes"
+            title = "### Other Changes"
           end
           "#{title}\n#{prs.join("\n")}"
         end.join("\n")

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -106,11 +106,11 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
         'mock-github-token',
         0
       )
-      expect(changelog).to eq("## Bugfixes\n" \
+      expect(changelog).to eq("### Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
-                              "## New Features\n" \
+                              "### New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
-                              "## Other Changes\n" \
+                              "### Other Changes\n" \
                               "* Prepare next version: 4.8.0-SNAPSHOT (#1750) via RevenueCat Releases (@revenuecat-ops)")
     end
 
@@ -122,11 +122,11 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
         'mock-github-token',
         3
       )
-      expect(changelog).to eq("## Bugfixes\n" \
+      expect(changelog).to eq("### Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
-                              "## New Features\n" \
+                              "### New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
-                              "## Other Changes\n" \
+                              "### Other Changes\n" \
                               "* Prepare next version: 4.8.0-SNAPSHOT (#1750) via RevenueCat Releases (@revenuecat-ops)")
     end
 
@@ -138,11 +138,11 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
         'mock-github-token',
         3
       )
-      expect(changelog).to eq("## Bugfixes\n" \
+      expect(changelog).to eq("### Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
-                              "## New Features\n" \
+                              "### New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
-                              "## Other Changes\n" \
+                              "### Other Changes\n" \
                               "* Prepare next version: 4.8.0-SNAPSHOT (#1750) via RevenueCat Releases (@revenuecat-ops)")
     end
 
@@ -179,11 +179,11 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
         'mock-github-token',
         0
       )
-      expect(changelog).to eq("## Breaking Changes\n" \
+      expect(changelog).to eq("### Breaking Changes\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
-                              "## Bugfixes\n" \
+                              "### Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
-                              "## Other Changes\n" \
+                              "### Other Changes\n" \
                               "* Prepare next version: 4.8.0-SNAPSHOT (#1750) via RevenueCat Releases (@revenuecat-ops)")
     end
 
@@ -202,9 +202,9 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
         'mock-github-token',
         0
       )
-      expect(changelog).to eq("## Bugfixes\n" \
+      expect(changelog).to eq("### Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
-                              "## Other Changes\n" \
+                              "### Other Changes\n" \
                               "* Prepare next version: 4.8.0-SNAPSHOT (#1750) via RevenueCat Releases (@revenuecat-ops)\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)")
     end


### PR DESCRIPTION
As suggested in https://github.com/RevenueCat/purchases-ios/pull/1800#discussion_r940554346. We are changing the title level of the generated changelog sections
