### PR TITLE
Support updating files on latest stable release only

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -114,8 +114,8 @@ module Fastlane
                                        type: Hash),
           FastlaneCore::ConfigItem.new(key: :files_to_update_on_latest_stable_releases,
                                        env_name: "RC_INTERNAL_FILES_TO_UPDATE_ON_LATEST_STABLE_RELEASES",
-                                       description: 'Hash of files that contain the version number and need to update' \
-                                                    'it only on stable releases (no prereleases) and on the latest' \
+                                       description: 'Hash of files that contain the version number and only need to' \
+                                                    'be updated on stable releases (no prereleases) and on the latest' \
                                                     'major (no hotfixes).' \
                                                     'Mark the version in the pattern using {x}.' \
                                                     'For example: { "./pubspec.yaml" => ["version: {x}"] }',

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -15,6 +15,7 @@ module Fastlane
         new_version_number = params[:next_version]
         files_to_update = params[:files_to_update]
         files_to_update_without_prerelease_modifiers = params[:files_to_update_without_prerelease_modifiers]
+        files_to_update_on_latest_stable_releases = params[:files_to_update_on_latest_stable_releases]
         changelog_latest_path = params[:changelog_latest_path]
         changelog_path = params[:changelog_path]
         editor = params[:editor]
@@ -54,7 +55,8 @@ module Fastlane
         Helper::RevenuecatInternalHelper.replace_version_number(version_number,
                                                                 new_version_number,
                                                                 files_to_update,
-                                                                files_to_update_without_prerelease_modifiers)
+                                                                files_to_update_without_prerelease_modifiers,
+                                                                files_to_update_on_latest_stable_releases)
         Helper::RevenuecatInternalHelper.attach_changelog_to_master(new_version_number, changelog_latest_path, changelog_path)
         Helper::RevenuecatInternalHelper.commit_changes_and_push_current_branch("Version bump for #{new_version_number}")
 
@@ -105,6 +107,16 @@ module Fastlane
                                        description: 'Hash of files that contain the version number without pre-release' \
                                                     'modifier and need to have it updated, to the patterns that' \
                                                     'contains the version in the file.' \
+                                                    'Mark the version in the pattern using {x}.' \
+                                                    'For example: { "./pubspec.yaml" => ["version: {x}"] }',
+                                       optional: true,
+                                       default_value: {},
+                                       type: Hash),
+          FastlaneCore::ConfigItem.new(key: :files_to_update_on_latest_stable_releases,
+                                       env_name: "RC_INTERNAL_FILES_TO_UPDATE_ON_LATEST_STABLE_RELEASES",
+                                       description: 'Hash of files that contain the version number and need to update' \
+                                                    'it only on stable releases (no prereleases) and on the latest' \
+                                                    'major (no hotfixes).' \
                                                     'Mark the version in the pattern using {x}.' \
                                                     'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: true,

--- a/lib/fastlane/plugin/revenuecat_internal/actions/replace_version_number_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/replace_version_number_action.rb
@@ -10,10 +10,12 @@ module Fastlane
         new_version_number = params[:new_version_number]
         files_to_update = params[:files_to_update]
         files_to_update_without_prerelease_modifiers = params[:files_to_update_without_prerelease_modifiers]
+        files_to_update_on_latest_stable_releases = params[:files_to_update_on_latest_stable_releases]
         Helper::RevenuecatInternalHelper.replace_version_number(previous_version_number,
                                                                 new_version_number,
                                                                 files_to_update,
-                                                                files_to_update_without_prerelease_modifiers)
+                                                                files_to_update_without_prerelease_modifiers,
+                                                                files_to_update_on_latest_stable_releases)
       end
 
       def self.description
@@ -47,6 +49,16 @@ module Fastlane
                                        description: 'Hash of files that contain the version number without pre-release' \
                                                     'modifier and need to have it updated, to the patterns that' \
                                                     'contains the version in the file.' \
