### PR TITLE
Support prerelease version during version increase

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -72,20 +72,29 @@ module Fastlane
       end
 
       def self.increase_version(current_version, type_of_bump, snapshot)
-        version_split = current_version.split('.')
-        UI.user_error("Invalid version number: #{current_version}. Expected 3 numbers separated by '.'") if version_split.size != 3
+        is_prerelease = %w(alpha beta rc).any? { |prerelease| current_version.include?(prerelease) }
+        is_valid_version = current_version.match?("^[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?$")
+
+        UI.user_error!("Invalid version number: #{current_version}. Expected 3 numbers separated by '.' with an optional prerelease modifier") unless is_valid_version
+
+        delimiters = ['.', '-']
+        version_split = current_version.split(Regexp.union(delimiters))
 
         major = version_split[0]
         minor = version_split[1]
         patch = version_split[2]
 
-        case type_of_bump
-        when :major
-          next_version = "#{major.to_i + 1}.0.0"
-        when :minor
-          next_version = "#{major}.#{minor.to_i + 1}.0"
+        if is_prerelease
+          next_version = "#{major}.#{minor}.#{patch}"
         else
-          next_version = "#{major}.#{minor}.#{patch.to_i + 1}"
+          case type_of_bump
+          when :major
+            next_version = "#{major.to_i + 1}.0.0"
+          when :minor
+            next_version = "#{major}.#{minor.to_i + 1}.0"
+          else
+            next_version = "#{major}.#{minor}.#{patch.to_i + 1}"
+          end
         end
 
         if snapshot

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -257,9 +257,9 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       expect(next_version).to eq('1.12.0-SNAPSHOT')
     end
 
-    it 'calculates next version correctly with snapshot version' do
-      next_version = Fastlane::Helper::RevenuecatInternalHelper.calculate_next_snapshot_version('1.11.1-SNAPSHOT')
-      expect(next_version).to eq('1.12.0-SNAPSHOT')
+    it 'calculates next version correctly with prerelease version' do
+      next_version = Fastlane::Helper::RevenuecatInternalHelper.calculate_next_snapshot_version('1.11.1-alpha.1')
+      expect(next_version).to eq('1.11.1-SNAPSHOT')
     end
 
     it 'calculates next version correctly with major relase' do

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -285,6 +285,38 @@ describe Fastlane::Helper::VersioningHelper do
       next_version = Fastlane::Helper::VersioningHelper.increase_version('1.2.3', :major, true)
       expect(next_version).to eq('2.0.0-SNAPSHOT')
     end
+
+    it 'keeps version with snapshot but removing alpha modifier if it appears' do
+      next_version = Fastlane::Helper::VersioningHelper.increase_version('1.2.3-alpha.1', :major, true)
+      expect(next_version).to eq('1.2.3-SNAPSHOT')
+    end
+
+    it 'keeps version with snapshot but removing beta modifier if it appears' do
+      next_version = Fastlane::Helper::VersioningHelper.increase_version('1.2.3-beta.1', :minor, true)
+      expect(next_version).to eq('1.2.3-SNAPSHOT')
+    end
+
+    it 'keeps version with snapshot but removing rc modifier if it appears' do
+      next_version = Fastlane::Helper::VersioningHelper.increase_version('1.2.3-beta.1', :patch, true)
+      expect(next_version).to eq('1.2.3-SNAPSHOT')
+    end
+
+    it 'keeps version but removing rc modifier if it appears' do
+      next_version = Fastlane::Helper::VersioningHelper.increase_version('1.2.3-beta.1', :patch, false)
+      expect(next_version).to eq('1.2.3')
+    end
+
+    it 'fails if given snapshot version to bump' do
+      expect do
+        Fastlane::Helper::VersioningHelper.increase_version('1.2.3-SNAPSHOT', :patch, false)
+      end.to raise_exception(StandardError)
+    end
+
+    it 'fails if given unsupported version to bump' do
+      expect do
+        Fastlane::Helper::VersioningHelper.increase_version('1.2.3-alpha', :patch, false)
+      end.to raise_exception(StandardError)
+    end
   end
 
   def setup_commit_search_stubs(hashes_to_responses)


### PR DESCRIPTION
This PR adds support for versions with prerelease modifiers when trying to bump versions automatically. Now we will support versions like `1.2.3-alpha.1`, `2.2.2-beta.3` or `3.3.3-rc.4` which will increase to the version without the prerelease modifier and add `SNAPSHOT` if needed. The regex for valid version numbers now is: `^[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?$`.
