### PR TITLE
`bump_version_update_changelog_create_pr_action` and `create_next_snapshot_version_action`: added `next_release` label

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -40,7 +40,8 @@ module Fastlane
         Helper::RevenuecatInternalHelper.commmit_changes_and_push_current_branch("Version bump for #{new_version_number}")
 
         pr_title = "Release/#{new_version_number}"
-        Helper::RevenuecatInternalHelper.create_pr_to_main(pr_title, changelog, repo_name, new_branch_name, github_pr_token)
+        label = 'next_release'
+        Helper::RevenuecatInternalHelper.create_pr_to_main(pr_title, changelog, repo_name, new_branch_name, github_pr_token, [label])
       end
 
       def self.description

--- a/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
@@ -14,6 +14,7 @@ module Fastlane
 
         next_version_snapshot = Helper::RevenuecatInternalHelper.calculate_next_snapshot_version(previous_version_number)
         new_branch_name = "bump/#{next_version_snapshot}"
+        label = 'next_release'
 
         Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump(nil, new_branch_name, github_pr_token)
 
@@ -26,7 +27,7 @@ module Fastlane
 
         Helper::RevenuecatInternalHelper.commmit_changes_and_push_current_branch('Preparing for next version')
 
-        Helper::RevenuecatInternalHelper.create_pr_to_main("Prepare next version: #{next_version_snapshot}", nil, repo_name, new_branch_name, github_pr_token)
+        Helper::RevenuecatInternalHelper.create_pr_to_main("Prepare next version: #{next_version_snapshot}", nil, repo_name, new_branch_name, github_pr_token, [label])
       end
 
       def self.description

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -41,7 +41,7 @@ module Fastlane
         body = JSON.parse(resp[:body])
         commits = body["commits"].reverse
 
-        supported_types = ["breaking", "build", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test"].to_set
+        supported_types = ["breaking", "build", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test", "next_release"].to_set
         changelog_sections = { breaking_changes: [], fixes: [], new_features: [], other: [] }
 
         commits.map do |commit|
@@ -133,7 +133,7 @@ module Fastlane
         Actions::PushToGitRemoteAction.run(remote: 'origin')
       end
 
-      def self.create_pr_to_main(title, body, repo_name, head_branch, github_pr_token)
+      def self.create_pr_to_main(title, body, repo_name, head_branch, github_pr_token, labels = [])
         Actions::CreatePullRequestAction.run(
           api_token: github_pr_token,
           title: title,
@@ -141,7 +141,8 @@ module Fastlane
           body: body,
           repo: "RevenueCat/#{repo_name}",
           head: head_branch,
-          api_url: 'https://api.github.com'
+          api_url: 'https://api.github.com',
+          labels: labels
         )
       end
 

--- a/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
+++ b/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
@@ -12,6 +12,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
     let(:current_version) { '1.12.0' }
     let(:new_version) { '1.13.0' }
     let(:new_branch_name) { 'release/1.13.0' }
+    let(:labels) { ['next_release'] }
 
     it 'calls all the appropriate methods with appropriate parameters' do
       allow(FastlaneCore::UI).to receive(:input).with('New version number: ').and_return(new_version)
@@ -39,7 +40,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         .with("Version bump for #{new_version}")
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
-        .with("Release/1.13.0", edited_changelog, mock_repo_name, new_branch_name, mock_github_pr_token)
+        .with("Release/1.13.0", edited_changelog, mock_repo_name, new_branch_name, mock_github_pr_token, labels)
         .once
 
       Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction.run(

--- a/spec/actions/create_next_snapshot_version_action_spec.rb
+++ b/spec/actions/create_next_snapshot_version_action_spec.rb
@@ -5,6 +5,7 @@ describe Fastlane::Actions::CreateNextSnapshotVersionAction do
     let(:current_version) { '1.12.0' }
     let(:next_version) { '1.13.0-SNAPSHOT' }
     let(:new_branch_name) { 'bump/1.13.0-SNAPSHOT' }
+    let(:labels) { ['next_release'] }
 
     it 'calls all the appropriate methods with appropriate parameters' do
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:validate_local_config_status_for_bump)
@@ -24,7 +25,7 @@ describe Fastlane::Actions::CreateNextSnapshotVersionAction do
         .with('Preparing for next version')
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
-        .with('Prepare next version: 1.13.0-SNAPSHOT', nil, repo_name, new_branch_name, github_pr_token)
+        .with('Prepare next version: 1.13.0-SNAPSHOT', nil, repo_name, new_branch_name, github_pr_token, labels)
         .once
       Fastlane::Actions::CreateNextSnapshotVersionAction.run(
         current_version: current_version,

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -360,9 +360,10 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
           body: 'fake-changelog',
           repo: 'RevenueCat/fake-repo-name',
           head: 'fake-branch',
-          api_url: 'https://api.github.com'
+          api_url: 'https://api.github.com',
+          labels: ['label_1', 'label_2']
         ).once
-      Fastlane::Helper::RevenuecatInternalHelper.create_pr_to_main('fake-title', 'fake-changelog', 'fake-repo-name', 'fake-branch', 'fake-github-pr-token')
+      Fastlane::Helper::RevenuecatInternalHelper.create_pr_to_main('fake-title', 'fake-changelog', 'fake-repo-name', 'fake-branch', 'fake-github-pr-token', ['label_1', 'label_2'])
     end
   end
 


### PR DESCRIPTION
This will prevent Danger from failing these PRs due to missing a change label.

See also https://github.com/RevenueCat/purchases-ios/pull/1810