### PR TITLE
Improve prerelease changelog generation

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_phc_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_phc_version_action.rb
@@ -110,7 +110,7 @@ module Fastlane
           pr_title = "[AUTOMATIC BUMP] #{pr_title}"
         end
 
-        Helper::RevenuecatInternalHelper.create_pr_to_main(pr_title, body, repo_name, new_branch_name, github_pr_token, labels)
+        Helper::RevenuecatInternalHelper.create_pr(pr_title, body, repo_name, "main", new_branch_name, github_pr_token, labels)
       end
     end
   end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_phc_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_phc_version_action.rb
@@ -104,13 +104,14 @@ module Fastlane
         labels = ['phc_dependencies']
         labels << 'minor' if type_of_bump == :minor
         body = pr_title
+        base_branch = "main"
 
         if automatic_release
           body = "**This is an automatic bump.**\n\n#{body}"
           pr_title = "[AUTOMATIC BUMP] #{pr_title}"
         end
 
-        Helper::RevenuecatInternalHelper.create_pr(pr_title, body, repo_name, "main", new_branch_name, github_pr_token, labels)
+        Helper::RevenuecatInternalHelper.create_pr(pr_title, body, repo_name, base_branch, new_branch_name, github_pr_token, labels)
       end
     end
   end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -21,7 +21,7 @@ module Fastlane
         automatic_release = params[:automatic_release]
         hybrid_common_version = params[:hybrid_common_version]
         versions_file_path = params[:versions_file_path]
-        include_prerelease = params[:is_prerelease]
+        include_prereleases = params[:is_prerelease]
 
         current_branch = Actions.git_branch
         if UI.interactive? && !UI.confirm("Current branch is #{current_branch}. Are you sure this is the base branch for your bump?")
@@ -40,7 +40,7 @@ module Fastlane
 
         Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump(new_branch_name, github_pr_token)
 
-        generated_contents = Helper::VersioningHelper.auto_generate_changelog(repo_name, github_token, rate_limit_sleep, include_prerelease, hybrid_common_version, versions_file_path)
+        generated_contents = Helper::VersioningHelper.auto_generate_changelog(repo_name, github_token, rate_limit_sleep, include_prereleases, hybrid_common_version, versions_file_path)
 
         if UI.interactive?
           Helper::RevenuecatInternalHelper.edit_changelog(generated_contents, changelog_latest_path, editor)

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -67,7 +67,7 @@ module Fastlane
           pr_title = "[AUTOMATIC] #{pr_title}"
         end
 
-        Helper::RevenuecatInternalHelper.create_pr_to_main(pr_title, body, repo_name, new_branch_name, github_pr_token, [label])
+        Helper::RevenuecatInternalHelper.create_pr(pr_title, body, repo_name, current_branch, new_branch_name, github_pr_token, [label])
       end
 
       def self.description

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -21,6 +21,7 @@ module Fastlane
         automatic_release = params[:automatic_release]
         hybrid_common_version = params[:hybrid_common_version]
         versions_file_path = params[:versions_file_path]
+        include_prerelease = true
 
         current_branch = Actions.git_branch
         if UI.interactive? && !UI.confirm("Current branch is #{current_branch}. Are you sure this is the base branch for your bump?")
@@ -37,9 +38,9 @@ module Fastlane
 
         new_branch_name = "release/#{new_version_number}"
 
-        Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump(new_branch_name, github_pr_token)
+        #Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump(new_branch_name, github_pr_token)
 
-        generated_contents = Helper::VersioningHelper.auto_generate_changelog(repo_name, github_token, rate_limit_sleep, hybrid_common_version, versions_file_path)
+        generated_contents = Helper::VersioningHelper.auto_generate_changelog(repo_name, github_token, rate_limit_sleep, include_prerelease, hybrid_common_version, versions_file_path)
 
         if UI.interactive?
           Helper::RevenuecatInternalHelper.edit_changelog(generated_contents, changelog_latest_path, editor)

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -21,7 +21,7 @@ module Fastlane
         automatic_release = params[:automatic_release]
         hybrid_common_version = params[:hybrid_common_version]
         versions_file_path = params[:versions_file_path]
