### PR TITLE
Adds minor label if the purchases-hybrid-common bump is a minor

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_phc_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_phc_version_action.rb
@@ -46,15 +46,17 @@ module Fastlane
         Helper::RevenuecatInternalHelper.commit_changes_and_push_current_branch("Version bump for #{new_version_number}")
 
         pr_title = "Updates purchases-hybrid-common to #{new_version_number}"
-        label = 'dependencies'
+        type_of_bump = Helper::VersioningHelper.detect_bump_type(version_number, new_version_number)
+        labels = ['dependencies']
+        labels << 'minor' if type_of_bump == :minor
         body = pr_title
 
         if automatic_release
-          body = "**This is an automatic release.**\n\n#{body}"
-          pr_title = "[AUTOMATIC] #{pr_title}"
+          body = "**This is an automatic bump.**\n\n#{body}"
+          pr_title = "[AUTOMATIC BUMP] #{pr_title}"
         end
 
-        Helper::RevenuecatInternalHelper.create_pr_to_main(pr_title, body, repo_name, new_branch_name, github_pr_token, [label])
+        Helper::RevenuecatInternalHelper.create_pr_to_main(pr_title, body, repo_name, new_branch_name, github_pr_token, labels)
       end
 
       def self.description

--- a/lib/fastlane/plugin/revenuecat_internal/actions/detect_bump_type.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/detect_bump_type.rb
@@ -1,0 +1,40 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require_relative '../helper/versioning_helper'
+
+module Fastlane
+  module Actions
+    class DetectBumpTypeAction < Action
+      def self.run(params)
+        previous_version_number = params[:current_version]
+        new_version_number = params[:new_version_number]
+        Helper::VersioningHelper.detect_bump_type(previous_version_number, new_version_number)
+      end
+
+      def self.description
+        "Compares two versions and returns the type of bump between them (major, minor or patch)"
+      end
+
+      def self.authors
+        ["Cesar de la Vega"]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :current_version,
+                                       description: "Previous version before bump",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :new_version_number,
+                                       description: "New version after bump",
+                                       optional: false,
+                                       type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -115,6 +115,19 @@ module Fastlane
         version_a = Gem::Version.new(version_name_a)
         version_b = Gem::Version.new(version_name_b)
 
+        version_a_number_segments = version_name_a.to_s.split('.').length
+        version_b_number_segments = version_name_b.to_s.split('.').length
+
+        if version_a_number_segments != version_b_number_segments
+          UI.error("Can't detect bump type because version #{version_a} and #{version_b} have a different format")
+          return :none
+        end
+
+        if version_a_number_segments != 3
+          UI.error("Can't detect bump type because versions don't follow format x.y.z")
+          return :none
+        end
+
         same_major = version_a.canonical_segments[0] == version_b.canonical_segments[0]
         same_minor = version_a.canonical_segments[1] == version_b.canonical_segments[1]
         if same_major && same_minor

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -107,6 +107,44 @@ module Fastlane
         snapshot ? "#{next_version}-SNAPSHOT" : next_version
       end
 
+      def detect_bump_type(a, b)
+        if a == b
+          return :none
+        end
+
+        version_a = Gem::Version.new(a)
+        version_b = Gem::Version.new(b)
+
+        same_major = version_a.canonical_segments[0] == version_b.canonical_segments[0]
+        same_minor = version_a.canonical_segments[1] == version_b.canonical_segments[1]
+        if same_major && same_minor
+          return :patch
+        elsif same_major
+          return :minor
+        else
+          return :major
+        end
+      end
+
+      def detect_bump_type(a, b)
+        if a == b
+          return :none
+        end
+
+        version_a = Gem::Version.new(a)
+        version_b = Gem::Version.new(b)
+
+        same_major = version_a.canonical_segments[0] == version_b.canonical_segments[0]
+        same_minor = version_a.canonical_segments[1] == version_b.canonical_segments[1]
+        if same_major && same_minor
+          return :patch
+        elsif same_major
+          return :minor
+        else
+          return :major
+        end
+      end
+
       private_class_method def self.latest_non_prerelease_version_number
         Actions
           .sh("git tag", log: false)

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -107,41 +107,22 @@ module Fastlane
         snapshot ? "#{next_version}-SNAPSHOT" : next_version
       end
 
