### PR TITLE
Force fetch tags in case local tags are outdated

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -43,7 +43,7 @@ module Fastlane
       end
 
       def self.auto_generate_changelog(repo_name, github_token, rate_limit_sleep)
-        Actions.sh("git fetch --tags")
+        Actions.sh("git fetch --tags -f")
         old_version = latest_non_prerelease_version_number
         UI.important("Auto-generating changelog since #{old_version}")
 

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -340,7 +340,7 @@ describe Fastlane::Helper::VersioningHelper do
   end
 
   def setup_commit_search_stubs(hashes_to_responses)
-    allow(Fastlane::Actions).to receive(:sh).with('git fetch --tags')
+    allow(Fastlane::Actions).to receive(:sh).with('git fetch --tags -f')
     allow(Fastlane::Actions).to receive(:sh)
       .with("git tag", log: false)
       .and_return("0.1.0\n0.1.1\n1.11.0\n1.1.1.1\n1.1.1-alpha.1\n1.10.1")


### PR DESCRIPTION
This should resolve: https://revenuecats.atlassian.net/browse/CSDK-437. Basically, we delete and readd the `latest` tag in android on every release. This can cause the fetch to fail with this error: 
```
[15:16:04]: Exit status of command 'git fetch --tags' was 1 instead of 0.
From github.com:RevenueCat/purchases-android
 * [new tag]           4.2.1-autosyncpurchases -> 4.2.1-autosyncpurchases
 * [new tag]           5.0.0-amazon.alpha.6    -> 5.0.0-amazon.alpha.6
 * [new tag]           5.5.0                   -> 5.5.0
 ! [rejected]          amazon-latest           -> amazon-latest  (would clobber existing tag)
 ! [rejected]          latest                  -> latest  (would clobber existing tag)
```

By adding the `-f` flag to the fetch, this will make sure we always use remote's tags. Note that this can cause local tags to be lost if they exist in a different place in remote.