-        include_prerelease = true
+        include_prerelease = false # TODO: make this a param
 
         current_branch = Actions.git_branch
         if UI.interactive? && !UI.confirm("Current branch is #{current_branch}. Are you sure this is the base branch for your bump?")
@@ -38,7 +38,7 @@ module Fastlane
 
         new_branch_name = "release/#{new_version_number}"
 
-        #Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump(new_branch_name, github_pr_token)
+        Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump(new_branch_name, github_pr_token)
 
         generated_contents = Helper::VersioningHelper.auto_generate_changelog(repo_name, github_token, rate_limit_sleep, include_prerelease, hybrid_common_version, versions_file_path)
 

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -21,7 +21,7 @@ module Fastlane
         automatic_release = params[:automatic_release]
         hybrid_common_version = params[:hybrid_common_version]
         versions_file_path = params[:versions_file_path]
-        include_prerelease = false # TODO: make this a param
+        include_prerelease = params[:is_prerelease]
 
         current_branch = Actions.git_branch
         if UI.interactive? && !UI.confirm("Current branch is #{current_branch}. Are you sure this is the base branch for your bump?")
@@ -146,7 +146,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :versions_file_path,
                                        description: "Path to the VERSIONS.md file",
                                        optional: true,
-                                       type: String)
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :is_prerelease,
+                                       description: "If this is a prerelease",
+                                       optional: true,
+                                       is_string: false,
+                                       default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
@@ -32,7 +32,7 @@ module Fastlane
 
         Helper::RevenuecatInternalHelper.commit_changes_and_push_current_branch('Preparing for next version')
 
-        Helper::RevenuecatInternalHelper.create_pr_to_main("Prepare next version: #{next_version_snapshot}", nil, repo_name, new_branch_name, github_pr_token, [label])
+        Helper::RevenuecatInternalHelper.create_pr("Prepare next version: #{next_version_snapshot}", nil, repo_name, "main", new_branch_name, github_pr_token, [label])
       end
 
       def self.description

--- a/lib/fastlane/plugin/revenuecat_internal/actions/determine_next_version_using_labels_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/determine_next_version_using_labels_action.rb
@@ -10,8 +10,9 @@ module Fastlane
         repo_name = params[:repo_name]
         github_token = params[:github_token]
         rate_limit_sleep = params[:github_rate_limit]
+        include_prerelease = false
 
-        Helper::VersioningHelper.determine_next_version_using_labels(repo_name, github_token, rate_limit_sleep)
+        Helper::VersioningHelper.determine_next_version_using_labels(repo_name, github_token, rate_limit_sleep, include_prerelease)
       end
 
       def self.description

--- a/lib/fastlane/plugin/revenuecat_internal/actions/determine_next_version_using_labels_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/determine_next_version_using_labels_action.rb
@@ -10,9 +10,9 @@ module Fastlane
         repo_name = params[:repo_name]
         github_token = params[:github_token]
         rate_limit_sleep = params[:github_rate_limit]
-        include_prerelease = false
+        include_prereleases = false
 
-        Helper::VersioningHelper.determine_next_version_using_labels(repo_name, github_token, rate_limit_sleep, include_prerelease)
+        Helper::VersioningHelper.determine_next_version_using_labels(repo_name, github_token, rate_limit_sleep, include_prereleases)
       end
 
       def self.description

--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -10,17 +10,15 @@ module Fastlane
     class GitHubHelper
       SUPPORTED_PR_LABELS = %w[breaking build ci docs feat fix perf refactor style test next_release dependencies phc_dependencies minor].to_set
 
-      def self.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name)
+      def self.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch)
         if rate_limit_sleep > 0
           UI.message("Sleeping #{rate_limit_sleep} second(s) to avoid rate limit 🐌")
           sleep(rate_limit_sleep)
         end
 