+                                                    'Mark the version in the pattern using {x}.' \
+                                                    'For example: { "./pubspec.yaml" => ["version: {x}"] }',
+                                       optional: true,
+                                       default_value: {},
+                                       type: Hash),
+          FastlaneCore::ConfigItem.new(key: :files_to_update_on_latest_stable_releases,
+                                       env_name: "RC_INTERNAL_FILES_TO_UPDATE_ON_LATEST_STABLE_RELEASES",
+                                       description: 'Hash of files that contain the version number and need to update' \
+                                                    'it only on stable releases (no prereleases) and on the latest' \
+                                                    'major (no hotfixes).' \
                                                     'Mark the version in the pattern using {x}.' \
                                                     'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: true,

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -27,14 +27,14 @@ module Fastlane
         files_to_update_without_prerelease_modifiers.each do |file_to_update, patterns|
           replace_in(previous_version_number_without_prerelease_modifiers, new_version_number_without_prerelease_modifiers, file_to_update, patterns)
         end
-        if !files_to_update_on_latest_stable_releases.empty? && latest_semver_tag?(new_version_number) && !Gem::Version.new(new_version_number).prerelease?
+        if !files_to_update_on_latest_stable_releases.empty? && newer_than_latest_published_version?(new_version_number) && !Gem::Version.new(new_version_number).prerelease?
           files_to_update_on_latest_stable_releases.each do |file_to_update, patterns|
             replace_in(previous_version_number_without_prerelease_modifiers, new_version_number_without_prerelease_modifiers, file_to_update, patterns)
           end
         end
       end
 
-      def self.latest_semver_tag?(version_number)
+      def self.newer_than_latest_published_version?(version_number)
         Actions.sh("git fetch --tags -f")
         latest_published_version = Actions.sh("git tag -l '[0-9]*.[0-9]*.[0-9]*' | sort -r --version-sort | head -n1")
         return true if latest_published_version.empty?

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -14,7 +14,11 @@ module Fastlane
 
   module Helper
     class RevenuecatInternalHelper
-      def self.replace_version_number(previous_version_number, new_version_number, files_to_update_with_patterns, files_to_update_without_prerelease_modifiers)
+      def self.replace_version_number(previous_version_number,
+                                      new_version_number,
+                                      files_to_update_with_patterns,
+                                      files_to_update_without_prerelease_modifiers,
+                                      files_to_update_on_latest_stable_releases)
         previous_version_number_without_prerelease_modifiers = previous_version_number.split("-")[0]
         new_version_number_without_prerelease_modifiers = new_version_number.split("-")[0]
         files_to_update_with_patterns.each do |file_to_update, patterns|
@@ -23,6 +27,19 @@ module Fastlane
         files_to_update_without_prerelease_modifiers.each do |file_to_update, patterns|
           replace_in(previous_version_number_without_prerelease_modifiers, new_version_number_without_prerelease_modifiers, file_to_update, patterns)
         end
+        if !files_to_update_on_latest_stable_releases.empty? && latest_semver_tag?(new_version_number) && !Gem::Version.new(new_version_number).prerelease?
+          files_to_update_on_latest_stable_releases.each do |file_to_update, patterns|
+            replace_in(previous_version_number_without_prerelease_modifiers, new_version_number_without_prerelease_modifiers, file_to_update, patterns)
+          end
+        end
+      end
+
+      def self.latest_semver_tag?(version_number)
+        Actions.sh("git fetch --tags -f")
+        latest_published_version = Actions.sh("git tag -l '[0-9]*.[0-9]*.[0-9]*' | sort -r --version-sort | head -n1")
+        return true if latest_published_version.empty?
+
+        Gem::Version.new(latest_published_version) < Gem::Version.new(version_number)
       end
 
       def self.edit_changelog(prepopulated_changelog, changelog_latest_path, editor)

--- a/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
+++ b/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
@@ -62,7 +62,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         .with(current_version,
               new_version,
               { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
-              { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] })
+              { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] },
+              { "./test_file5.kt" => ['{x}'], "./test_file6.swift" => ['{x}'] })
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:attach_changelog_to_master)
         .with(new_version, mock_changelog_latest_path, mock_changelog_path)
