### PR TITLE
Don't include next_release in changelog

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -59,6 +59,7 @@ module Fastlane
             message = "#{item['title']} (##{item['number']})"
             username = item["user"]["login"]
             types_of_change = get_type_of_change_from_pr_info(item)
+            next if types_of_change.include?("next_release")
 
             section = get_section_depending_on_types_of_change(types_of_change)
 

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -43,9 +43,7 @@ describe Fastlane::Helper::VersioningHelper do
       expect(changelog).to eq("### Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
                               "### New Features\n" \
-                              "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
-                              "### Other Changes\n" \
-                              "* Prepare next version: 4.8.0-SNAPSHOT (#1750) via RevenueCat Releases (@revenuecat-ops)")
+                              "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)")
     end
 
     it 'sleeps between getting commits info if passing rate limit sleep' do
@@ -59,9 +57,7 @@ describe Fastlane::Helper::VersioningHelper do
       expect(changelog).to eq("### Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
                               "### New Features\n" \
-                              "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
-                              "### Other Changes\n" \
-                              "* Prepare next version: 4.8.0-SNAPSHOT (#1750) via RevenueCat Releases (@revenuecat-ops)")
+                              "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)")
     end
 
     it 'fails if it finds multiple commits with same sha' do
@@ -100,9 +96,7 @@ describe Fastlane::Helper::VersioningHelper do
       expect(changelog).to eq("### Breaking Changes\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
                               "### Bugfixes\n" \
-                              "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
-                              "### Other Changes\n" \
-                              "* Prepare next version: 4.8.0-SNAPSHOT (#1750) via RevenueCat Releases (@revenuecat-ops)")
+                              "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)")
     end
 
     it 'change is classified as Other Changes if pr has no label' do
@@ -123,7 +117,6 @@ describe Fastlane::Helper::VersioningHelper do
       expect(changelog).to eq("### Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
                               "### Other Changes\n" \
-                              "* Prepare next version: 4.8.0-SNAPSHOT (#1750) via RevenueCat Releases (@revenuecat-ops)\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)")
     end
   end


### PR DESCRIPTION
`next_release` PRs shouldn't be incldued in the changelog

[CSDK-421]

[CSDK-421]: https://revenuecats.atlassian.net/browse/CSDK-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