### PR TITLE
Prevents edit_changelog and branch confirmation in CI

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -20,8 +20,10 @@ module Fastlane
         editor = params[:editor]
 
         current_branch = Actions.git_branch
-        unless UI.confirm("Current branch is #{current_branch}. Are you sure this is the base branch for your bump?")
-          UI.user_error!("Cancelled during branch confirmation")
+        if UI.interactive?
+          unless UI.confirm("Current branch is #{current_branch}. Are you sure this is the base branch for your bump?")
+            UI.user_error!("Cancelled during branch confirmation")
+          end
         end
 
         UI.important("Current version is #{version_number}")

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -20,10 +20,8 @@ module Fastlane
         editor = params[:editor]
 
         current_branch = Actions.git_branch
-        if UI.interactive?
-          unless UI.confirm("Current branch is #{current_branch}. Are you sure this is the base branch for your bump?")
-            UI.user_error!("Cancelled during branch confirmation")
-          end
+        if UI.interactive? && !UI.confirm("Current branch is #{current_branch}. Are you sure this is the base branch for your bump?")
+          UI.user_error!("Cancelled during branch confirmation")
         end
 
         UI.important("Current version is #{version_number}")

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -38,7 +38,11 @@ module Fastlane
         Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump(new_branch_name, github_pr_token)
 
         generated_contents = Helper::VersioningHelper.auto_generate_changelog(repo_name, github_token, rate_limit_sleep)
-        Helper::RevenuecatInternalHelper.edit_changelog(generated_contents, changelog_latest_path, editor)
+
+        if UI.interactive?
+          Helper::RevenuecatInternalHelper.edit_changelog(generated_contents, changelog_latest_path, editor)
+        end
+
         changelog = File.read(changelog_latest_path)
 
         Helper::RevenuecatInternalHelper.create_new_branch_and_checkout(new_branch_name)

--- a/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
+++ b/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
@@ -74,6 +74,78 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         )
       end.to raise_exception(StandardError)
     end
+
+    it 'does not prompt for branch confirmation if UI is not interactive' do
+      allow(FastlaneCore::UI).to receive(:interactive?).and_return(false)
+      allow(FastlaneCore::UI).to receive(:input).with('New version number: ').and_return(new_version)
+      allow(FastlaneCore::UI).to receive(:confirm).with(anything).and_return(false)
+      allow(File).to receive(:read).with(mock_changelog_latest_path).and_return(edited_changelog)
+      allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:validate_local_config_status_for_bump)
+        .with('release/1.13.0', mock_github_pr_token)
+      allow(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
+        .with(mock_repo_name, mock_github_token, 3)
+        .and_return(auto_generated_changelog)
+      allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_new_branch_and_checkout)
+        .with(new_branch_name)
+      allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_version_number)
+        .with(current_version, new_version, ['./test_file.sh', './test_file2.rb'], ['./test_file3.kt', './test_file4.swift'])
+      allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:attach_changelog_to_master)
+        .with(new_version, mock_changelog_latest_path, mock_changelog_path)
+      allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:commmit_changes_and_push_current_branch)
+        .with("Version bump for #{new_version}")
+      allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
+        .with("Release/1.13.0", edited_changelog, mock_repo_name, new_branch_name, mock_github_pr_token, labels)
+
+      Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction.run(
+        current_version: current_version,
+        changelog_latest_path: mock_changelog_latest_path,
+        changelog_path: mock_changelog_path,
+        files_to_update: ['./test_file.sh', './test_file2.rb'],
+        files_to_update_without_prerelease_modifiers: ['./test_file3.kt', './test_file4.swift'],
+        repo_name: mock_repo_name,
+        github_pr_token: mock_github_pr_token,
+        github_token: mock_github_token,
+        github_rate_limit: 3,
+        editor: editor
+      )
+    end
+
+    it 'does not edit changelog if UI is not interactive' do
+      allow(FastlaneCore::UI).to receive(:interactive?).and_return(false)
+      allow(FastlaneCore::UI).to receive(:input).with('New version number: ').and_return(new_version)
+      allow(FastlaneCore::UI).to receive(:confirm).with(anything).and_return(false)
+      allow(File).to receive(:read).with(mock_changelog_latest_path).and_return(edited_changelog)
+      allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:validate_local_config_status_for_bump)
+        .with('release/1.13.0', mock_github_pr_token)
+      allow(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
+        .with(mock_repo_name, mock_github_token, 3)
+        .and_return(auto_generated_changelog)
+      allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_new_branch_and_checkout)
+        .with(new_branch_name)
+      allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_version_number)
+        .with(current_version, new_version, ['./test_file.sh', './test_file2.rb'], ['./test_file3.kt', './test_file4.swift'])
+      allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:attach_changelog_to_master)
+        .with(new_version, mock_changelog_latest_path, mock_changelog_path)
+      allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:commmit_changes_and_push_current_branch)
+        .with("Version bump for #{new_version}")
+      allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
+        .with("Release/1.13.0", edited_changelog, mock_repo_name, new_branch_name, mock_github_pr_token, labels)
+
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to_not(receive(:edit_changelog)
+                                                                  .with(auto_generated_changelog, mock_changelog_latest_path, editor))
+      Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction.run(
+        current_version: current_version,
+        changelog_latest_path: mock_changelog_latest_path,
+        changelog_path: mock_changelog_path,
+        files_to_update: ['./test_file.sh', './test_file2.rb'],
+        files_to_update_without_prerelease_modifiers: ['./test_file3.kt', './test_file4.swift'],
+        repo_name: mock_repo_name,
+        github_pr_token: mock_github_pr_token,
+        github_token: mock_github_token,
+        github_rate_limit: 3,
+        editor: editor
+      )
+    end
   end
 
   describe '#available_options' do

--- a/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
+++ b/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
@@ -14,6 +14,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
     let(:labels) { ['next_release'] }
 
     it 'calls all the appropriate methods with appropriate parameters' do
+      allow(FastlaneCore::UI).to receive(:interactive?).and_return(true)
       allow(FastlaneCore::UI).to receive(:input).with('New version number: ').and_return(new_version)
       allow(FastlaneCore::UI).to receive(:confirm).with(anything).and_return(true)
       allow(File).to receive(:read).with(mock_changelog_latest_path).and_return(edited_changelog)
@@ -58,6 +59,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
     end
 
     it 'fails if selected no during prompt validating current branch' do
+      allow(FastlaneCore::UI).to receive(:interactive?).and_return(true)
       allow(FastlaneCore::UI).to receive(:confirm).with(anything).and_return(false)
       expect do
         Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction.run(


### PR DESCRIPTION
Uses `UI.interactive?` to prevent asking for branch confirmation and edit of the changelog in CI