-        current_branch = Actions.git_branch
-
         # Get pull request associate with commit message
         pr_resp = Actions::GithubApiAction.run(server_url: 'https://api.github.com',
-                                               path: "/search/issues?q=repo:RevenueCat/#{repo_name}+is:pr+base:#{current_branch}+SHA:#{sha}",
+                                               path: "/search/issues?q=repo:RevenueCat/#{repo_name}+is:pr+base:#{base_branch}+SHA:#{sha}",
                                                http_method: 'GET',
                                                body: {},
                                                api_token: github_token)

--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -16,9 +16,11 @@ module Fastlane
           sleep(rate_limit_sleep)
         end
 
+        current_branch = Actions.git_branch
+
         # Get pull request associate with commit message
         pr_resp = Actions::GithubApiAction.run(server_url: 'https://api.github.com',
-                                               path: "/search/issues?q=repo:RevenueCat/#{repo_name}+is:pr+base:main+SHA:#{sha}",
+                                               path: "/search/issues?q=repo:RevenueCat/#{repo_name}+is:pr+base:#{current_branch}+SHA:#{sha}",
                                                http_method: 'GET',
                                                body: {},
                                                api_token: github_token)

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -85,11 +85,11 @@ module Fastlane
         Actions::PushToGitRemoteAction.run(remote: 'origin')
       end
 
-      def self.create_pr_to_main(title, body, repo_name, head_branch, github_pr_token, labels = [])
+      def self.create_pr(title, body, repo_namek, base_branch, head_branch, github_pr_token, labels = [])
         Actions::CreatePullRequestAction.run(
           api_token: github_pr_token,
           title: title,
-          base: 'main',
+          base: base_branch,
           body: body,
           repo: "RevenueCat/#{repo_name}",
           head: head_branch,

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -85,7 +85,7 @@ module Fastlane
         Actions::PushToGitRemoteAction.run(remote: 'origin')
       end
 
-      def self.create_pr(title, body, repo_namek, base_branch, head_branch, github_pr_token, labels = [])
+      def self.create_pr(title, body, repo_name, base_branch, head_branch, github_pr_token, labels = [])
         Actions::CreatePullRequestAction.run(
           api_token: github_pr_token,
           title: title,

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -161,12 +161,17 @@ module Fastlane
       end
 
       private_class_method def self.latest_version_number(include_prerelease: false)
-        Actions
-          .sh("git tag", log: false)
-          .strip
-          .split("\n")
-          #.select { |tag| tag.match("^[0-9]+.[0-9]+.[0-9]+$") }
-          .max_by { |tag| Gem::Version.new(tag) rescue Gem::Version.new(0) }
+        tags = Actions
+               .sh("git tag", log: false)
+               .strip
+               .split("\n")
+               .select { |tag| Gem::Version.correct?(tag) }
+
+        unless include_prerelease
+          tags = tags.select { |tag| tag.match("^[0-9]+.[0-9]+.[0-9]+$") }
+        end
+
+        tags.max_by { |tag| Gem::Version.new(tag) }
       end
 
       private_class_method def self.build_changelog_sections(changelog_sections)

--- a/spec/actions/bump_phc_version_action_spec.rb
+++ b/spec/actions/bump_phc_version_action_spec.rb
@@ -7,6 +7,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
     let(:auto_generated_changelog) { 'mock-auto-generated-changelog' }
     let(:edited_changelog) { 'mock-edited-changelog' }
     let(:current_version) { '1.12.0' }
+    let(:base_branch) { 'main' }
     let(:new_version) { '1.13.0' }
     let(:new_branch_name) { 'bump-phc/1.13.0' }
     let(:labels) { ['phc_dependencies', 'minor'] }
@@ -48,8 +49,8 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         .with("Version bump for #{new_version}")
         .once
       message = "Updates purchases-hybrid-common to 1.13.0"
-      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
-        .with(message, message, mock_repo_name, new_branch_name, mock_github_pr_token, labels)
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr)
+        .with(message, message, mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, labels)
         .once
 
       Fastlane::Actions::BumpPhcVersionAction.run(
@@ -96,8 +97,8 @@ describe Fastlane::Actions::BumpPhcVersionAction do
       setup_stubs
 
       message = "Updates purchases-hybrid-common to 1.13.0"
-      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
-        .with("[AUTOMATIC BUMP] #{message}", "**This is an automatic bump.**\n\n#{message}", mock_repo_name, new_branch_name, mock_github_pr_token, labels)
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr)
+        .with("[AUTOMATIC BUMP] #{message}", "**This is an automatic bump.**\n\n#{message}", mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, labels)
 
       Fastlane::Actions::BumpPhcVersionAction.run(
         current_version: current_version,
@@ -121,7 +122,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         .never
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:commit_changes_and_push_current_branch)
         .never
-      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr)
         .never
 
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_version_number)
@@ -156,8 +157,8 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         .with("Version bump for #{new_version}")
         .once
       message = "Updates purchases-hybrid-common to #{new_version}"
