### PR TITLE
Fix for changelog not being generated properly

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -39,6 +39,8 @@ module Fastlane
 
         if UI.interactive?
           Helper::RevenuecatInternalHelper.edit_changelog(generated_contents, changelog_latest_path, editor)
+        else
+          Helper::RevenuecatInternalHelper.prepare_changelog(generated_contents, changelog_latest_path)
         end
 
         changelog = File.read(changelog_latest_path)

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -40,7 +40,7 @@ module Fastlane
         if UI.interactive?
           Helper::RevenuecatInternalHelper.edit_changelog(generated_contents, changelog_latest_path, editor)
         else
-          Helper::RevenuecatInternalHelper.prepare_changelog(generated_contents, changelog_latest_path)
+          Helper::RevenuecatInternalHelper.write_changelog(generated_contents, changelog_latest_path)
         end
 
         changelog = File.read(changelog_latest_path)

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -49,7 +49,7 @@ module Fastlane
         end
       end
 
-      def self.prepare_changelog(prepopulated_changelog, changelog_latest_path)
+      def self.write_changelog(prepopulated_changelog, changelog_latest_path)
         UI.user_error!("Pre populated content for changelog was empty") if prepopulated_changelog.empty?
 
         UI.message("Using pre populated contents:\n#{prepopulated_changelog}")

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -49,6 +49,16 @@ module Fastlane
         end
       end
 
+      def self.prepare_changelog(prepopulated_changelog, changelog_latest_path)
+        changelog_filename = File.basename(changelog_latest_path)
+
+        UI.user_error!("Pre populated content for changelog was empty") if prepopulated_changelog.empty?
+
+        UI.message("Using pre populated contents:\n#{prepopulated_changelog}")
+
+        File.write(changelog_latest_path, prepopulated_changelog)
+      end
+
       def self.attach_changelog_to_master(version_number, changelog_latest_path, changelog_path)
         current_changelog = File.open(changelog_latest_path, 'r')
         master_changelog = File.open(changelog_path, 'r')

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -54,7 +54,8 @@ module Fastlane
 
         UI.message("Using pre populated contents:\n#{prepopulated_changelog}")
 
-        File.write(changelog_latest_path, prepopulated_changelog)
+        # An extra line at the end needs to be added. Vim adds it automatically.
+        File.write(changelog_latest_path, "#{prepopulated_changelog}\n")
       end
 
       def self.attach_changelog_to_master(version_number, changelog_latest_path, changelog_path)

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -50,8 +50,6 @@ module Fastlane
       end
 
       def self.prepare_changelog(prepopulated_changelog, changelog_latest_path)
-        changelog_filename = File.basename(changelog_latest_path)
-
         UI.user_error!("Pre populated content for changelog was empty") if prepopulated_changelog.empty?
 
         UI.message("Using pre populated contents:\n#{prepopulated_changelog}")

--- a/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
+++ b/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
@@ -87,6 +87,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
       allow(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
         .with(mock_repo_name, mock_github_token, 3)
         .and_return(auto_generated_changelog)
+      allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:write_changelog)
+        .with(auto_generated_changelog, mock_changelog_latest_path)
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_new_branch_and_checkout)
         .with(new_branch_name)
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_version_number)
@@ -133,6 +135,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
         .with("Release/1.13.0", edited_changelog, mock_repo_name, new_branch_name, mock_github_pr_token, labels)
 
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:write_changelog)
+        .with(auto_generated_changelog, mock_changelog_latest_path)
       expect(Fastlane::Helper::RevenuecatInternalHelper).to_not(receive(:edit_changelog)
                                                                   .with(auto_generated_changelog, mock_changelog_latest_path, editor))
       Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction.run(

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -129,15 +129,20 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
 
   describe '.write_changelog' do
     let(:prepopulated_changelog) { 'mock prepopulated changelog' }
-    let(:changelog_latest_path) { './mock-path/CHANGELOG.latest.md' }
+    let(:changelog_latest_path) { './tmp_test_files/CHANGELOG.latest.md' }
 
     before(:each) do
-      allow(File).to receive(:write).with(changelog_latest_path, prepopulated_changelog)
+      Dir.mkdir('./tmp_test_files')
+      File.write(changelog_latest_path, 'Old changelog')
+    end
+
+    after(:each) do
+      FileUtils.rm_rf('./tmp_test_files')
     end
 
     it 'writes prepopulated changelog to latest changelog file' do
-      expect(File).to receive(:write).with(changelog_latest_path, "#{prepopulated_changelog}\n").once
       Fastlane::Helper::RevenuecatInternalHelper.write_changelog(prepopulated_changelog, changelog_latest_path)
+      expect(File.read(changelog_latest_path)).to eq("#{prepopulated_changelog}\n")
     end
 
     it 'fails if prepopulated changelog is empty' do

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -127,6 +127,27 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
     end
   end
 
+  describe '.write_changelog' do
+    let(:prepopulated_changelog) { 'mock prepopulated changelog' }
+    let(:changelog_latest_path) { './mock-path/CHANGELOG.latest.md' }
+
+    before(:each) do
+      allow(File).to receive(:write).with(changelog_latest_path, prepopulated_changelog)
+    end
+
+    it 'writes prepopulated changelog to latest changelog file' do
+      expect(File).to receive(:write).with(changelog_latest_path, "#{prepopulated_changelog}\n").once
+      Fastlane::Helper::RevenuecatInternalHelper.write_changelog(prepopulated_changelog, changelog_latest_path)
+    end
+
+    it 'fails if prepopulated changelog is empty' do
+      expect(File).not_to receive(:write)
+      expect do
+        Fastlane::Helper::RevenuecatInternalHelper.write_changelog('', changelog_latest_path)
+      end.to raise_exception(StandardError)
+    end
+  end
+
   describe '.attach_changelog_to_master' do
     require 'fileutils'
 


### PR DESCRIPTION
As noted in https://github.com/RevenueCat/purchases-hybrid-common/pull/209, the changelog was not being populated properly because `edit_changelog` is the function that updates the latest changelog file

[CSDK-422]

[CSDK-422]: https://revenuecats.atlassian.net/browse/CSDK-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