### PR TITLE
Fixes issues during flutter next snapshot creation

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -40,7 +40,7 @@ module Fastlane
         Helper::RevenuecatInternalHelper.commmit_changes_and_push_current_branch("Version bump for #{new_version_number}")
 
         pr_title = "Release/#{new_version_number}"
-        Helper::RevenuecatInternalHelper.create_pr_to_main(pr_title, changelog, repo_name, github_pr_token)
+        Helper::RevenuecatInternalHelper.create_pr_to_main(pr_title, changelog, repo_name, new_branch_name, github_pr_token)
       end
 
       def self.description

--- a/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
@@ -26,7 +26,7 @@ module Fastlane
 
         Helper::RevenuecatInternalHelper.commmit_changes_and_push_current_branch('Preparing for next version')
 
-        Helper::RevenuecatInternalHelper.create_pr_to_main("Prepare next version: #{next_version_snapshot}", nil, repo_name, github_pr_token)
+        Helper::RevenuecatInternalHelper.create_pr_to_main("Prepare next version: #{next_version_snapshot}", nil, repo_name, new_branch_name, github_pr_token)
       end
 
       def self.description

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -228,7 +228,7 @@ module Fastlane
         end
 
         remote_branches = Actions.sh('git', 'ls-remote', '--heads', 'origin', new_branch)
-        if remote_branches.include?(new_branch)
+        if !remote_branches.nil? && remote_branches.include?(new_branch)
           UI.error("Branch '#{new_branch}' already exists in remote repository.")
           UI.user_error!("Please make sure it doesn't have any unsaved changes and delete it to continue.")
         end

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -133,14 +133,14 @@ module Fastlane
         Actions::PushToGitRemoteAction.run(remote: 'origin')
       end
 
-      def self.create_pr_to_main(title, body, repo_name, github_pr_token)
+      def self.create_pr_to_main(title, body, repo_name, head_branch, github_pr_token)
         Actions::CreatePullRequestAction.run(
           api_token: github_pr_token,
           title: title,
           base: 'main',
           body: body,
           repo: "RevenueCat/#{repo_name}",
-          head: Actions.git_branch,
+          head: head_branch,
           api_url: 'https://api.github.com'
         )
       end
@@ -228,7 +228,7 @@ module Fastlane
         end
 
         remote_branches = Actions.sh('git', 'ls-remote', '--heads', 'origin', new_branch)
-        unless remote_branches.empty?
+        if remote_branches.include?(new_branch)
           UI.error("Branch '#{new_branch}' already exists in remote repository.")
           UI.user_error!("Please make sure it doesn't have any unsaved changes and delete it to continue.")
         end

--- a/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
+++ b/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
@@ -11,6 +11,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
     let(:edited_changelog) { 'mock-edited-changelog' }
     let(:current_version) { '1.12.0' }
     let(:new_version) { '1.13.0' }
+    let(:new_branch_name) { 'release/1.13.0' }
 
     it 'calls all the appropriate methods with appropriate parameters' do
       allow(FastlaneCore::UI).to receive(:input).with('New version number: ').and_return(new_version)
@@ -26,7 +27,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         .with(auto_generated_changelog, mock_changelog_latest_path, editor)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_new_branch_and_checkout)
-        .with('release/1.13.0')
+        .with(new_branch_name)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_version_number)
         .with(current_version, new_version, ['./test_file.sh', './test_file2.rb'], ['./test_file3.kt', './test_file4.swift'])
@@ -38,7 +39,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         .with("Version bump for #{new_version}")
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
-        .with("Release/1.13.0", edited_changelog, mock_repo_name, mock_github_pr_token)
+        .with("Release/1.13.0", edited_changelog, mock_repo_name, new_branch_name, mock_github_pr_token)
         .once
 
       Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction.run(

--- a/spec/actions/create_next_snapshot_version_action_spec.rb
+++ b/spec/actions/create_next_snapshot_version_action_spec.rb
@@ -4,6 +4,7 @@ describe Fastlane::Actions::CreateNextSnapshotVersionAction do
     let(:repo_name) { 'fake-repo-name' }
     let(:current_version) { '1.12.0' }
     let(:next_version) { '1.13.0-SNAPSHOT' }
+    let(:new_branch_name) { 'bump/1.13.0-SNAPSHOT' }
 
     it 'calls all the appropriate methods with appropriate parameters' do
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:validate_local_config_status_for_bump)
@@ -14,7 +15,7 @@ describe Fastlane::Actions::CreateNextSnapshotVersionAction do
         .and_return(next_version)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_new_branch_and_checkout)
-        .with('bump/1.13.0-SNAPSHOT')
+        .with(new_branch_name)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_version_number)
         .with(current_version, next_version, ['./test_file.sh', './test_file2.rb'], ['./test_file4.swift', './test_file5.kt'])
@@ -23,7 +24,7 @@ describe Fastlane::Actions::CreateNextSnapshotVersionAction do
         .with('Preparing for next version')
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
-        .with('Prepare next version: 1.13.0-SNAPSHOT', nil, repo_name, github_pr_token)
+        .with('Prepare next version: 1.13.0-SNAPSHOT', nil, repo_name, new_branch_name, github_pr_token)
         .once
       Fastlane::Actions::CreateNextSnapshotVersionAction.run(
         current_version: current_version,

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -352,7 +352,6 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
 
   describe '.create_pr_to_main' do
     it 'creates pr' do
-      allow(Fastlane::Actions).to receive(:git_branch).and_return('fake-current-branch')
       expect(Fastlane::Actions::CreatePullRequestAction).to receive(:run)
         .with(
           api_token: 'fake-github-pr-token',
@@ -360,10 +359,10 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
           base: 'main',
           body: 'fake-changelog',
           repo: 'RevenueCat/fake-repo-name',
-          head: 'fake-current-branch',
+          head: 'fake-branch',
           api_url: 'https://api.github.com'
         ).once
-      Fastlane::Helper::RevenuecatInternalHelper.create_pr_to_main('fake-title', 'fake-changelog', 'fake-repo-name', 'fake-github-pr-token')
+      Fastlane::Helper::RevenuecatInternalHelper.create_pr_to_main('fake-title', 'fake-changelog', 'fake-repo-name', 'fake-branch', 'fake-github-pr-token')
     end
   end
 
@@ -401,6 +400,13 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       expect do
         Fastlane::Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump('fake-branch', 'new-branch', 'fake-github-pr-token')
       end.to raise_exception(StandardError)
+    end
+
+    it 'works if git returns ssh warning' do
+      expect(Fastlane::Actions).to receive(:sh)
+        .with('git', 'ls-remote', '--heads', 'origin', 'new-branch')
+        .and_return("Warning: Permanently added the ECDSA host key for IP address 'xxx.xxx.xxx.xxx' to the list of known hosts.")
+      Fastlane::Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump('fake-branch', 'new-branch', 'fake-github-pr-token')
     end
 
     it 'ensures new branch does not exist remotely' do


### PR DESCRIPTION
During the latest release of flutter, we noticed a few issues with the `prepare_next_version` job:
- Checking for the existence of the bump branch in remote sometimes returned a warning, which was making the code think that the branch existed in remote, even though it didn't. This PR changes the behavior to check that the returned value of the sh command contains the branch name, so it's more accurate.
- `Actions.git_branch` is supposed to give the current branch, but it wasn't working (it was returning nothing). We use this when creating the PR so we knew the `head` branch, but since it wasn't returning anything it failed during the PR creation. This PR changes the behavior to pass the branch as a parameter since we do have this information on the caller actions.