-      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
-        .with(message, message, mock_repo_name, new_branch_name, mock_github_pr_token, labels)
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr)
+        .with(message, message, mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, labels)
         .once
 
       Fastlane::Actions::BumpPhcVersionAction.run(
@@ -191,8 +192,8 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         .with("Version bump for #{new_patch_version}")
         .once
       message = "Updates purchases-hybrid-common to 1.12.1"
-      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
-        .with(message, message, mock_repo_name, new_branch_name, mock_github_pr_token, ['phc_dependencies'])
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr)
+        .with(message, message, mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, ['phc_dependencies'])
         .once
 
       Fastlane::Actions::BumpPhcVersionAction.run(
@@ -219,8 +220,8 @@ describe Fastlane::Actions::BumpPhcVersionAction do
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:commit_changes_and_push_current_branch)
         .with("Version bump for #{new_version}")
       message = "Updates purchases-hybrid-common to 1.13.0"
-      allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
-        .with(message, message, mock_repo_name, new_branch_name, mock_github_pr_token, labels)
+      allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr)
+        .with(message, message, mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, labels)
     end
   end
 

--- a/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
+++ b/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
@@ -81,7 +81,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
         github_rate_limit: 3,
-        editor: editor
+        editor: editor,
+        is_prerelease: false
       )
     end
 
@@ -104,7 +105,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         github_rate_limit: 3,
         editor: editor,
         hybrid_common_version: hybrid_common_version,
-        versions_file_path: versions_file_path
+        versions_file_path: versions_file_path,
+        is_prerelease: false
       )
     end
 
@@ -122,7 +124,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
           github_pr_token: mock_github_pr_token,
           github_token: mock_github_token,
           github_rate_limit: 3,
-          editor: editor
+          editor: editor,
+          is_prerelease: false
         )
       end.to raise_exception(StandardError)
     end
@@ -140,7 +143,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
         github_rate_limit: 3,
-        editor: editor
+        editor: editor,
+        is_prerelease: false
       )
     end
 
@@ -161,7 +165,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
         github_rate_limit: 3,
-        editor: editor
+        editor: editor,
+        is_prerelease: false
       )
     end
 
@@ -182,7 +187,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         github_token: mock_github_token,
         github_rate_limit: 3,
         editor: editor,
-        automatic_release: true
+        automatic_release: true,
+        is_prerelease: false
       )
     end
 
@@ -214,7 +220,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
 
   describe '#available_options' do
     it 'has correct number of options' do
-      expect(Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction.available_options.size).to eq(14)
+      expect(Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction.available_options.size).to eq(15)
     end
   end
 end

--- a/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
+++ b/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
@@ -9,6 +9,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
     let(:auto_generated_changelog) { 'mock-auto-generated-changelog' }
     let(:edited_changelog) { 'mock-edited-changelog' }
     let(:current_version) { '1.12.0' }
+    let(:base_branch) { 'main' }
     let(:new_version) { '1.13.0' }
     let(:new_branch_name) { 'release/1.13.0' }
     let(:labels) { ['next_release'] }
