### PR TITLE
Use last commit instead of HEAD when comparing against last release

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -1,6 +1,7 @@
 require 'fastlane_core/ui/ui'
 require 'fastlane/action'
 require 'fastlane/actions/github_api'
+require 'fastlane/actions/last_git_commit'
 
 module Fastlane
   UI = FastlaneCore::UI unless Fastlane.const_defined?(:UI)
@@ -27,7 +28,8 @@ module Fastlane
       end
 
       def self.get_commits_since_old_version(github_token, old_version, repo_name)
-        path = "/repos/RevenueCat/#{repo_name}/compare/#{old_version}...HEAD"
+        commit_head = Actions::LastGitCommitAction.run({})
+        path = "/repos/RevenueCat/#{repo_name}/compare/#{old_version}...#{commit_head[:commit_hash]}"
 
         # Get all commits from previous version (tag) to HEAD
         resp = Actions::GithubApiAction.run(server_url: 'https://api.github.com',

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -64,9 +64,13 @@ describe Fastlane::Helper::GitHubHelper do
     end
 
     it 'returns commits from response' do
+      allow(Fastlane::Actions::LastGitCommitAction).to receive(:run)
+        .and_return({
+                                                                       commit_hash: 'cfdd80f73d8c91121313d72227b4cbe283b57c1e'
+                                                                     })
       allow(Fastlane::Actions::GithubApiAction).to receive(:run)
         .with(server_url: server_url,
-              path: '/repos/RevenueCat/mock-repo-name/compare/1.11.0...HEAD',
+              path: '/repos/RevenueCat/mock-repo-name/compare/1.11.0...cfdd80f73d8c91121313d72227b4cbe283b57c1e',
               http_method: http_method,
               body: {},
               api_token: github_token)

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -65,9 +65,7 @@ describe Fastlane::Helper::GitHubHelper do
 
     it 'returns commits from response' do
       allow(Fastlane::Actions::LastGitCommitAction).to receive(:run)
-        .and_return({
-                                                                       commit_hash: 'cfdd80f73d8c91121313d72227b4cbe283b57c1e'
-                                                                     })
+        .and_return(commit_hash: 'cfdd80f73d8c91121313d72227b4cbe283b57c1e')
       allow(Fastlane::Actions::GithubApiAction).to receive(:run)
         .with(server_url: server_url,
               path: '/repos/RevenueCat/mock-repo-name/compare/1.11.0...cfdd80f73d8c91121313d72227b4cbe283b57c1e',

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -57,7 +57,7 @@ describe Fastlane::Helper::GitHubHelper do
   describe '.get_commits_since_old_version' do
     let(:server_url) { 'https://api.github.com' }
     let(:http_method) { 'GET' }
-    let(:hash) { 'a72c0435ecf71248f311900475e881cc07ac2eaf' }
+    let(:last_commit_sha) { 'cfdd80f73d8c91121313d72227b4cbe283b57c1e' }
     let(:github_token) { 'mock-github-token' }
     let(:get_commits_response) do
       { body: File.read("#{File.dirname(__FILE__)}/../test_files/get_commits_since_last_release.json") }
@@ -65,10 +65,10 @@ describe Fastlane::Helper::GitHubHelper do
 
     it 'returns commits from response' do
       allow(Fastlane::Actions::LastGitCommitAction).to receive(:run)
-        .and_return(commit_hash: 'cfdd80f73d8c91121313d72227b4cbe283b57c1e')
+        .and_return(commit_hash: last_commit_sha)
       allow(Fastlane::Actions::GithubApiAction).to receive(:run)
         .with(server_url: server_url,
-              path: '/repos/RevenueCat/mock-repo-name/compare/1.11.0...cfdd80f73d8c91121313d72227b4cbe283b57c1e',
+              path: "/repos/RevenueCat/mock-repo-name/compare/1.11.0...#{last_commit_sha}",
               http_method: http_method,
               body: {},
               api_token: github_token)

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -480,9 +480,7 @@ describe Fastlane::Helper::VersioningHelper do
 
   def mock_commits_since_last_release(last_commit_hash, response)
     allow(Fastlane::Actions::LastGitCommitAction).to receive(:run)
-      .and_return({
-                                                                     commit_hash: last_commit_hash
-                                                                   })
+      .and_return(commit_hash: last_commit_hash)
     allow(Fastlane::Actions::GithubApiAction).to receive(:run)
       .with(server_url: server_url,
             path: "/repos/RevenueCat/mock-repo-name/compare/1.11.0...#{last_commit_hash}",

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -128,14 +128,7 @@ describe Fastlane::Helper::VersioningHelper do
 
     it 'change is classified as Other Changes if commit has no pr' do
       setup_tag_stubs
-
-      allow(Fastlane::Actions::GithubApiAction).to receive(:run)
-        .with(server_url: server_url,
-              path: '/repos/RevenueCat/mock-repo-name/compare/1.11.0...HEAD',
-              http_method: http_method,
-              body: {},
-              api_token: 'mock-github-token')
-        .and_return(get_commits_response_no_pr)
+      mock_commits_since_last_release("4ceaceb20e700b92197daf8904f5c4e226625d8a", get_commits_response_no_pr)
 
       allow(Fastlane::Actions::GithubApiAction).to receive(:run)
         .with(server_url: server_url,
@@ -223,14 +216,7 @@ describe Fastlane::Helper::VersioningHelper do
 
     it 'determines next version as patch correctly' do
       setup_commit_search_stubs(hashes_to_responses)
-
-      allow(Fastlane::Actions::GithubApiAction).to receive(:run)
-        .with(server_url: server_url,
-              path: '/repos/RevenueCat/mock-repo-name/compare/1.11.0...HEAD',
-              http_method: http_method,
-              body: {},
-              api_token: 'mock-github-token')
-        .and_return(get_commits_response_patch)
+      mock_commits_since_last_release("6d37c766b6da55dcab67c201c93ba3d4ca538e55", get_commits_response_patch)
       expect_any_instance_of(Object).not_to receive(:sleep)
       next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
         'mock-repo-name',
@@ -243,14 +229,7 @@ describe Fastlane::Helper::VersioningHelper do
 
     it 'skips next version if no release is needed' do
       setup_commit_search_stubs(hashes_to_responses)
-
-      allow(Fastlane::Actions::GithubApiAction).to receive(:run)
-        .with(server_url: server_url,
-              path: '/repos/RevenueCat/mock-repo-name/compare/1.11.0...HEAD',
-              http_method: http_method,
-              body: {},
-              api_token: 'mock-github-token')
-        .and_return(get_commits_response_skip)
+      mock_commits_since_last_release("1285b6df6fb756d8b31337be9dabbf3ec5c0bbfe", get_commits_response_skip)
       expect_any_instance_of(Object).not_to receive(:sleep)
       next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
         'mock-repo-name',
@@ -348,14 +327,7 @@ describe Fastlane::Helper::VersioningHelper do
 
     it 'skips if it finds commit without a pr associated' do
       setup_commit_search_stubs(hashes_to_responses)
-
-      allow(Fastlane::Actions::GithubApiAction).to receive(:run)
-        .with(server_url: server_url,
-              path: '/repos/RevenueCat/mock-repo-name/compare/1.11.0...HEAD',
-              http_method: http_method,
-              body: {},
-              api_token: 'mock-github-token')
-        .and_return(get_commits_response_no_pr)
+      mock_commits_since_last_release('4ceaceb20e700b92197daf8904f5c4e226625d8a', get_commits_response_no_pr)
       expect_any_instance_of(Object).not_to receive(:sleep)
       next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
         'mock-repo-name',
@@ -369,13 +341,7 @@ describe Fastlane::Helper::VersioningHelper do
     it 'ignores commits without associated prs' do
       setup_commit_search_stubs(hashes_to_responses)
 
-      allow(Fastlane::Actions::GithubApiAction).to receive(:run)
-        .with(server_url: server_url,
-              path: '/repos/RevenueCat/mock-repo-name/compare/1.11.0...HEAD',
-              http_method: http_method,
-              body: {},
-              api_token: 'mock-github-token')
-        .and_return(get_commits_response_no_pr_more_commits)
+      mock_commits_since_last_release("885cfa2d3d570c7427ad6581bc8e4e6c4baf82e4", get_commits_response_no_pr_more_commits)
       allow(Fastlane::Actions::GithubApiAction).to receive(:run)
         .with(server_url: server_url,
               path: '/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:main+SHA:a72c0435ecf71248f311900475e881cc07ac2eaf',
@@ -500,13 +466,7 @@ describe Fastlane::Helper::VersioningHelper do
 
   def setup_commit_search_stubs(hashes_to_responses)
     setup_tag_stubs
-    allow(Fastlane::Actions::GithubApiAction).to receive(:run)
-      .with(server_url: server_url,
-            path: '/repos/RevenueCat/mock-repo-name/compare/1.11.0...HEAD',
-            http_method: http_method,
-            body: {},
-            api_token: 'mock-github-token')
-      .and_return(get_commits_response)
+    mock_commits_since_last_release("cfdd80f73d8c91121313d72227b4cbe283b57c1e", get_commits_response)
     hashes_to_responses.each do |hash, response|
       allow(Fastlane::Actions::GithubApiAction).to receive(:run)
         .with(server_url: server_url,
@@ -516,5 +476,19 @@ describe Fastlane::Helper::VersioningHelper do
               api_token: 'mock-github-token')
         .and_return(response)
     end
+  end
+
+  def mock_commits_since_last_release(last_commit_hash, response)
+    allow(Fastlane::Actions::LastGitCommitAction).to receive(:run)
+      .and_return({
+                                                                     commit_hash: last_commit_hash
+                                                                   })
+    allow(Fastlane::Actions::GithubApiAction).to receive(:run)
+      .with(server_url: server_url,
+            path: "/repos/RevenueCat/mock-repo-name/compare/1.11.0...#{last_commit_hash}",
+            http_method: http_method,
+            body: {},
+            api_token: 'mock-github-token')
+      .and_return(response)
   end
 end

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -216,7 +216,7 @@ describe Fastlane::Helper::VersioningHelper do
 
     it 'determines next version as patch correctly' do
       setup_commit_search_stubs(hashes_to_responses)
-      mock_commits_since_last_release("6d37c766b6da55dcab67c201c93ba3d4ca538e55", get_commits_response_patch)
+      mock_commits_since_last_release('6d37c766b6da55dcab67c201c93ba3d4ca538e55', get_commits_response_patch)
       expect_any_instance_of(Object).not_to receive(:sleep)
       next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
         'mock-repo-name',
@@ -229,7 +229,7 @@ describe Fastlane::Helper::VersioningHelper do
 
     it 'skips next version if no release is needed' do
       setup_commit_search_stubs(hashes_to_responses)
-      mock_commits_since_last_release("1285b6df6fb756d8b31337be9dabbf3ec5c0bbfe", get_commits_response_skip)
+      mock_commits_since_last_release('1285b6df6fb756d8b31337be9dabbf3ec5c0bbfe', get_commits_response_skip)
       expect_any_instance_of(Object).not_to receive(:sleep)
       next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
         'mock-repo-name',
@@ -341,7 +341,7 @@ describe Fastlane::Helper::VersioningHelper do
     it 'ignores commits without associated prs' do
       setup_commit_search_stubs(hashes_to_responses)
 
-      mock_commits_since_last_release("885cfa2d3d570c7427ad6581bc8e4e6c4baf82e4", get_commits_response_no_pr_more_commits)
+      mock_commits_since_last_release('885cfa2d3d570c7427ad6581bc8e4e6c4baf82e4', get_commits_response_no_pr_more_commits)
       allow(Fastlane::Actions::GithubApiAction).to receive(:run)
         .with(server_url: server_url,
               path: '/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:main+SHA:a72c0435ecf71248f311900475e881cc07ac2eaf',
@@ -466,7 +466,7 @@ describe Fastlane::Helper::VersioningHelper do
 
   def setup_commit_search_stubs(hashes_to_responses)
     setup_tag_stubs
-    mock_commits_since_last_release("cfdd80f73d8c91121313d72227b4cbe283b57c1e", get_commits_response)
+    mock_commits_since_last_release('cfdd80f73d8c91121313d72227b4cbe283b57c1e', get_commits_response)
     hashes_to_responses.each do |hash, response|
       allow(Fastlane::Actions::GithubApiAction).to receive(:run)
         .with(server_url: server_url,


### PR DESCRIPTION
We should be comparing against the commit where the lane is running and not against HEAD. It's possible HEAD is actually not the commit where the lane is running at.