### PR TITLE
Fix links to native releases

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -92,7 +92,7 @@ module Fastlane
       def self.platform_changelogs(releases, platform)
         platform_changelogs = []
         releases.each do |release|
-          platform_changelogs.push("  * (#{platform} #{release['name']})[#{release['html_url']}]")
+          platform_changelogs.push("  * [#{platform} #{release['name']}](#{release['html_url']})")
         end
         platform_changelogs
       end

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -116,9 +116,9 @@ describe Fastlane::Helper::VersioningHelper do
       )
       expect(changelog).to eq("### Dependency Updates\n" \
                               "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.3 (#553) via RevenueCat Git Bot (@RCGitBot)\n" \
-                              "\s\s* (Android 5.6.6)[https://github.com/RevenueCat/purchases-android/releases/tag/5.6.6]\n" \
-                              "\s\s* (iOS 4.15.4)[https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.4]\n" \
-                              "\s\s* (iOS 4.15.3)[https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.3]")
+                              "\s\s* [Android 5.6.6](https://github.com/RevenueCat/purchases-android/releases/tag/5.6.6)\n" \
+                              "\s\s* [iOS 4.15.4](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.4)\n" \
+                              "\s\s* [iOS 4.15.3](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.3)")
     end
 
     it 'includes native dependencies links automatically. Also works for unity style VERSIONS.md' do
@@ -148,9 +148,9 @@ describe Fastlane::Helper::VersioningHelper do
       )
       expect(changelog).to eq("### Dependency Updates\n" \
                               "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.3 (#553) via RevenueCat Git Bot (@RCGitBot)\n" \
-                              "\s\s* (Android 5.6.6)[https://github.com/RevenueCat/purchases-android/releases/tag/5.6.6]\n" \
-                              "\s\s* (iOS 4.15.4)[https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.4]\n" \
-                              "\s\s* (iOS 4.15.3)[https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.3]")
+                              "\s\s* [Android 5.6.6](https://github.com/RevenueCat/purchases-android/releases/tag/5.6.6)\n" \
+                              "\s\s* [iOS 4.15.4](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.4)\n" \
+                              "\s\s* [iOS 4.15.3](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.3)")
     end
 
     it 'handles empty VERSIONS.md' do
@@ -240,8 +240,8 @@ describe Fastlane::Helper::VersioningHelper do
       )
       expect(changelog).to eq("### Dependency Updates\n" \
                               "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.3 (#553) via RevenueCat Git Bot (@RCGitBot)\n" \
-                              "\s\s* (iOS 4.15.4)[https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.4]\n" \
-                              "\s\s* (iOS 4.15.3)[https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.3]")
+                              "\s\s* [iOS 4.15.4](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.4)\n" \
+                              "\s\s* [iOS 4.15.3](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.3)")
     end
 
     it 'includes native dependencies links automatically. skips if no updates to native' do


### PR DESCRIPTION
I didn't use the correct markdown notation for links

(Android 5.6.6)[https://github.com/RevenueCat/purchases-android/releases/tag/5.6.6]

```
(Android 5.6.6)[https://github.com/RevenueCat/purchases-android/releases/tag/5.6.6]
```

should be :

[Android 5.6.6](https://github.com/RevenueCat/purchases-android/releases/tag/5.6.6)

```
[Android 5.6.6](https://github.com/RevenueCat/purchases-android/releases/tag/5.6.6)
```