@@ -80,6 +81,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         changelog_path: mock_changelog_path,
         files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
         files_to_update_without_prerelease_modifiers: { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] },
+        files_to_update_on_latest_stable_releases: { "./test_file5.kt" => ['{x}'], "./test_file6.swift" => ['{x}'] },
         repo_name: mock_repo_name,
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
@@ -102,6 +104,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         changelog_path: mock_changelog_path,
         files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
         files_to_update_without_prerelease_modifiers: { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] },
+        files_to_update_on_latest_stable_releases: { "./test_file5.kt" => ['{x}'], "./test_file6.swift" => ['{x}'] },
         repo_name: mock_repo_name,
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
@@ -123,6 +126,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
           changelog_path: mock_changelog_path,
           files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
           files_to_update_without_prerelease_modifiers: { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] },
+          files_to_update_on_latest_stable_releases: { "./test_file5.kt" => ['{x}'], "./test_file6.swift" => ['{x}'] },
           repo_name: mock_repo_name,
           github_pr_token: mock_github_pr_token,
           github_token: mock_github_token,
@@ -142,6 +146,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         changelog_path: mock_changelog_path,
         files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
         files_to_update_without_prerelease_modifiers: { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] },
+        files_to_update_on_latest_stable_releases: { "./test_file5.kt" => ['{x}'], "./test_file6.swift" => ['{x}'] },
         repo_name: mock_repo_name,
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
@@ -164,6 +169,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         changelog_path: mock_changelog_path,
         files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
         files_to_update_without_prerelease_modifiers: { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] },
+        files_to_update_on_latest_stable_releases: { "./test_file5.kt" => ['{x}'], "./test_file6.swift" => ['{x}'] },
         repo_name: mock_repo_name,
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
@@ -185,6 +191,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         changelog_path: mock_changelog_path,
         files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
         files_to_update_without_prerelease_modifiers: { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] },
+        files_to_update_on_latest_stable_releases: { "./test_file5.kt" => ['{x}'], "./test_file6.swift" => ['{x}'] },
         repo_name: mock_repo_name,
         github_pr_token: mock_github_pr_token,
         github_token: mock_github_token,
@@ -214,7 +221,8 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         .with(current_version,
               new_version,
               { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
-              { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] })
+              { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] },
+              { "./test_file5.kt" => ['{x}'], "./test_file6.swift" => ['{x}'] })
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:attach_changelog_to_master)
         .with(new_version, mock_changelog_latest_path, mock_changelog_path)
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:commit_changes_and_push_current_branch)
@@ -226,7 +234,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
 
   describe '#available_options' do
     it 'has correct number of options' do
-      expect(Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction.available_options.size).to eq(15)
+      expect(Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction.available_options.size).to eq(16)
     end
   end
 end

--- a/spec/actions/replace_version_number_action_spec.rb
+++ b/spec/actions/replace_version_number_action_spec.rb
@@ -5,20 +5,22 @@ describe Fastlane::Actions::ReplaceVersionNumberAction do
         .with('1.12.0',
               '1.13.0',
               { './test_file.sh' => ['{x}'], './test_file2.rb' => ['{x}'] },
-              { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] })
+              { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] },
+              { "./test_file5.kt" => ['{x}'], "./test_file6.swift" => ['{x}'] })
         .once
       Fastlane::Actions::ReplaceVersionNumberAction.run(
         current_version: '1.12.0',
         new_version_number: '1.13.0',
         files_to_update: { './test_file.sh' => ['{x}'], './test_file2.rb' => ['{x}'] },
-        files_to_update_without_prerelease_modifiers: { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] }
+        files_to_update_without_prerelease_modifiers: { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] },
+        files_to_update_on_latest_stable_releases: { "./test_file5.kt" => ['{x}'], "./test_file6.swift" => ['{x}'] }
       )
     end
   end
 
   describe '#available_options' do
     it 'has correct number of options' do
