### PR TITLE
Stop adding `minor` labels if minor phc update

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_phc_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_phc_version_action.rb
@@ -104,7 +104,6 @@ module Fastlane
         pr_title = "Updates purchases-hybrid-common to #{new_version_number}"
         type_of_bump = Helper::VersioningHelper.detect_bump_type(version_number, new_version_number)
         labels = ['phc_dependencies']
-        labels << 'minor' if type_of_bump == :minor
         body = pr_title
         base_branch = "main"
 

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_phc_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_phc_version_action.rb
@@ -102,7 +102,6 @@ module Fastlane
         Helper::RevenuecatInternalHelper.commit_changes_and_push_current_branch("Version bump for #{new_version_number}")
 
         pr_title = "Updates purchases-hybrid-common to #{new_version_number}"
-        type_of_bump = Helper::VersioningHelper.detect_bump_type(version_number, new_version_number)
         labels = ['phc_dependencies']
         body = pr_title
         base_branch = "main"

--- a/spec/actions/bump_phc_version_action_spec.rb
+++ b/spec/actions/bump_phc_version_action_spec.rb
@@ -10,7 +10,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
     let(:base_branch) { 'main' }
     let(:new_version) { '1.13.0' }
     let(:new_branch_name) { 'bump-phc/1.13.0' }
-    let(:labels) { ['phc_dependencies', 'minor'] }
+    let(:labels) { ['phc_dependencies'] }
 
     it 'fails if version is invalid' do
       allow(FastlaneCore::UI).to receive(:interactive?).and_return(true)


### PR DESCRIPTION
We don't want to make the type of update dependent of phc anymore