-      def detect_bump_type(a, b)
-        if a == b
+      def self.detect_bump_type(version_name_a, version_name_b)
+        if version_name_a == version_name_b
           return :none
         end
 
-        version_a = Gem::Version.new(a)
-        version_b = Gem::Version.new(b)
+        version_a = Gem::Version.new(version_name_a)
+        version_b = Gem::Version.new(version_name_b)
 
         same_major = version_a.canonical_segments[0] == version_b.canonical_segments[0]
         same_minor = version_a.canonical_segments[1] == version_b.canonical_segments[1]
         if same_major && same_minor
-          return :patch
+          :patch
         elsif same_major
-          return :minor
+          :minor
         else
-          return :major
-        end
-      end
-
-      def detect_bump_type(a, b)
-        if a == b
-          return :none
-        end
-
-        version_a = Gem::Version.new(a)
-        version_b = Gem::Version.new(b)
-
-        same_major = version_a.canonical_segments[0] == version_b.canonical_segments[0]
-        same_minor = version_a.canonical_segments[1] == version_b.canonical_segments[1]
-        if same_major && same_minor
-          return :patch
-        elsif same_major
-          return :minor
-        else
-          return :major
+          :major
         end
       end
 

--- a/spec/actions/bump_phc_version_action_spec.rb
+++ b/spec/actions/bump_phc_version_action_spec.rb
@@ -36,7 +36,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
       allow(FastlaneCore::UI).to receive(:input).with('New version number: ').and_return(new_version)
       allow(FastlaneCore::UI).to receive(:confirm).with(anything).and_return(true)
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:validate_local_config_status_for_bump)
-        .with('bump-phc/1.13.0', mock_github_pr_token)
+        .with(new_branch_name, mock_github_pr_token)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_new_branch_and_checkout)
         .with(new_branch_name)
@@ -144,7 +144,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
       expect(FastlaneCore::UI).to receive(:input)
         .never
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:validate_local_config_status_for_bump)
-        .with('bump-phc/1.13.0', mock_github_pr_token)
+        .with(new_branch_name, mock_github_pr_token)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_new_branch_and_checkout)
         .with(new_branch_name)
@@ -155,7 +155,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:commit_changes_and_push_current_branch)
         .with("Version bump for #{new_version}")
         .once
-      message = "Updates purchases-hybrid-common to 1.13.0"
+      message = "Updates purchases-hybrid-common to #{new_version}"
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
         .with(message, message, mock_repo_name, new_branch_name, mock_github_pr_token, labels)
         .once
@@ -168,6 +168,41 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         files_to_update: ['./test_file.sh', './test_file2.rb'],
         open_pr: true,
         next_version: new_version
+      )
+    end
+
+    it 'does not add the minor label if bump is not minor' do
+      new_patch_version = '1.12.1'
+      new_branch_name = 'bump-phc/1.12.1'
+      allow(FastlaneCore::UI).to receive(:interactive?).and_return(true)
+      allow(FastlaneCore::UI).to receive(:confirm).with(anything).and_return(true)
+      expect(FastlaneCore::UI).to receive(:input)
+        .never
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:validate_local_config_status_for_bump)
+        .with(new_branch_name, mock_github_pr_token)
+        .once
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_new_branch_and_checkout)
+        .with(new_branch_name)
+        .once
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_version_number)
+        .with(current_version, new_patch_version, ['./test_file.sh', './test_file2.rb'], [])
+        .once
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:commit_changes_and_push_current_branch)
+        .with("Version bump for #{new_patch_version}")
+        .once
+      message = "Updates purchases-hybrid-common to 1.12.1"
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
+        .with(message, message, mock_repo_name, new_branch_name, mock_github_pr_token, ['dependencies'])
+        .once
+
+      Fastlane::Actions::BumpPhcVersionAction.run(
+        current_version: current_version,
+        repo_name: mock_repo_name,
+        github_pr_token: mock_github_pr_token,
+        github_token: mock_github_token,
+        files_to_update: ['./test_file.sh', './test_file2.rb'],
+        open_pr: true,
+        next_version: new_patch_version
       )
     end
 