-      expect(Fastlane::Actions::ReplaceVersionNumberAction.available_options.size).to eq(4)
+      expect(Fastlane::Actions::ReplaceVersionNumberAction.available_options.size).to eq(5)
     end
   end
 end

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -214,7 +214,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
     end
   end
 
-  describe '.latest_semver_tag?' do
+  describe '.newer_than_latest_published_version?' do
     before(:each) do
       allow(Fastlane::Actions).to receive(:sh).with("git fetch --tags -f")
       allow(Fastlane::Actions).to receive(:sh).with("git tag -l '[0-9]*.[0-9]*.[0-9]*' | sort -r --version-sort | head -n1").and_return('1.2.3')
@@ -222,17 +222,17 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
 
     it 'if no tag is returned its considered latest' do
       allow(Fastlane::Actions).to receive(:sh).with("git tag -l '[0-9]*.[0-9]*.[0-9]*' | sort -r --version-sort | head -n1").and_return('')
-      expect(Fastlane::Helper::RevenuecatInternalHelper.latest_semver_tag?('1.0.0')).to be_truthy
+      expect(Fastlane::Helper::RevenuecatInternalHelper.newer_than_latest_published_version?('1.0.0')).to be_truthy
     end
 
     it 'returns false if tag older than latest' do
-      expect(Fastlane::Helper::RevenuecatInternalHelper.latest_semver_tag?('1.0.0')).to eq(false)
+      expect(Fastlane::Helper::RevenuecatInternalHelper.newer_than_latest_published_version?('1.0.0')).to eq(false)
     end
 
     it 'returns true if tag newer than latest' do
-      expect(Fastlane::Helper::RevenuecatInternalHelper.latest_semver_tag?('1.2.4')).to eq(true)
-      expect(Fastlane::Helper::RevenuecatInternalHelper.latest_semver_tag?('1.3.0')).to eq(true)
-      expect(Fastlane::Helper::RevenuecatInternalHelper.latest_semver_tag?('2.0.0')).to eq(true)
+      expect(Fastlane::Helper::RevenuecatInternalHelper.newer_than_latest_published_version?('1.2.4')).to eq(true)
+      expect(Fastlane::Helper::RevenuecatInternalHelper.newer_than_latest_published_version?('1.3.0')).to eq(true)
+      expect(Fastlane::Helper::RevenuecatInternalHelper.newer_than_latest_published_version?('2.0.0')).to eq(true)
     end
   end
 

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -6,8 +6,11 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
     let(:file_to_update_2) { './tmp_test_files/file_to_update_2.txt' }
     let(:file_to_update_without_prerelease_modifiers_3) { './tmp_test_files/file_to_update_3.txt' }
     let(:file_to_update_without_prerelease_modifiers_4) { './tmp_test_files/file_to_update_4.txt' }
+    let(:file_to_update_on_latest_stable_release_5) { './tmp_test_files/file_to_update_5.txt' }
 
     before(:each) do
+      allow(Fastlane::Actions).to receive(:sh).with("git fetch --tags -f")
+      allow(Fastlane::Actions).to receive(:sh).with("git tag -l '[0-9]*.[0-9]*.[0-9]*' | sort -r --version-sort | head -n1").and_return('1.2.3')
       Dir.mkdir('./tmp_test_files')
     end
 
@@ -20,18 +23,21 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       File.write(file_to_update_2, 'Contains version: 1.11.0 and other version: 1.11.1')
       File.write(file_to_update_without_prerelease_modifiers_3, 'Contains version: 1.11.0')
       File.write(file_to_update_without_prerelease_modifiers_4, 'Contains version: 1.11.0')
+      File.write(file_to_update_on_latest_stable_release_5, 'Contains version: 1.11.0')
 
       Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
         '1.11.0',
         '1.12.0',
         { file_to_update_1 => ["{x}"], file_to_update_2 => ["{x}"] },
