### PR TITLE
Add support for `RevenueCatUI` label

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -8,7 +8,7 @@ module Fastlane
 
   module Helper
     class GitHubHelper
-      SUPPORTED_PR_LABELS = %w[breaking build ci docs feat fix perf RevenueCatUI refactor style test next_release dependencies phc_dependencies minor].to_set
+      SUPPORTED_PR_LABELS = %w[breaking build ci docs feat fix perf revenuecatui refactor style test next_release dependencies phc_dependencies minor].to_set
 
       def self.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch)
         if rate_limit_sleep > 0

--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -8,7 +8,7 @@ module Fastlane
 
   module Helper
     class GitHubHelper
-      SUPPORTED_PR_LABELS = %w[breaking build ci docs feat fix perf refactor style test next_release dependencies phc_dependencies minor].to_set
+      SUPPORTED_PR_LABELS = %w[breaking build ci docs feat fix perf RevenueCatUI refactor style test next_release dependencies phc_dependencies minor].to_set
 
       def self.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch)
         if rate_limit_sleep > 0

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -199,6 +199,7 @@ module Fastlane
         end.join("\n")
       end
 
+      # rubocop:disable Metrics/PerceivedComplexity
       private_class_method def self.get_section_depending_on_types_of_change(change_types)
         if change_types.include?("breaking")
           :breaking_changes
@@ -216,6 +217,7 @@ module Fastlane
           :other
         end
       end
+      # rubocop:enable Metrics/PerceivedComplexity
 
       private_class_method def self.get_type_of_bump_from_types_of_change(change_types)
         if change_types.intersection(BUMP_PER_LABEL[:major]).size > 0

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -17,7 +17,7 @@ module Fastlane
   BUMP_PER_LABEL = {
     major: %w[breaking].to_set,
     minor: %w[feat minor].to_set,
-    patch: %w[docs fix perf dependencies phc_dependencies].to_set,
+    patch: %w[docs fix perf dependencies phc_dependencies revenuecatui].to_set,
     skip: %w[build ci refactor style test next_release].to_set
   }
 
@@ -51,7 +51,7 @@ module Fastlane
 
         commits = Helper::GitHubHelper.get_commits_since_old_version(github_token, old_version, repo_name)
 
-        changelog_sections = { breaking_changes: [], new_features: [], fixes: [], performance: [], dependency_updates: [], other: [] }
+        changelog_sections = { breaking_changes: [], new_features: [], paywalls: [], fixes: [], performance: [], dependency_updates: [], other: [] }
 
         commits.map do |commit|
           name = commit["commit"]["author"]["name"]
@@ -186,6 +186,8 @@ module Fastlane
             title = "### Bugfixes"
           when :new_features
             title = "### New Features"
+          when :paywalls
+            title = "### Paywalls"
           when :performance
             title = "### Performance Improvements"
           when :dependency_updates
@@ -204,6 +206,8 @@ module Fastlane
           :new_features
         elsif change_types.include?("fix")
           :fixes
+        elsif change_types.include?("RevenueCatUI")
+          :paywalls
         elsif change_types.include?("perf")
           :performance
         elsif change_types.include?("dependencies") || change_types.include?("phc_dependencies")

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -187,7 +187,7 @@ module Fastlane
           when :new_features
             title = "### New Features"
           when :paywalls
-            title = "### Paywalls"
+            title = "### RevenueCatUI"
           when :performance
             title = "### Performance Improvements"
           when :dependency_updates
@@ -207,7 +207,7 @@ module Fastlane
           :new_features
         elsif change_types.include?("fix")
           :fixes
-        elsif change_types.include?("RevenueCatUI")
+        elsif change_types.include?("revenuecatui")
           :paywalls
         elsif change_types.include?("perf")
           :performance
@@ -233,7 +233,7 @@ module Fastlane
 
       private_class_method def self.get_type_of_change_from_pr_info(pr_info)
         pr_info["labels"]
-          .map { |label_info| label_info["name"] }
+          .map { |label_info| label_info["name"].downcase }
           .select { |label| Helper::GitHubHelper::SUPPORTED_PR_LABELS.include?(label) }
           .to_set
       end

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -84,7 +84,7 @@ describe Fastlane::Helper::GitHubHelper do
       expected_items = body["commits"]
 
       expect(items).not_to be_nil
