### PR TITLE
Add pattern option to files to update

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_phc_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_phc_version_action.rb
@@ -39,7 +39,7 @@ module Fastlane
         Helper::RevenuecatInternalHelper.replace_version_number(version_number,
                                                                 new_version_number,
                                                                 files_to_update,
-                                                                [])
+                                                                {})
 
         return unless open_pr
 
@@ -61,10 +61,12 @@ module Fastlane
                                        optional: false,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :files_to_update,
-                                       env_name: "RC_INTERNAL_FILES_TO_UPDATE_VERSION",
-                                       description: "Files that contain the version number and need to have it updated",
+                                       description: 'Hash of files that contain the version number and need to have it' \
+                                                    'updated to the pattern that contains the version in the file.' \
+                                                    'Mark the version in the pattern using {x}.' \
+                                                    'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: false,
-                                       type: Array),
+                                       type: Hash),
           FastlaneCore::ConfigItem.new(key: :repo_name,
                                        env_name: "RC_INTERNAL_REPO_NAME",
                                        description: "Name of the repo of the SDK",

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -94,15 +94,22 @@ module Fastlane
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :files_to_update,
                                        env_name: "RC_INTERNAL_FILES_TO_UPDATE_VERSION",
-                                       description: "Files that contain the version number and need to have it updated",
+                                       description: 'Hash of files that contain the version number and need to have it' \
+                                                    'updated to the patterns that contains the version in the file.' \
+                                                    'Mark the version in the pattern using {x}.' \
+                                                    'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: false,
-                                       type: Array),
+                                       type: Hash),
           FastlaneCore::ConfigItem.new(key: :files_to_update_without_prerelease_modifiers,
                                        env_name: "RC_INTERNAL_FILES_TO_UPDATE_VERSION_WITHOUT_PRERELEASE_MODIFIERS",
-                                       description: "Files that contain the version number without release modifiers and need to have it updated",
+                                       description: 'Hash of files that contain the version number without pre-release' \
+                                                    'modifier and need to have it updated, to the patterns that' \
+                                                    'contains the version in the file.' \
+                                                    'Mark the version in the pattern using {x}.' \
+                                                    'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: true,
-                                       default_value: [],
-                                       type: Array),
+                                       default_value: {},
+                                       type: Hash),
           FastlaneCore::ConfigItem.new(key: :repo_name,
                                        env_name: "RC_INTERNAL_REPO_NAME",
                                        description: "Name of the repo of the SDK",

--- a/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
@@ -61,15 +61,22 @@ module Fastlane
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :files_to_update,
                                        env_name: "RC_INTERNAL_FILES_TO_UPDATE_VERSION",
-                                       description: "Files that contain the version number and need to have it updated",
+                                       description: 'Hash of files that contain the version number and need to have it' \
+                                                    'updated to the patterns that contains the version in the file.' \
+                                                    'Mark the version in the pattern using {x}.' \
+                                                    'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: false,
-                                       type: Array),
+                                       type: Hash),
           FastlaneCore::ConfigItem.new(key: :files_to_update_without_prerelease_modifiers,
                                        env_name: "RC_INTERNAL_FILES_TO_UPDATE_VERSION_WITHOUT_PRERELEASE_MODIFIERS",
-                                       description: "Files that contain the version number without release modifiers and need to have it updated",
+                                       description: 'Hash of files that contain the version number without pre-release' \
+                                                    'modifier and need to have it updated, to the patterns that' \
+                                                    'contains the version in the file.' \
+                                                    'Mark the version in the pattern using {x}.' \
+                                                    'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: true,
-                                       default_value: [],
-                                       type: Array)
+                                       default_value: {},
+                                       type: Hash)
         ]
       end
 

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -13,15 +13,14 @@ module Fastlane
 
   module Helper
     class RevenuecatInternalHelper
-      def self.replace_version_number(previous_version_number, new_version_number, files_to_update, files_to_update_without_prerelease_modifiers)
+      def self.replace_version_number(previous_version_number, new_version_number, files_to_update_with_patterns, files_to_update_without_prerelease_modifiers)
         previous_version_number_without_prerelease_modifiers = previous_version_number.split("-")[0]
         new_version_number_without_prerelease_modifiers = new_version_number.split("-")[0]
-
-        files_to_update.each do |file_to_update|
-          replace_in(previous_version_number, new_version_number, file_to_update)
+        files_to_update_with_patterns.each do |file_to_update, patterns|
+          replace_in(previous_version_number, new_version_number, file_to_update, patterns)
         end
-        files_to_update_without_prerelease_modifiers.each do |file_to_update|
-          replace_in(previous_version_number_without_prerelease_modifiers, new_version_number_without_prerelease_modifiers, file_to_update)
+        files_to_update_without_prerelease_modifiers.each do |file_to_update, patterns|
+          replace_in(previous_version_number_without_prerelease_modifiers, new_version_number_without_prerelease_modifiers, file_to_update, patterns)
         end
       end
 