-        { file_to_update_without_prerelease_modifiers_3 => ["{x}"], file_to_update_without_prerelease_modifiers_4 => ["{x}"] }
+        { file_to_update_without_prerelease_modifiers_3 => ["{x}"], file_to_update_without_prerelease_modifiers_4 => ["{x}"] },
+        { file_to_update_on_latest_stable_release_5 => ["{x}"] }
       )
 
       expect(File.read(file_to_update_1)).to eq('Contains version: 1.12.0')
       expect(File.read(file_to_update_2)).to eq('Contains version: 1.12.0 and other version: 1.11.1')
       expect(File.read(file_to_update_without_prerelease_modifiers_3)).to eq('Contains version: 1.12.0')
       expect(File.read(file_to_update_without_prerelease_modifiers_4)).to eq('Contains version: 1.12.0')
+      expect(File.read(file_to_update_on_latest_stable_release_5)).to eq('Contains version: 1.12.0')
     end
 
     it 'updates previous version number with new version number when current version has prerelease modifiers' do
@@ -39,18 +45,21 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       File.write(file_to_update_2, 'Contains version: 1.11.0-SNAPSHOT and other version: 1.11.1')
       File.write(file_to_update_without_prerelease_modifiers_3, 'Contains version: 1.11.0')
       File.write(file_to_update_without_prerelease_modifiers_4, 'Contains version: 1.11.0')
+      File.write(file_to_update_on_latest_stable_release_5, 'Contains version: 1.11.0')
 
       Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
         '1.11.0-SNAPSHOT',
         '1.12.0',
         { file_to_update_1 => ["{x}"], file_to_update_2 => ["{x}"] },
-        { file_to_update_without_prerelease_modifiers_3 => ["{x}"], file_to_update_without_prerelease_modifiers_4 => ["{x}"] }
+        { file_to_update_without_prerelease_modifiers_3 => ["{x}"], file_to_update_without_prerelease_modifiers_4 => ["{x}"] },
+        { file_to_update_on_latest_stable_release_5 => ["{x}"] }
       )
 
       expect(File.read(file_to_update_1)).to eq('Contains version: 1.11.0 and version with snapshot: 1.12.0')
       expect(File.read(file_to_update_2)).to eq('Contains version: 1.12.0 and other version: 1.11.1')
       expect(File.read(file_to_update_without_prerelease_modifiers_3)).to eq('Contains version: 1.12.0')
       expect(File.read(file_to_update_without_prerelease_modifiers_4)).to eq('Contains version: 1.12.0')
+      expect(File.read(file_to_update_on_latest_stable_release_5)).to eq('Contains version: 1.12.0')
     end
 
     it 'updates previous version number with new version number when new version has prerelease modifiers' do
@@ -58,18 +67,21 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       File.write(file_to_update_2, 'Contains version: 1.11.0 and other version: 1.11.1')
       File.write(file_to_update_without_prerelease_modifiers_3, 'Contains version: 1.11.0')
       File.write(file_to_update_without_prerelease_modifiers_4, 'Contains version: 1.11.0')
+      File.write(file_to_update_on_latest_stable_release_5, 'Contains version: 1.11.0')
 
       Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
         '1.11.0',
         '1.12.0-SNAPSHOT',
         { file_to_update_1 => ["{x}"], file_to_update_2 => ["{x}"] },
-        { file_to_update_without_prerelease_modifiers_3 => ["{x}"], file_to_update_without_prerelease_modifiers_4 => ["{x}"] }
+        { file_to_update_without_prerelease_modifiers_3 => ["{x}"], file_to_update_without_prerelease_modifiers_4 => ["{x}"] },
+        { file_to_update_on_latest_stable_release_5 => ["{x}"] }
       )
 
       expect(File.read(file_to_update_1)).to eq('Contains version: 1.12.0-SNAPSHOT')
       expect(File.read(file_to_update_2)).to eq('Contains version: 1.12.0-SNAPSHOT and other version: 1.11.1')
       expect(File.read(file_to_update_without_prerelease_modifiers_3)).to eq('Contains version: 1.12.0')
       expect(File.read(file_to_update_without_prerelease_modifiers_4)).to eq('Contains version: 1.12.0')
