### PR TITLE
Sets reviewers for all created PRs

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -94,7 +94,8 @@ module Fastlane
           repo: "RevenueCat/#{repo_name}",
           head: head_branch,
           api_url: 'https://api.github.com',
-          labels: labels
+          labels: labels,
+          reviewers: 'RevenueCat/core-sdk'
         )
       end
 

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -218,7 +218,8 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
           repo: 'RevenueCat/fake-repo-name',
           head: 'fake-branch',
           api_url: 'https://api.github.com',
-          labels: ['label_1', 'label_2']
+          labels: ['label_1', 'label_2'],
+          reviewers: 'RevenueCat/core-sdk'
         ).once
       Fastlane::Helper::RevenuecatInternalHelper.create_pr_to_main('fake-title', 'fake-changelog', 'fake-repo-name', 'fake-branch', 'fake-github-pr-token', ['label_1', 'label_2'])
     end


### PR DESCRIPTION
I thought it would be good to set it to `core-sdk` for all created PRs from any automation