### PR TITLE
`edit_changelog`: remove error when prepopulated changelog is empty

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -28,6 +28,7 @@ module Fastlane
       def self.edit_changelog(prepopulated_changelog, changelog_latest_path, editor)
         changelog_filename = File.basename(changelog_latest_path)
 
+        UI.message("Warning: pre-populated content for changelog is empty") if prepopulated_changelog.empty?
         UI.message("Using pre populated contents:\n#{prepopulated_changelog}")
 
         UI.message("Will use '#{editor}'... Override by setting FASTLANE_EDITOR environment variable")

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -28,8 +28,6 @@ module Fastlane
       def self.edit_changelog(prepopulated_changelog, changelog_latest_path, editor)
         changelog_filename = File.basename(changelog_latest_path)
 
-        UI.user_error!("Pre populated content for changelog was empty") if prepopulated_changelog.empty?
-
         UI.message("Using pre populated contents:\n#{prepopulated_changelog}")
 
         UI.message("Will use '#{editor}'... Override by setting FASTLANE_EDITOR environment variable")

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -95,11 +95,11 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       Fastlane::Helper::RevenuecatInternalHelper.edit_changelog(prepopulated_changelog, changelog_latest_path, editor)
     end
 
-    it 'fails if prepopulated changelog is empty' do
-      expect(File).not_to receive(:write)
+    it 'does not fail if prepopulated changelog is empty' do
+      expect(File).to receive(:write)
       expect do
         Fastlane::Helper::RevenuecatInternalHelper.edit_changelog('', changelog_latest_path, editor)
-      end.to raise_exception(StandardError)
+      end.not_to raise_exception(StandardError)
     end
 
     it 'fails if user cancels on confirmation to open editor' do


### PR DESCRIPTION
Here's the suggested workflow in iOS for hotfixes:
```
##### Hotfixes:
Sometimes you might need to release a patch on a version that's not the latest. Or sometimes there might have been commits on `main` that shouldn't be released, but the latest version has a big bug. For example, let's say the last version is 4.0.0, but there's a bug on 3.9.0 that needs to be released as a 3.9.1:
1. Open a PR with the fix, merge it to `main`.
1. Jump to 3.9.0 and create a new branch `release/3.9.0`. Push this branch since it will be used as base for the PR you will open in the next steps.
1. Run `bundle exec fastlane ios bump` as you would do with any release. This will create a new PR `release/3.9.1`.
```

Unfortunately, this right now leads to
> [!] Pre populated content for changelog was empty

Because there's still no commits from the targeted release.

The action has this logic:
```ruby
if UI.interactive?
  Helper::RevenuecatInternalHelper.edit_changelog(generated_contents, changelog_latest_path, editor)
else
  Helper::RevenuecatInternalHelper.write_changelog(generated_contents, changelog_latest_path)
end
```

If it's interactive, `edit_changelog` is called (the modified function in this PR). So if the autogenerated changelog is empty, it can be fixed in the editor.