+      expect(File.read(file_to_update_on_latest_stable_release_5)).to eq('Contains version: 1.11.0')
     end
 
     it 'updates only version number that follows pattern' do
@@ -77,18 +89,21 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       File.write(file_to_update_2, 'Contains version: 1.11.0 and other version: 1.11.0')
       File.write(file_to_update_without_prerelease_modifiers_3, 'Contains version: 1.11.0')
       File.write(file_to_update_without_prerelease_modifiers_4, 'Contains version: 1.11.0')
+      File.write(file_to_update_on_latest_stable_release_5, 'Contains version: 1.11.0')
 
       Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
         '1.11.0',
         '1.12.0',
         { file_to_update_1 => ["{x}"], file_to_update_2 => ["Contains version: {x} and"] },
-        { file_to_update_without_prerelease_modifiers_3 => ["{x}"], file_to_update_without_prerelease_modifiers_4 => ["{x}"] }
+        { file_to_update_without_prerelease_modifiers_3 => ["{x}"], file_to_update_without_prerelease_modifiers_4 => ["{x}"] },
+        { file_to_update_on_latest_stable_release_5 => ["{x}"] }
       )
 
       expect(File.read(file_to_update_1)).to eq('Contains version: 1.12.0')
       expect(File.read(file_to_update_2)).to eq('Contains version: 1.12.0 and other version: 1.11.0')
       expect(File.read(file_to_update_without_prerelease_modifiers_3)).to eq('Contains version: 1.12.0')
       expect(File.read(file_to_update_without_prerelease_modifiers_4)).to eq('Contains version: 1.12.0')
+      expect(File.read(file_to_update_on_latest_stable_release_5)).to eq('Contains version: 1.12.0')
     end
 
     it 'updates only version number that follows pattern when current version has prerelease modifiers' do
@@ -96,6 +111,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       File.write(file_to_update_2, 'Contains version: 1.11.0-SNAPSHOT and other version: 1.11.0-SNAPSHOT')
       File.write(file_to_update_without_prerelease_modifiers_3, 'Contains version: 1.11.0')
       File.write(file_to_update_without_prerelease_modifiers_4, 'Contains version: 1.11.0 and other version: 1.11.0')
+      File.write(file_to_update_on_latest_stable_release_5, 'Contains version: 1.11.0 and other version: 1.11.0')
 
       pattern = "Contains version: {x} and"
       Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
@@ -108,6 +124,9 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
         {
             file_to_update_without_prerelease_modifiers_3 => ["{x}"],
             file_to_update_without_prerelease_modifiers_4 => [pattern]
+        },
+        {
+            file_to_update_on_latest_stable_release_5 => [pattern]
         }
       )
 
@@ -115,6 +134,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       expect(File.read(file_to_update_2)).to eq('Contains version: 1.12.0 and other version: 1.11.0-SNAPSHOT')
       expect(File.read(file_to_update_without_prerelease_modifiers_3)).to eq('Contains version: 1.12.0')
       expect(File.read(file_to_update_without_prerelease_modifiers_4)).to eq('Contains version: 1.12.0 and other version: 1.11.0')
+      expect(File.read(file_to_update_on_latest_stable_release_5)).to eq('Contains version: 1.12.0 and other version: 1.11.0')
     end
 
     it 'updates only version number that follows pattern when new version has prerelease modifiers' do
@@ -122,6 +142,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       File.write(file_to_update_2, 'Contains version: 1.11.0 and other version: 1.11.1')
       File.write(file_to_update_without_prerelease_modifiers_3, 'Contains version: 1.11.0')
       File.write(file_to_update_without_prerelease_modifiers_4, 'Contains version: 1.11.0 and other version: 1.11.0')
+      File.write(file_to_update_on_latest_stable_release_5, 'Contains version: 1.11.0 and other version: 1.11.0')
 
       pattern = "Contains version: {x} and"
       Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