@@ -39,6 +40,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
     end
 
     it 'calls all the appropriate methods with appropriate parameters' do
+      allow(Fastlane::Actions).to receive(:git_branch).and_return(base_branch)
       allow(FastlaneCore::UI).to receive(:interactive?).and_return(true)
       allow(FastlaneCore::UI).to receive(:input).with('New version number: ').and_return(new_version)
       allow(FastlaneCore::UI).to receive(:confirm).with(anything).and_return(true)
@@ -47,7 +49,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         .with('release/1.13.0', mock_github_pr_token)
         .once
       expect(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
-        .with(mock_repo_name, mock_github_token, 3, nil, nil)
+        .with(mock_repo_name, mock_github_token, 3, false, nil, nil)
         .and_return(auto_generated_changelog)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:edit_changelog)
@@ -65,8 +67,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:commit_changes_and_push_current_branch)
         .with("Version bump for #{new_version}")
         .once
-      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
-        .with("Release/1.13.0", edited_changelog, mock_repo_name, new_branch_name, mock_github_pr_token, labels)
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr)
+        .with("Release/1.13.0", edited_changelog, mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, labels)
         .once
 
       Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction.run(
@@ -86,7 +88,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
     it 'generates changelog with appropriate parameters when bumping a hybrid SDK' do
       setup_stubs
       expect(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
-        .with(mock_repo_name, mock_github_token, 3, hybrid_common_version, versions_file_path)
+        .with(mock_repo_name, mock_github_token, 3, false, hybrid_common_version, versions_file_path)
         .and_return(auto_generated_changelog)
         .once
 
@@ -166,8 +168,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
     it 'adds automatic label to title and body' do
       setup_stubs
 
-      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
-        .with("[AUTOMATIC] Release/1.13.0", "**This is an automatic release.**\n\nmock-edited-changelog", mock_repo_name, new_branch_name, mock_github_pr_token, labels)
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr)
+        .with("[AUTOMATIC] Release/1.13.0", "**This is an automatic release.**\n\nmock-edited-changelog", mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, labels)
 
       Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction.run(
         current_version: current_version,
@@ -185,6 +187,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
     end
 
     def setup_stubs
+      allow(Fastlane::Actions).to receive(:git_branch).and_return(base_branch)
       allow(FastlaneCore::UI).to receive(:interactive?).and_return(false)
       allow(FastlaneCore::UI).to receive(:input).with('New version number: ').and_return(new_version)
       allow(FastlaneCore::UI).to receive(:confirm).with(anything).and_return(false)
@@ -192,7 +195,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:validate_local_config_status_for_bump)
         .with('release/1.13.0', mock_github_pr_token)
       allow(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
-        .with(mock_repo_name, mock_github_token, 3, nil, nil)
+        .with(mock_repo_name, mock_github_token, 3, false, nil, nil)
         .and_return(auto_generated_changelog)
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:write_changelog)
         .with(auto_generated_changelog, mock_changelog_latest_path)
@@ -204,8 +207,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         .with(new_version, mock_changelog_latest_path, mock_changelog_path)
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:commit_changes_and_push_current_branch)
         .with("Version bump for #{new_version}")
-      allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
-        .with("Release/1.13.0", edited_changelog, mock_repo_name, new_branch_name, mock_github_pr_token, labels)
+      allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr)
+        .with("Release/1.13.0", edited_changelog, mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, labels)
     end
   end
 

--- a/spec/actions/create_next_snapshot_version_action_spec.rb
+++ b/spec/actions/create_next_snapshot_version_action_spec.rb
@@ -4,6 +4,7 @@ describe Fastlane::Actions::CreateNextSnapshotVersionAction do
     let(:repo_name) { 'fake-repo-name' }
     let(:current_version) { '1.12.0' }
     let(:current_version_snapshot) { '1.12.0-SNAPSHOT' }