-      expect(items.length).to eq(4)
+      expect(items.length).to eq(5)
       expected_items.each do |item|
         expect(expected_items.include?(item)).to be_truthy
       end

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -98,7 +98,7 @@ describe Fastlane::Helper::VersioningHelper do
       )
       expect(changelog).to eq("### New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
-                              "### Paywalls\n" \
+                              "### RevenueCatUI\n" \
                               "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
                               "### Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
@@ -315,7 +315,7 @@ describe Fastlane::Helper::VersioningHelper do
       )
       expect(changelog).to eq("### New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
-                              "### Paywalls\n" \
+                              "### RevenueCatUI\n" \
                               "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
                               "### Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
@@ -364,7 +364,7 @@ describe Fastlane::Helper::VersioningHelper do
       )
       expect(changelog).to eq("### Breaking Changes\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
-                              "### Paywalls\n" \
+                              "### RevenueCatUI\n" \
                               "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
                               "### Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
@@ -390,7 +390,7 @@ describe Fastlane::Helper::VersioningHelper do
         nil,
         nil
       )
-      expect(changelog).to eq("### Paywalls\n" \
+      expect(changelog).to eq("### RevenueCatUI\n" \
                               "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
                               "### Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -21,6 +21,9 @@ describe Fastlane::Helper::VersioningHelper do
     let(:get_commit_4_response) do
       { body: File.read("#{File.dirname(__FILE__)}/../test_files/get_commit_sha_9a289e554fe384e6987b086fad047671058cf044.json") }
     end
+    let(:get_commit_5_response) do
+      { body: File.read("#{File.dirname(__FILE__)}/../test_files/get_commit_sha_1625e195a117ad0435864dc8a561e6a0c6052bdf.json") }
+    end
     let(:get_commit_923_response) do
       { body: File.read("#{File.dirname(__FILE__)}/../test_files/get_commit_sha_9237147947bcbce00f36ae3ab51acccc54690782.json") }
     end
@@ -68,7 +71,8 @@ describe Fastlane::Helper::VersioningHelper do
         'a72c0435ecf71248f311900475e881cc07ac2eaf' => get_commit_1_response,
         '0e67cdb1c7582ce3e2fd00367acc24db6242c6d6' => get_commit_2_response,
         'cfdd80f73d8c91121313d72227b4cbe283b57c1e' => get_commit_3_response,
-        '9a289e554fe384e6987b086fad047671058cf044' => get_commit_4_response
+        '9a289e554fe384e6987b086fad047671058cf044' => get_commit_4_response,
+        '1625e195a117ad0435864dc8a561e6a0c6052bdf' => get_commit_5_response
       }
     end
 
@@ -94,6 +98,8 @@ describe Fastlane::Helper::VersioningHelper do
       )
       expect(changelog).to eq("### New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
+                              "### Paywalls\n" \
+                              "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
                               "### Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
                               "### Performance Improvements\n" \
@@ -298,7 +304,7 @@ describe Fastlane::Helper::VersioningHelper do
 
     it 'sleeps between getting commits info if passing rate limit sleep' do
       setup_commit_search_stubs(hashes_to_responses)
-      expect_any_instance_of(Object).to receive(:sleep).with(3).exactly(4).times
+      expect_any_instance_of(Object).to receive(:sleep).with(3).exactly(5).times
       changelog = Fastlane::Helper::VersioningHelper.auto_generate_changelog(
         'mock-repo-name',
         'mock-github-token',
@@ -309,6 +315,8 @@ describe Fastlane::Helper::VersioningHelper do
       )
       expect(changelog).to eq("### New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
+                              "### Paywalls\n" \
+                              "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
                               "### Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
                               "### Performance Improvements\n" \
@@ -356,6 +364,8 @@ describe Fastlane::Helper::VersioningHelper do
       )
       expect(changelog).to eq("### Breaking Changes\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
+                              "### Paywalls\n" \
+                              "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
                               "### Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
                               "### Performance Improvements\n" \
@@ -380,7 +390,9 @@ describe Fastlane::Helper::VersioningHelper do
         nil,
         nil
       )
-      expect(changelog).to eq("### Bugfixes\n" \
+      expect(changelog).to eq("### Paywalls\n" \
+                              "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
+                              "### Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
                               "### Performance Improvements\n" \
                               "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Nacho Soto (@nachosoto)\n" \
@@ -455,6 +467,9 @@ describe Fastlane::Helper::VersioningHelper do
     let(:get_fix_commit_response) do
       { body: File.read("#{File.dirname(__FILE__)}/../test_files/get_commit_sha_0e67cdb1c7582ce3e2fd00367acc24db6242c6d6.json") }
     end
+    let(:get_paywalls_commit_response) do
+      { body: File.read("#{File.dirname(__FILE__)}/../test_files/get_commit_sha_1625e195a117ad0435864dc8a561e6a0c6052bdf.json") }
+    end
     let(:get_perf_commit_response) do
       { body: File.read("#{File.dirname(__FILE__)}/../test_files/get_commit_sha_9a289e554fe384e6987b086fad047671058cf044.json") }
     end
@@ -490,6 +505,7 @@ describe Fastlane::Helper::VersioningHelper do
       {
         'a72c0435ecf71248f311900475e881cc07ac2eaf' => get_feat_commit_response,
         '0e67cdb1c7582ce3e2fd00367acc24db6242c6d6' => get_fix_commit_response,
+        '1625e195a117ad0435864dc8a561e6a0c6052bdf' => get_paywalls_commit_response,
         '9a289e554fe384e6987b086fad047671058cf044' => get_perf_commit_response,
         'cfdd80f73d8c91121313d72227b4cbe283b57c1e' => get_next_release_commit_response,
         '819dc620db5608fb952c852038a3560554161707' => get_ci_commit_response,
@@ -613,7 +629,7 @@ latest
     it 'sleeps between getting commits info if passing rate limit sleep' do
       setup_commit_search_stubs(hashes_to_responses)
 
-      expect_any_instance_of(Object).to receive(:sleep).with(3).exactly(4).times
+      expect_any_instance_of(Object).to receive(:sleep).with(3).exactly(5).times
       next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
         'mock-repo-name',
         'mock-github-token',

--- a/spec/test_files/get_commit_sha_1625e195a117ad0435864dc8a561e6a0c6052bdf.json
+++ b/spec/test_files/get_commit_sha_1625e195a117ad0435864dc8a561e6a0c6052bdf.json
@@ -1,0 +1,85 @@
+{
+    "total_count": 1,
+    "incomplete_results": false,
+    "items": [
+        {
+            "url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949",
+            "repository_url": "https://api.github.com/repos/RevenueCat/purchases-ios",
+            "labels_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/labels{/name}",
+            "comments_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/comments",
+            "events_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/events",
+            "html_url": "https://github.com/RevenueCat/purchases-ios/pull/2949",
+            "id": 1293434654,
+            "node_id": "PR_kwDOBnB8hc46z_fk",
+            "number": 2949,
+            "title": "`Paywalls`: multi-package horizontal template",
+            "user": {
+                "login": "nachosoto",
+                "id": 808417,
+                "node_id": "MDQ6VXNlcjgwODQxNw==",
+                "avatar_url": "https://avatars.githubusercontent.com/u/808417?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/nachosoto",
+                "html_url": "https://github.com/nachosoto",
+                "followers_url": "https://api.github.com/users/nachosoto/followers",
+                "following_url": "https://api.github.com/users/nachosoto/following{/other_user}",
+                "gists_url": "https://api.github.com/users/nachosoto/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/nachosoto/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/nachosoto/subscriptions",
+                "organizations_url": "https://api.github.com/users/nachosoto/orgs",
+                "repos_url": "https://api.github.com/users/nachosoto/repos",
+                "events_url": "https://api.github.com/users/nachosoto/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/nachosoto/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "labels": [
+                {
+                    "id": 4352868120,
+                    "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
+                    "name": "RevenueCatUI",
+                    "color": "8E3E6B",
+                    "default": false,
+                    "description": ""
+                }
+            ],
+            "state": "closed",
+            "locked": false,
+            "assignee": null,
+            "assignees": [],
+            "milestone": null,
+            "comments": 0,
+            "created_at": "2022-07-04T17:32:45Z",
+            "updated_at": "2022-07-05T04:49:19Z",
+            "closed_at": "2022-07-05T04:49:18Z",
+            "author_association": "CONTRIBUTOR",
+            "active_lock_reason": null,
+            "draft": false,
+            "pull_request": {
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/pulls/2949",
+                "html_url": "https://github.com/RevenueCat/purchases-ios/pull/2949",
+                "diff_url": "https://github.com/RevenueCat/purchases-ios/pull/2949.diff",
+                "patch_url": "https://github.com/RevenueCat/purchases-ios/pull/2949.patch",
+                "merged_at": "2022-07-05T04:49:18Z"
+            },
+            "body": "![image](https://github.com/RevenueCat/purchases-ios/assets/685609/a5cc3f4b-99d0-40a2-8a85-82f243383978)",
+            "reactions": {
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/reactions",
+                "total_count": 0,
+                "+1": 0,
+                "-1": 0,
+                "laugh": 0,
+                "hooray": 0,
+                "confused": 0,
+                "heart": 0,
+                "rocket": 0,
+                "eyes": 0
+            },
+            "timeline_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/timeline",
+            "performed_via_github_app": null,
+            "state_reason": null,
+            "score": 1.0
+        }
+    ]
+}

--- a/spec/test_files/get_commits_since_last_release.json
+++ b/spec/test_files/get_commits_since_last_release.json
@@ -405,6 +405,85 @@
             ]
         },
         {
+            "sha": "1625e195a117ad0435864dc8a561e6a0c6052bdf",
+            "node_id": "C_kwDOBnB8hdoAKDBlNjdjZGIxYzc1ODJjZTNlMmZkMDAzNjdhY2MyNGRiNjI0MmM2ZDY",
+            "commit": {
+                "author": {
+                    "name": "Nacho Soto",
+                    "email": "ignacio@revenuecat.com",
+                    "date": "2023-01-15T04:49:17Z"
+                },
+                "committer": {
+                    "name": "GitHub",
+                    "email": "noreply@github.com",
+                    "date": "2022-07-05T04:49:17Z"
+                },
+                "message": "`Paywalls`: multi-package horizontal template",
+                "tree": {
+                    "sha": "1625e195a117ad0435864dc8a561e6a0c6052bdf",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/git/trees/1625e195a117ad0435864dc8a561e6a0c6052bdf"
+                },
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/git/commits/1625e195a117ad0435864dc8a561e6a0c6052bdf",
+                "comment_count": 0,
+                "verification": {
+                    "verified": true,
+                    "reason": "valid",
+                    "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsBcBAABCAAQBQJiw8LNCRBK7hj4Ov3rIwAAx28IAK9cCcm3f58V5rLV9dPmJXjb\n46NoSgWH4jG/yuSdPbIwMFU0KoxjrZFLn0xsgRzdKFwxDSdZufjukEB8K25nw+/H\niYBxq5muO/NcN+zjYpl8a6xVWrMEgmAzgkM6C4KK7dAFOPPzh96yo2H0XfwJbBd8\nU+Bseg+J8Dq7+ObKnSeQ03Oo8kUfbdzV673r+4z5iR6FgY3hBiFjzzkXqIQn6N9u\nPxpErOgLmsb21gKF/BrvWzg9y+CTZhsbiktDxLM3GuPxOynJLCuRvqliADZNw6Z3\nDsiPdvIwezopzppYHy+VXsKKnzeSnIB3QddLp9eNIUaaIKgXb/MNurc54/mB+pQ=\n=0/O8\n-----END PGP SIGNATURE-----\n",
+                    "payload": "tree 3b552b9fbfcc806a009325e84a098680cb9cf952\nparent a72c0435ecf71248f311900475e881cc07ac2eaf\nauthor Toni Rico <antonio.rico.diez@revenuecat.com> 1656996557 +0200\ncommitter GitHub <noreply@github.com> 1656996557 +0200\n\nFix replace version without prerelease modifiers (#1751)\n\n* Fix replacing version without prerelease modifiers\r\n\r\n* Move SystemInfo.swift to use version with prerelease modifiers and remove outdated files"
+                }
+            },
+            "url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/1625e195a117ad0435864dc8a561e6a0c6052bdf",
+            "html_url": "https://github.com/RevenueCat/purchases-ios/commit/1625e195a117ad0435864dc8a561e6a0c6052bdf",
+            "comments_url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/1625e195a117ad0435864dc8a561e6a0c6052bdf/comments",
+            "author": {
+                "login": "NachoSoto",
+                "id": 808417,
+                "node_id": "MDQ6VXNlcjgwODQxNw==",
+                "avatar_url": "https://avatars.githubusercontent.com/u/808417?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/nachosoto",
+                "html_url": "https://github.com/nachosoto",
+                "followers_url": "https://api.github.com/users/nachosoto/followers",
+                "following_url": "https://api.github.com/users/nachosoto/following{/other_user}",
+                "gists_url": "https://api.github.com/users/nachosoto/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/nachosoto/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/nachosoto/subscriptions",
+                "organizations_url": "https://api.github.com/users/nachosoto/orgs",
+                "repos_url": "https://api.github.com/users/nachosoto/repos",
+                "events_url": "https://api.github.com/users/nachosoto/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/nachosoto/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "committer": {
+                "login": "web-flow",
+                "id": 19864447,
+                "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+                "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/web-flow",
+                "html_url": "https://github.com/web-flow",
+                "followers_url": "https://api.github.com/users/web-flow/followers",
+                "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+                "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+                "organizations_url": "https://api.github.com/users/web-flow/orgs",
+                "repos_url": "https://api.github.com/users/web-flow/repos",
+                "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/web-flow/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "parents": [
+                {
+                    "sha": "a72c0435ecf71248f311900475e881cc07ac2eaf",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/a72c0435ecf71248f311900475e881cc07ac2eaf",
+                    "html_url": "https://github.com/RevenueCat/purchases-ios/commit/a72c0435ecf71248f311900475e881cc07ac2eaf"
+                }
+            ]
+        },
+        {
             "sha": "cfdd80f73d8c91121313d72227b4cbe283b57c1e",
             "node_id": "C_kwDOBnB8hdoAKGNmZGQ4MGY3M2Q4YzkxMTIxMzEzZDcyMjI3YjRjYmUyODNiNTdjMWU",
             "commit": {


### PR DESCRIPTION
This will allow PRs with this label to be grouped together instead of all inside "Other changes".
If a PR has `feat` at the same time, that gets prioritized, but a PR with something like `refactor` + `RevenueCatUI` will use this new logic.
