### PR TITLE
CreateNextSnapshotVersionAction skips if current version is SNAPSHOT

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,8 +29,7 @@ lane :sample_create_next_snapshot_version_action do |options|
     repo_name: 'repo-name',
     github_pr_token: 'github-api-token', # This can also be obtained from ENV GITHUB_PULL_REQUEST_API_TOKEN
     files_to_update: ['./file-containing-version-1.txt', './file-containing-version-2.rb'],
-    files_to_update_without_prerelease_modifiers: [],
-    branch: 'main'
+    files_to_update_without_prerelease_modifiers: []
   )
 end
 

--- a/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
@@ -12,6 +12,11 @@ module Fastlane
         files_to_update = params[:files_to_update]
         files_to_update_without_prerelease_modifiers = params[:files_to_update_without_prerelease_modifiers]
 
+        if previous_version_number =~ /^.*-SNAPSHOT/
+          UI.message("Skipping since current version is already a SNAPSHOT version.")
+          return
+        end
+
         next_version_snapshot = Helper::RevenuecatInternalHelper.calculate_next_snapshot_version(previous_version_number)
         new_branch_name = "bump/#{next_version_snapshot}"
         label = 'next_release'

--- a/spec/actions/create_next_snapshot_version_action_spec.rb
+++ b/spec/actions/create_next_snapshot_version_action_spec.rb
@@ -39,17 +39,11 @@ describe Fastlane::Actions::CreateNextSnapshotVersionAction do
 
     it 'skips if current version is SNAPSHOT' do
       expect(Fastlane::Helper::RevenuecatInternalHelper).not_to receive(:validate_local_config_status_for_bump)
-        .with("bump/#{next_version}", github_pr_token)
       expect(Fastlane::Helper::RevenuecatInternalHelper).not_to receive(:calculate_next_snapshot_version)
-        .with(current_version_snapshot)
       expect(Fastlane::Helper::RevenuecatInternalHelper).not_to receive(:create_new_branch_and_checkout)
-        .with(new_branch_name)
       expect(Fastlane::Helper::RevenuecatInternalHelper).not_to receive(:replace_version_number)
-        .with(current_version_snapshot, next_version, ['./test_file.sh', './test_file2.rb'], ['./test_file4.swift', './test_file5.kt'])
       expect(Fastlane::Helper::RevenuecatInternalHelper).not_to receive(:commmit_changes_and_push_current_branch)
-        .with('Preparing for next version')
       expect(Fastlane::Helper::RevenuecatInternalHelper).not_to receive(:create_pr_to_main)
-        .with('Prepare next version: 1.13.0-SNAPSHOT', nil, repo_name, new_branch_name, github_pr_token, labels)
       Fastlane::Actions::CreateNextSnapshotVersionAction.run(
         current_version: current_version_snapshot,
         repo_name: repo_name,

--- a/spec/actions/create_next_snapshot_version_action_spec.rb
+++ b/spec/actions/create_next_snapshot_version_action_spec.rb
@@ -3,6 +3,7 @@ describe Fastlane::Actions::CreateNextSnapshotVersionAction do
     let(:github_pr_token) { 'fake-github-pr-token' }
     let(:repo_name) { 'fake-repo-name' }
     let(:current_version) { '1.12.0' }
+    let(:current_version_snapshot) { '1.12.0-SNAPSHOT' }
     let(:next_version) { '1.13.0-SNAPSHOT' }
     let(:new_branch_name) { 'bump/1.13.0-SNAPSHOT' }
     let(:labels) { ['next_release'] }
@@ -29,6 +30,28 @@ describe Fastlane::Actions::CreateNextSnapshotVersionAction do
         .once
       Fastlane::Actions::CreateNextSnapshotVersionAction.run(
         current_version: current_version,
+        repo_name: repo_name,
+        github_pr_token: github_pr_token,
+        files_to_update: ['./test_file.sh', './test_file2.rb'],
+        files_to_update_without_prerelease_modifiers: ['./test_file4.swift', './test_file5.kt']
+      )
+    end
+
+    it 'skips if current version is SNAPSHOT' do
+      expect(Fastlane::Helper::RevenuecatInternalHelper).not_to receive(:validate_local_config_status_for_bump)
+        .with("bump/#{next_version}", github_pr_token)
+      expect(Fastlane::Helper::RevenuecatInternalHelper).not_to receive(:calculate_next_snapshot_version)
+        .with(current_version_snapshot)
+      expect(Fastlane::Helper::RevenuecatInternalHelper).not_to receive(:create_new_branch_and_checkout)
+        .with(new_branch_name)
+      expect(Fastlane::Helper::RevenuecatInternalHelper).not_to receive(:replace_version_number)
+        .with(current_version_snapshot, next_version, ['./test_file.sh', './test_file2.rb'], ['./test_file4.swift', './test_file5.kt'])
+      expect(Fastlane::Helper::RevenuecatInternalHelper).not_to receive(:commmit_changes_and_push_current_branch)
+        .with('Preparing for next version')
+      expect(Fastlane::Helper::RevenuecatInternalHelper).not_to receive(:create_pr_to_main)
+        .with('Prepare next version: 1.13.0-SNAPSHOT', nil, repo_name, new_branch_name, github_pr_token, labels)
+      Fastlane::Actions::CreateNextSnapshotVersionAction.run(
+        current_version: current_version_snapshot,
         repo_name: repo_name,
         github_pr_token: github_pr_token,
         files_to_update: ['./test_file.sh', './test_file2.rb'],


### PR DESCRIPTION
We are going to start running this action on every commit to `main` and we should skip if the current version is already a snapshot version.