+    let(:base_branch) { 'main' }
     let(:next_version) { '1.13.0-SNAPSHOT' }
     let(:new_branch_name) { 'bump/1.13.0-SNAPSHOT' }
     let(:labels) { ['next_release'] }
@@ -25,8 +26,8 @@ describe Fastlane::Actions::CreateNextSnapshotVersionAction do
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:commit_changes_and_push_current_branch)
         .with('Preparing for next version')
         .once
-      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_to_main)
-        .with('Prepare next version: 1.13.0-SNAPSHOT', nil, repo_name, new_branch_name, github_pr_token, labels)
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr)
+        .with('Prepare next version: 1.13.0-SNAPSHOT', nil, repo_name, base_branch, new_branch_name, github_pr_token, labels)
         .once
       Fastlane::Actions::CreateNextSnapshotVersionAction.run(
         current_version: current_version,
@@ -43,7 +44,7 @@ describe Fastlane::Actions::CreateNextSnapshotVersionAction do
       expect(Fastlane::Helper::RevenuecatInternalHelper).not_to receive(:create_new_branch_and_checkout)
       expect(Fastlane::Helper::RevenuecatInternalHelper).not_to receive(:replace_version_number)
       expect(Fastlane::Helper::RevenuecatInternalHelper).not_to receive(:commit_changes_and_push_current_branch)
-      expect(Fastlane::Helper::RevenuecatInternalHelper).not_to receive(:create_pr_to_main)
+      expect(Fastlane::Helper::RevenuecatInternalHelper).not_to receive(:create_pr)
       Fastlane::Actions::CreateNextSnapshotVersionAction.run(
         current_version: current_version_snapshot,
         repo_name: repo_name,

--- a/spec/actions/determine_next_version_using_labels_action_spec.rb
+++ b/spec/actions/determine_next_version_using_labels_action_spec.rb
@@ -6,7 +6,7 @@ describe Fastlane::Actions::DetermineNextVersionUsingLabelsAction do
 
     it 'calls all the appropriate methods with appropriate parameters' do
       expect(Fastlane::Helper::VersioningHelper).to receive(:determine_next_version_using_labels)
-        .with(mock_repo_name, mock_github_token, 3)
+        .with(mock_repo_name, mock_github_token, 3, false)
         .and_return(new_version)
         .once
 

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -9,10 +9,6 @@ describe Fastlane::Helper::GitHubHelper do
       { body: File.read("#{File.dirname(__FILE__)}/../test_files/get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json") }
     end
 
-    before(:each) do
-      allow(Fastlane::Actions).to receive(:git_branch).and_return(base_branch)
-    end
-
     it 'returns items from response' do
       allow(Fastlane::Actions::GithubApiAction).to receive(:run)
         .with(server_url: server_url,
@@ -26,7 +22,8 @@ describe Fastlane::Helper::GitHubHelper do
         hash,
         github_token,
         0,
-        'mock-repo-name'
+        'mock-repo-name',
+        'main'
       )
 
       github_response = get_feat_commit_response
@@ -53,7 +50,8 @@ describe Fastlane::Helper::GitHubHelper do
         hash,
         github_token,
         1,
-        'mock-repo-name'
+        'mock-repo-name',
+        'main'
       )
       expect(items).not_to be_nil
     end

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -1,5 +1,6 @@
 describe Fastlane::Helper::GitHubHelper do
   describe '.get_pr_resp_items_for_sha' do
+    let(:base_branch) { 'main' }
     let(:server_url) { 'https://api.github.com' }
     let(:http_method) { 'GET' }
     let(:hash) { 'a72c0435ecf71248f311900475e881cc07ac2eaf' }
@@ -8,10 +9,14 @@ describe Fastlane::Helper::GitHubHelper do
       { body: File.read("#{File.dirname(__FILE__)}/../test_files/get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json") }
     end
 
+    before(:each) do
+      allow(Fastlane::Actions).to receive(:git_branch).and_return(base_branch)
+    end
+
     it 'returns items from response' do
       allow(Fastlane::Actions::GithubApiAction).to receive(:run)
         .with(server_url: server_url,
-              path: "/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:main+SHA:#{hash}",
+              path: "/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:#{base_branch}+SHA:#{hash}",
               http_method: http_method,
               body: {},
               api_token: github_token)
@@ -36,7 +41,7 @@ describe Fastlane::Helper::GitHubHelper do
     it 'sleeps if passing rate limit sleep' do
       allow(Fastlane::Actions::GithubApiAction).to receive(:run)
         .with(server_url: server_url,
-              path: "/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:main+SHA:#{hash}",
+              path: "/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:#{base_branch}+SHA:#{hash}",
               http_method: http_method,
               body: {},
               api_token: github_token)

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -207,7 +207,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
     end
   end
 
-  describe '.create_pr_to_main' do
+  describe '.create_pr' do
     it 'creates pr' do
       expect(Fastlane::Actions::CreatePullRequestAction).to receive(:run)
         .with(
@@ -221,7 +221,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
           labels: ['label_1', 'label_2'],
           team_reviewers: ['coresdk']
         ).once
-      Fastlane::Helper::RevenuecatInternalHelper.create_pr_to_main('fake-title', 'fake-changelog', 'fake-repo-name', 'fake-branch', 'fake-github-pr-token', ['label_1', 'label_2'])
+      Fastlane::Helper::RevenuecatInternalHelper.create_pr('fake-title', 'fake-changelog', 'fake-repo-name', 'main', 'fake-branch', 'fake-github-pr-token', ['label_1', 'label_2'])
     end
   end
 

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -500,6 +500,32 @@ describe Fastlane::Helper::VersioningHelper do
       }
     end
 
