### PR TITLE
Update team reviewers to coresdk

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -95,7 +95,7 @@ module Fastlane
           head: head_branch,
           api_url: 'https://api.github.com',
           labels: labels,
-          team_reviewers: ['core-sdk']
+          team_reviewers: ['coresdk']
         )
       end
 

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -219,7 +219,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
           head: 'fake-branch',
           api_url: 'https://api.github.com',
           labels: ['label_1', 'label_2'],
-          team_reviewers: ['core-sdk']
+          team_reviewers: ['coresdk']
         ).once
       Fastlane::Helper::RevenuecatInternalHelper.create_pr_to_main('fake-title', 'fake-changelog', 'fake-repo-name', 'fake-branch', 'fake-github-pr-token', ['label_1', 'label_2'])
     end


### PR DESCRIPTION
Team name has changed and automatic PRs are failing to add automatic reviewers.

This used to work when the team was `core-sdk` but now it looks like even updating it to `coresdk` fails (at least requesting reviewers using their API). It looks like GitHub might have a bug, related to name changes