--- a/spec/actions/bump_phc_version_action_spec.rb
+++ b/spec/actions/bump_phc_version_action_spec.rb
@@ -9,7 +9,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
     let(:current_version) { '1.12.0' }
     let(:new_version) { '1.13.0' }
     let(:new_branch_name) { 'bump-phc/1.13.0' }
-    let(:labels) { ['dependencies'] }
+    let(:labels) { ['dependencies', 'minor'] }
 
     it 'fails if version is invalid' do
       allow(FastlaneCore::UI).to receive(:interactive?).and_return(true)
@@ -97,7 +97,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
 
       message = "Updates purchases-hybrid-common to 1.13.0"
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
-        .with("[AUTOMATIC] #{message}", "**This is an automatic release.**\n\n#{message}", mock_repo_name, new_branch_name, mock_github_pr_token, labels)
+        .with("[AUTOMATIC BUMP] #{message}", "**This is an automatic bump.**\n\n#{message}", mock_repo_name, new_branch_name, mock_github_pr_token, labels)
 
       Fastlane::Actions::BumpPhcVersionAction.run(
         current_version: current_version,

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -473,6 +473,22 @@ describe Fastlane::Helper::VersioningHelper do
       bump_type = Fastlane::Helper::VersioningHelper.detect_bump_type('1.2.3', '1.2.3')
       expect(bump_type).to eq(:none)
     end
+
+    it 'fails if incompatible versions' do
+      expect(FastlaneCore::UI).to receive(:error)
+        .with("Can't detect bump type because version 1.2.3 and 1.2 have a different format")
+        .once
+      bump_type = Fastlane::Helper::VersioningHelper.detect_bump_type('1.2.3', '1.2')
+      expect(bump_type).to eq(:none)
+    end
+
+    it 'fails if versions don\'t have 3 segments' do
+      expect(FastlaneCore::UI).to receive(:error)
+        .with("Can't detect bump type because versions don't follow format x.y.z")
+        .once
+      bump_type = Fastlane::Helper::VersioningHelper.detect_bump_type('1.3', '1.2')
+      expect(bump_type).to eq(:none)
+    end
   end
 
   def setup_tag_stubs

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -453,6 +453,23 @@ describe Fastlane::Helper::VersioningHelper do
     end
   end
 
+  describe '.detect_bump_type' do
+    it 'correctly detects patch bumps' do
+      bump_type = Fastlane::Helper::VersioningHelper.detect_bump_type('1.2.3', '1.2.4')
+      expect(bump_type).to eq(:patch)
+    end
+
+    it 'correctly detects minor bumps' do
+      bump_type = Fastlane::Helper::VersioningHelper.detect_bump_type('1.2.3', '1.3.0')
+      expect(bump_type).to eq(:minor)
+    end
+
+    it 'correctly detects major bumps' do
+      bump_type = Fastlane::Helper::VersioningHelper.detect_bump_type('1.2.3', '2.0.0')
+      expect(bump_type).to eq(:major)
+    end
+  end
+
   def setup_tag_stubs
     allow(Fastlane::Actions).to receive(:sh).with('git fetch --tags -f')
     allow(Fastlane::Actions).to receive(:sh)

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -468,6 +468,11 @@ describe Fastlane::Helper::VersioningHelper do
       bump_type = Fastlane::Helper::VersioningHelper.detect_bump_type('1.2.3', '2.0.0')
       expect(bump_type).to eq(:major)
     end
+
+    it 'correctly detects no version bump' do
+      bump_type = Fastlane::Helper::VersioningHelper.detect_bump_type('1.2.3', '1.2.3')
+      expect(bump_type).to eq(:none)
+    end
   end
 
   def setup_tag_stubs


### PR DESCRIPTION
- Adds a `minor` label if the purchases-hybrid-common bump is a minor. This minor label will be detected and will force a minor bump in the next release
- Updates title and body of PR from `Automatic release` to `Automatic bump`