@@ -131,12 +130,18 @@ module Fastlane
         )
       end
 
-      def self.replace_in(previous_text, new_text, path, allow_empty: false)
+      def self.replace_in(previous_text, new_text, path, patterns = ['{x}'], allow_empty: false)
         if new_text.to_s.strip.empty? && !allow_empty
           UI.user_error!("Missing `new_text` in call to `replace_in`, looking for replacement for #{previous_text} 😵.")
         end
         original_text = File.read(path)
-        replaced_text = original_text.gsub(previous_text, new_text)
+        replaced_text = original_text.dup
+        patterns.each do |pattern|
+          replaced_previous_text = pattern.gsub('{x}', previous_text)
+          replaced_new_text = pattern.gsub('{x}', new_text)
+          replaced_text = replaced_text.gsub(replaced_previous_text, replaced_new_text)
+        end
+
         File.write(path, replaced_text)
       end
 

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -135,7 +135,7 @@ module Fastlane
           UI.user_error!("Missing `new_text` in call to `replace_in`, looking for replacement for #{previous_text} 😵.")
         end
         original_text = File.read(path)
-        replaced_text = original_text.dup
+        replaced_text = original_text
         patterns.each do |pattern|
           replaced_previous_text = pattern.gsub('{x}', previous_text)
           replaced_new_text = pattern.gsub('{x}', new_text)

--- a/spec/actions/bump_phc_version_action_spec.rb
+++ b/spec/actions/bump_phc_version_action_spec.rb
@@ -43,7 +43,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         .with(new_branch_name)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_version_number)
-        .with(current_version, new_version, ['./test_file.sh', './test_file2.rb'], [])
+        .with(current_version, new_version, { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] }, {})
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:commit_changes_and_push_current_branch)
         .with("Version bump for #{new_version}")
@@ -58,7 +58,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         repo_name: mock_repo_name,
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
-        files_to_update: ['./test_file.sh', './test_file2.rb'],
+        files_to_update: { './test_file.sh' => ['{x}'], './test_file2.rb' => ['{x}'] },
         open_pr: true
       )
     end
@@ -72,7 +72,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
           repo_name: mock_repo_name,
           github_pr_token: mock_github_pr_token,
           github_token: mock_github_token,
-          files_to_update: ['./test_file.sh', './test_file2.rb'],
+          files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
           open_pr: true,
           next_version: new_version
         )
@@ -87,7 +87,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         repo_name: mock_repo_name,
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
-        files_to_update: ['./test_file.sh', './test_file2.rb'],
+        files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
         open_pr: true,
         next_version: new_version
       )
@@ -105,7 +105,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         repo_name: mock_repo_name,
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
-        files_to_update: ['./test_file.sh', './test_file2.rb'],
+        files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
         open_pr: true,
         next_version: new_version,
         automatic_release: true
@@ -126,7 +126,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         .never
 
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_version_number)
-        .with(current_version, new_version, ['./test_file.sh', './test_file2.rb'], [])
+        .with(current_version, new_version, { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] }, {})
         .once
 
       Fastlane::Actions::BumpPhcVersionAction.run(
@@ -134,7 +134,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         repo_name: mock_repo_name,
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
-        files_to_update: ['./test_file.sh', './test_file2.rb'],
+        files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
         open_pr: false
       )
     end
@@ -151,7 +151,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         .with(new_branch_name)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_version_number)
-        .with(current_version, new_version, ['./test_file.sh', './test_file2.rb'], [])
+        .with(current_version, new_version, { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] }, {})
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:commit_changes_and_push_current_branch)
         .with("Version bump for #{new_version}")
@@ -166,7 +166,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         repo_name: mock_repo_name,
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
-        files_to_update: ['./test_file.sh', './test_file2.rb'],
+        files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
         open_pr: true,
         next_version: new_version
       )
@@ -186,7 +186,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         .with(new_branch_name)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_version_number)
-        .with(current_version, new_patch_version, ['./test_file.sh', './test_file2.rb'], [])
+        .with(current_version, new_patch_version, { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] }, {})
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:commit_changes_and_push_current_branch)
         .with("Version bump for #{new_patch_version}")
@@ -201,7 +201,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         repo_name: mock_repo_name,
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
-        files_to_update: ['./test_file.sh', './test_file2.rb'],
+        files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
         open_pr: true,
         next_version: new_patch_version
       )
@@ -216,7 +216,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_new_branch_and_checkout)
         .with(new_branch_name)
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_version_number)
-        .with(current_version, new_version, ['./test_file.sh', './test_file2.rb'], [])
+        .with(current_version, new_version, { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] }, {})
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:commit_changes_and_push_current_branch)
         .with("Version bump for #{new_version}")
       message = "Updates purchases-hybrid-common to 1.13.0"

