### PR TITLE
Fix replace_version_number_action to accept a hash instead of an array of files

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/replace_version_number_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/replace_version_number_action.rb
@@ -36,15 +36,22 @@ module Fastlane
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :files_to_update,
                                        env_name: "RC_INTERNAL_FILES_TO_UPDATE_VERSION",
-                                       description: "Files that contain the version number and need to have it updated",
+                                       description: 'Hash of files that contain the version number and need to have it' \
+                                                    'updated to the patterns that contains the version in the file.' \
+                                                    'Mark the version in the pattern using {x}.' \
+                                                    'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: false,
-                                       type: Array),
+                                       type: Hash),
           FastlaneCore::ConfigItem.new(key: :files_to_update_without_prerelease_modifiers,
                                        env_name: "RC_INTERNAL_FILES_TO_UPDATE_VERSION_WITHOUT_PRERELEASE_MODIFIERS",
-                                       description: "Files that contain the version number without release modifiers and need to have it updated",
+                                       description: 'Hash of files that contain the version number without pre-release' \
+                                                    'modifier and need to have it updated, to the patterns that' \
+                                                    'contains the version in the file.' \
+                                                    'Mark the version in the pattern using {x}.' \
+                                                    'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: true,
-                                       default_value: [],
-                                       type: Array)
+                                       default_value: {},
+                                       type: Hash)
         ]
       end
 

--- a/spec/actions/create_next_snapshot_version_action_spec.rb
+++ b/spec/actions/create_next_snapshot_version_action_spec.rb
@@ -21,7 +21,10 @@ describe Fastlane::Actions::CreateNextSnapshotVersionAction do
         .with(new_branch_name)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_version_number)
-        .with(current_version, next_version, ['./test_file.sh', './test_file2.rb'], ['./test_file4.swift', './test_file5.kt'])
+        .with(current_version,
+              next_version,
+              { './test_file.sh' => ['{x}'], './test_file2.rb' => ['{x}'] },
+              { './test_file4.swift' => ['{x}'], './test_file5.kt' => ['{x}'] })
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:commit_changes_and_push_current_branch)
         .with('Preparing for next version')
@@ -33,8 +36,8 @@ describe Fastlane::Actions::CreateNextSnapshotVersionAction do
         current_version: current_version,
         repo_name: repo_name,
         github_pr_token: github_pr_token,
-        files_to_update: ['./test_file.sh', './test_file2.rb'],
-        files_to_update_without_prerelease_modifiers: ['./test_file4.swift', './test_file5.kt']
+        files_to_update: { './test_file.sh' => ['{x}'], './test_file2.rb' => ['{x}'] },
+        files_to_update_without_prerelease_modifiers: { './test_file4.swift' => ['{x}'], './test_file5.kt' => ['{x}'] }
       )
     end
 
@@ -49,8 +52,8 @@ describe Fastlane::Actions::CreateNextSnapshotVersionAction do
         current_version: current_version_snapshot,
         repo_name: repo_name,
         github_pr_token: github_pr_token,
-        files_to_update: ['./test_file.sh', './test_file2.rb'],
-        files_to_update_without_prerelease_modifiers: ['./test_file4.swift', './test_file5.kt']
+        files_to_update: { './test_file.sh' => ['{x}'], './test_file2.rb' => ['{x}'] },
+        files_to_update_without_prerelease_modifiers: { './test_file4.swift' => ['{x}'], './test_file5.kt' => ['{x}'] }
       )
     end
   end

--- a/spec/actions/replace_version_number_action_spec.rb
+++ b/spec/actions/replace_version_number_action_spec.rb
@@ -2,12 +2,16 @@ describe Fastlane::Actions::ReplaceVersionNumberAction do
   describe '#run' do
     it 'calls appropriate helper with correct parameters' do
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:replace_version_number)
-        .with('1.12.0', '1.13.0', ['./test_file.sh', './test_file2.rb'], ['./test_file3.kt', './test_file4.swift']).once
+        .with('1.12.0',
+              '1.13.0',
+              { './test_file.sh' => ['{x}'], './test_file2.rb' => ['{x}'] },
+              { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] })
+        .once
       Fastlane::Actions::ReplaceVersionNumberAction.run(
         current_version: '1.12.0',
         new_version_number: '1.13.0',
-        files_to_update: ['./test_file.sh', './test_file2.rb'],
-        files_to_update_without_prerelease_modifiers: ['./test_file3.kt', './test_file4.swift']
+        files_to_update: { './test_file.sh' => ['{x}'], './test_file2.rb' => ['{x}'] },
+        files_to_update_without_prerelease_modifiers: { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] }
       )
     end
   end


### PR DESCRIPTION
With the changes from #46 , the helper `replace_version_number` got updated to accept a hash of files instead of an array. `replace_version_number_action` depends on this helper, so the action needed to be updated. This PR updates the parameters and fixes some tests