+    describe '#latest_version_number' do
+      let(:git_tag_output) do
+        <<~GIT_TAG
+5.7.0
+5.7.1
+6.0.0-alpha.1
+6.0.0-alpha.2
+amazon-latest
+latest
+        GIT_TAG
+      end
+      it 'finds latest version number' do
+        allow(Fastlane::Actions).to receive(:sh).and_return(git_tag_output)
+
+        latest_version = Fastlane::Helper::VersioningHelper.send(:latest_version_number)
+        expect(latest_version).to eq("5.7.1")
+      end
+
+      it 'finds latest prerelease version number' do
+        allow(Fastlane::Actions).to receive(:sh).and_return(git_tag_output)
+
+        latest_version = Fastlane::Helper::VersioningHelper.send(:latest_version_number, include_prereleases: true)
+        expect(latest_version).to eq("6.0.0-alpha.2")
+      end
+    end
+
     it 'determines next version as patch correctly' do
       setup_commit_search_stubs(hashes_to_responses)
       mock_commits_since_last_release('6d37c766b6da55dcab67c201c93ba3d4ca538e55', get_commits_response_patch)

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -1,4 +1,8 @@
 describe Fastlane::Helper::VersioningHelper do
+  before(:each) do
+    allow(Fastlane::Actions).to receive(:git_branch).and_return('main')
+  end
+
   describe '.auto_generate_changelog' do
     let(:server_url) { 'https://api.github.com' }
     let(:http_method) { 'GET' }
@@ -84,6 +88,7 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         0,
+        false,
         nil,
         nil
       )
@@ -117,6 +122,7 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         0,
+        false,
         hybrid_common_version,
         versions_path
       )
@@ -149,6 +155,7 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         0,
+        false,
         hybrid_common_version,
         unity_versions_path
       )
@@ -179,6 +186,7 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         0,
+        false,
         hybrid_common_version,
         empty_versions_path
       )
@@ -206,6 +214,7 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         0,
+        false,
         hybrid_common_version,
         broken_versions_path
       )
@@ -241,6 +250,7 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         0,
+        false,
         hybrid_common_version,
         versions_path
       )
@@ -278,6 +288,7 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         0,
+        false,
         hybrid_common_version,
         versions_path
       )
@@ -292,6 +303,7 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         3,
+        false,
         nil,
         nil
       )