@@ -131,6 +152,9 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
         {
             file_to_update_without_prerelease_modifiers_3 => ["{x}"],
             file_to_update_without_prerelease_modifiers_4 => [pattern]
+        },
+        {
+            file_to_update_on_latest_stable_release_5 => [pattern]
         }
       )
 
@@ -138,6 +162,77 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       expect(File.read(file_to_update_2)).to eq('Contains version: 1.12.0-SNAPSHOT and other version: 1.11.1')
       expect(File.read(file_to_update_without_prerelease_modifiers_3)).to eq('Contains version: 1.12.0')
       expect(File.read(file_to_update_without_prerelease_modifiers_4)).to eq('Contains version: 1.12.0 and other version: 1.11.0')
+      expect(File.read(file_to_update_on_latest_stable_release_5)).to eq('Contains version: 1.11.0 and other version: 1.11.0')
+    end
+
+    it 'does not update files on latest stable release if new version is prerelease' do
+      File.write(file_to_update_on_latest_stable_release_5, 'Contains version: 1.11.0')
+
+      Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
+        '1.11.0',
+        '1.12.0-SNAPSHOT',
+        {},
+        {},
+        {
+          file_to_update_on_latest_stable_release_5 => ["{x}"]
+        }
+      )
+
+      expect(File.read(file_to_update_on_latest_stable_release_5)).to eq('Contains version: 1.11.0')
+    end
+
+    it 'does not update files on latest stable release if new version is older than latest version' do
+      File.write(file_to_update_on_latest_stable_release_5, 'Contains version: 1.1.0')
+
+      Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
+        '1.1.0',
+        '1.1.8',
+        {},
+        {},
+        {
+          file_to_update_on_latest_stable_release_5 => ["{x}"]
+        }
+      )
+
+      expect(File.read(file_to_update_on_latest_stable_release_5)).to eq('Contains version: 1.1.0')
+    end
+
+    it 'does update files on latest stable release if new version is newer than latest version' do
+      File.write(file_to_update_on_latest_stable_release_5, 'Contains version: 1.2.3')
+
+      Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
+        '1.2.3',
+        '1.2.4',
+        {},
+        {},
+        {
+          file_to_update_on_latest_stable_release_5 => ["{x}"]
+        }
+      )
+
+      expect(File.read(file_to_update_on_latest_stable_release_5)).to eq('Contains version: 1.2.4')
+    end
+  end
+
+  describe '.latest_semver_tag?' do
+    before(:each) do
+      allow(Fastlane::Actions).to receive(:sh).with("git fetch --tags -f")
+      allow(Fastlane::Actions).to receive(:sh).with("git tag -l '[0-9]*.[0-9]*.[0-9]*' | sort -r --version-sort | head -n1").and_return('1.2.3')
+    end
+
+    it 'if no tag is returned its considered latest' do
+      allow(Fastlane::Actions).to receive(:sh).with("git tag -l '[0-9]*.[0-9]*.[0-9]*' | sort -r --version-sort | head -n1").and_return('')
+      expect(Fastlane::Helper::RevenuecatInternalHelper.latest_semver_tag?('1.0.0')).to be_truthy
+    end
+
+    it 'returns false if tag older than latest' do
+      expect(Fastlane::Helper::RevenuecatInternalHelper.latest_semver_tag?('1.0.0')).to eq(false)
+    end
+
+    it 'returns true if tag newer than latest' do
+      expect(Fastlane::Helper::RevenuecatInternalHelper.latest_semver_tag?('1.2.4')).to eq(true)
+      expect(Fastlane::Helper::RevenuecatInternalHelper.latest_semver_tag?('1.3.0')).to eq(true)
+      expect(Fastlane::Helper::RevenuecatInternalHelper.latest_semver_tag?('2.0.0')).to eq(true)
     end
   end
 


### PR DESCRIPTION
When we need to make a hotfix or make a prerelease, sometimes we update the files that we shouldn't. This adds support for a new parameter on these lanes that will only be updated if the version given is posterior (in semver versions) to the latest tag and it's not a prerelease.