### PR TITLE
Sort autogenerated changelog sections to put new features before fixes

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -49,7 +49,7 @@ module Fastlane
 
         commits = Helper::GitHubHelper.get_commits_since_old_version(github_token, old_version, repo_name)
 
-        changelog_sections = { breaking_changes: [], fixes: [], new_features: [], other: [] }
+        changelog_sections = { breaking_changes: [], new_features: [], fixes: [], other: [] }
 
         commits.map do |commit|
           name = commit["commit"]["author"]["name"]

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -40,10 +40,10 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-github-token',
         0
       )
-      expect(changelog).to eq("### Bugfixes\n" \
-                              "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
-                              "### New Features\n" \
-                              "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)")
+      expect(changelog).to eq("### New Features\n" \
+                              "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
+                              "### Bugfixes\n" \
+                              "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)")
     end
 
     it 'sleeps between getting commits info if passing rate limit sleep' do
@@ -54,10 +54,10 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-github-token',
         3
       )
-      expect(changelog).to eq("### Bugfixes\n" \
-                              "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
-                              "### New Features\n" \
-                              "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)")
+      expect(changelog).to eq("### New Features\n" \
+                              "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
+                              "### Bugfixes\n" \
+                              "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)")
     end
 
     it 'fails if it finds multiple commits with same sha' do


### PR DESCRIPTION
While working on https://github.com/RevenueCat/purchases-unity/pull/153, the bugfixes section was added before the new features section. I think it makes more sense to show the new features before bugfixes.  This PR just changes the order for those sections.