@@ -317,6 +329,7 @@ describe Fastlane::Helper::VersioningHelper do
           'mock-repo-name',
           'mock-github-token',
           0,
+          false,
           nil,
           nil
         )
@@ -337,6 +350,7 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         0,
+        false,
         nil,
         nil
       )
@@ -362,6 +376,7 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         0,
+        false,
         nil,
         nil
       )
@@ -389,6 +404,7 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         0,
+        false,
         nil,
         nil
       )
@@ -491,7 +507,8 @@ describe Fastlane::Helper::VersioningHelper do
       next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
         'mock-repo-name',
         'mock-github-token',
-        0
+        0,
+        false
       )
       expect(next_version).to eq("1.11.1")
       expect(type_of_bump).to eq(:patch)
@@ -504,7 +521,8 @@ describe Fastlane::Helper::VersioningHelper do
       next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
         'mock-repo-name',
         'mock-github-token',
-        0
+        0,
+        false
       )
       expect(next_version).to eq("1.11.0")
       expect(type_of_bump).to eq(:skip)
@@ -517,7 +535,8 @@ describe Fastlane::Helper::VersioningHelper do
       next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
         'mock-repo-name',
         'mock-github-token',
-        0
+        0,
+        false
       )
       expect(next_version).to eq("1.12.0")
       expect(type_of_bump).to eq(:minor)
@@ -537,7 +556,8 @@ describe Fastlane::Helper::VersioningHelper do
       next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
         'mock-repo-name',
         'mock-github-token',
-        0
+        0,
+        false
       )
       expect(next_version).to eq("1.12.0")
       expect(type_of_bump).to eq(:minor)
@@ -557,7 +577,8 @@ describe Fastlane::Helper::VersioningHelper do
       next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
         'mock-repo-name',
         'mock-github-token',
-        0
+        0,
+        false
       )
       expect(next_version).to eq("2.0.0")
       expect(type_of_bump).to eq(:major)
@@ -570,7 +591,8 @@ describe Fastlane::Helper::VersioningHelper do
       next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
         'mock-repo-name',
         'mock-github-token',
-        3
+        3,
+        false
       )
       expect(next_version).to eq("1.12.0")
       expect(type_of_bump).to eq(:minor)
@@ -590,7 +612,8 @@ describe Fastlane::Helper::VersioningHelper do
         Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
           'mock-repo-name',
           'mock-github-token',
-          0
+          0,
+          false
         )
       end.to raise_exception(StandardError)
     end
@@ -602,7 +625,8 @@ describe Fastlane::Helper::VersioningHelper do
       next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
         'mock-repo-name',
         'mock-github-token',
-        0
+        0,
+        false
       )
       expect(next_version).to eq("1.11.0")
       expect(type_of_bump).to eq(:skip)
@@ -623,7 +647,8 @@ describe Fastlane::Helper::VersioningHelper do
       next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
         'mock-repo-name',
         'mock-github-token',
-        0
+        0,
+        false
       )
       expect(next_version).to eq("2.0.0")
       expect(type_of_bump).to eq(:major)


### PR DESCRIPTION
⚠️ This still needs new tests for when prerelease is true (currently is just passing with old tests)

## Motivation

Improve `fastlane bump` for prereleases

This is fixing an issue when bumping from `6.0.0-alpha.1` to `6.0.0-alpha.2`
- The generated changelog was empty which was 💥 ing the entire process

## Description

Can now run `fastlane bump is_prerelease:true`

See https://github.com/RevenueCat/purchases-android/pull/764 for results

- New `is_prerelease` option on `bump_version_update_changelog_create_pr`
    - Defaults to `false` 
- Renamed `create_pr_to_main` to `create_pr`
    - Added `base_branch` as a parameter
- Renamed `latest_non_prerelease_version_number` to `latest_version_number`
    - Added `include_prerelease` parameter
    - This is what allow for a nice changelog only between prerelease versions
- `get_pr_resp_items_for_sha` no longer default to `main` as the base branch