--- a/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
+++ b/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
@@ -59,7 +59,10 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         .with(new_branch_name)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_version_number)
-        .with(current_version, new_version, ['./test_file.sh', './test_file2.rb'], ['./test_file3.kt', './test_file4.swift'])
+        .with(current_version,
+              new_version,
+              { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
+              { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] })
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:attach_changelog_to_master)
         .with(new_version, mock_changelog_latest_path, mock_changelog_path)
@@ -75,8 +78,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         current_version: current_version,
         changelog_latest_path: mock_changelog_latest_path,
         changelog_path: mock_changelog_path,
-        files_to_update: ['./test_file.sh', './test_file2.rb'],
-        files_to_update_without_prerelease_modifiers: ['./test_file3.kt', './test_file4.swift'],
+        files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
+        files_to_update_without_prerelease_modifiers: { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] },
         repo_name: mock_repo_name,
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
@@ -97,8 +100,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         current_version: current_version,
         changelog_latest_path: mock_changelog_latest_path,
         changelog_path: mock_changelog_path,
-        files_to_update: ['./test_file.sh', './test_file2.rb'],
-        files_to_update_without_prerelease_modifiers: ['./test_file3.kt', './test_file4.swift'],
+        files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
+        files_to_update_without_prerelease_modifiers: { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] },
         repo_name: mock_repo_name,
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
@@ -118,8 +121,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
           current_version: current_version,
           changelog_latest_path: mock_changelog_latest_path,
           changelog_path: mock_changelog_path,
-          files_to_update: ['./test_file.sh', './test_file2.rb'],
-          files_to_update_without_prerelease_modifiers: ['./test_file3.kt', './test_file4.swift'],
+          files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
+          files_to_update_without_prerelease_modifiers: { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] },
           repo_name: mock_repo_name,
           github_pr_token: mock_github_pr_token,
           github_token: mock_github_token,
@@ -137,8 +140,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         current_version: current_version,
         changelog_latest_path: mock_changelog_latest_path,
         changelog_path: mock_changelog_path,
-        files_to_update: ['./test_file.sh', './test_file2.rb'],
-        files_to_update_without_prerelease_modifiers: ['./test_file3.kt', './test_file4.swift'],
+        files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
+        files_to_update_without_prerelease_modifiers: { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] },
         repo_name: mock_repo_name,
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
@@ -159,8 +162,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         current_version: current_version,
         changelog_latest_path: mock_changelog_latest_path,
         changelog_path: mock_changelog_path,
-        files_to_update: ['./test_file.sh', './test_file2.rb'],
-        files_to_update_without_prerelease_modifiers: ['./test_file3.kt', './test_file4.swift'],
+        files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
+        files_to_update_without_prerelease_modifiers: { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] },
         repo_name: mock_repo_name,
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
@@ -180,8 +183,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         current_version: current_version,
         changelog_latest_path: mock_changelog_latest_path,
         changelog_path: mock_changelog_path,
-        files_to_update: ['./test_file.sh', './test_file2.rb'],
-        files_to_update_without_prerelease_modifiers: ['./test_file3.kt', './test_file4.swift'],
+        files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
+        files_to_update_without_prerelease_modifiers: { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] },
         repo_name: mock_repo_name,
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
@@ -208,7 +211,10 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_new_branch_and_checkout)
         .with(new_branch_name)
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_version_number)
-        .with(current_version, new_version, ['./test_file.sh', './test_file2.rb'], ['./test_file3.kt', './test_file4.swift'])
+        .with(current_version,
+              new_version,
+              { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
+              { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] })
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:attach_changelog_to_master)
         .with(new_version, mock_changelog_latest_path, mock_changelog_path)
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:commit_changes_and_push_current_branch)


### PR DESCRIPTION
[CSDK-644](https://revenuecats.atlassian.net/browse/CSDK-644)

This will prevent updating the wrong versions when replacing in files

[CSDK-644]: https://revenuecats.atlassian.net/browse/CSDK-644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


The way it should be called now would be passing the following to the action:

```
files_with_version_number = {
  './.version' => ["{x}"],
  './pubspec.yaml' => ["version: {x}"],
  './ios/purchases_flutter.podspec' => ["s.version          = '{x}'"],
  './macos/purchases_flutter.podspec' => ["s.version          = '{x}'", "s.dependency_version     = '{x}'"],
  './ios/Classes/PurchasesFlutterPlugin.m' => ["return @\"{x}\""],
  './android/build.gradle' => ["version '{x}'"],
  './android/src/main/java/com/revenuecat/purchases_flutter/PurchasesFlutterPlugin.java' => ["PLUGIN_VERSION = \"{x}\""],
}
 ```
 We should update it in all actions that call `replace_version_number`