### PR TITLE
`bump_version_update_changelog_create_pr_action`: validate new version is not empty

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -29,6 +29,7 @@ module Fastlane
         # Ask for new version number
         new_version_number ||= UI.input("New version number: ")
 
+        UI.user_error!("Version number cannot be empty") if new_version_number.strip.empty?
         UI.important("New version is #{new_version_number}")
 
         new_branch_name = "release/#{new_version_number}"

--- a/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
+++ b/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
@@ -17,7 +17,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
       allow(FastlaneCore::UI).to receive(:interactive?).and_return(true)
       allow(FastlaneCore::UI).to receive(:confirm).with(anything).and_return(true)
       allow(FastlaneCore::UI).to receive(:input).with('New version number: ').and_return('')
-      
+
       expect(FastlaneCore::UI).to receive(:user_error!)
         .with('Version number cannot be empty')
         .once

--- a/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
+++ b/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
@@ -13,6 +13,29 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
     let(:new_branch_name) { 'release/1.13.0' }
     let(:labels) { ['next_release'] }
 
+    it 'fails if version is invalid' do
+      allow(FastlaneCore::UI).to receive(:interactive?).and_return(true)
+      allow(FastlaneCore::UI).to receive(:confirm).with(anything).and_return(true)
+      allow(FastlaneCore::UI).to receive(:input).with('New version number: ').and_return('')
+      
+      expect(FastlaneCore::UI).to receive(:user_error!)
+        .with('Version number cannot be empty')
+        .once
+        .and_throw(:expected_error)
+
+      catch :expected_error do
+        Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction.run(
+          current_version: current_version,
+          changelog_latest_path: mock_changelog_latest_path,
+          changelog_path: mock_changelog_path,
+          repo_name: mock_repo_name,
+          github_pr_token: mock_github_pr_token,
+          github_token: mock_github_token,
+          editor: editor
+        )
+      end
+    end
+
     it 'calls all the appropriate methods with appropriate parameters' do
       allow(FastlaneCore::UI).to receive(:interactive?).and_return(true)
       allow(FastlaneCore::UI).to receive(:input).with('New version number: ').and_return(new_version)


### PR DESCRIPTION
I realized the script kept going after I just pressed "enter" with an empty version number.