### PR TITLE
Fix issue where we were not detecting versions as latest if there was a higher prerelease version

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -36,7 +36,7 @@ module Fastlane
 
       def self.newer_than_latest_published_version?(version_number)
         Actions.sh("git fetch --tags -f")
-        latest_published_version = Actions.sh("git tag -l '[0-9]*.[0-9]*.[0-9]*' | sort -r --version-sort | head -n1")
+        latest_published_version = Actions.sh("git tag | grep '^[0-9]*\.[0-9]*\.[0-9]*$' | sort -r --version-sort | head -n1")
         return true if latest_published_version.empty?
 
         Gem::Version.new(latest_published_version) < Gem::Version.new(version_number)

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -10,7 +10,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
 
     before(:each) do
       allow(Fastlane::Actions).to receive(:sh).with("git fetch --tags -f")
-      allow(Fastlane::Actions).to receive(:sh).with("git tag -l '[0-9]*.[0-9]*.[0-9]*' | sort -r --version-sort | head -n1").and_return('1.2.3')
+      allow(Fastlane::Actions).to receive(:sh).with("git tag | grep '^[0-9]*\.[0-9]*\.[0-9]*$' | sort -r --version-sort | head -n1").and_return('1.2.3')
       Dir.mkdir('./tmp_test_files')
     end
 
@@ -217,11 +217,11 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
   describe '.newer_than_latest_published_version?' do
     before(:each) do
       allow(Fastlane::Actions).to receive(:sh).with("git fetch --tags -f")
-      allow(Fastlane::Actions).to receive(:sh).with("git tag -l '[0-9]*.[0-9]*.[0-9]*' | sort -r --version-sort | head -n1").and_return('1.2.3')
+      allow(Fastlane::Actions).to receive(:sh).with("git tag | grep '^[0-9]*\.[0-9]*\.[0-9]*$' | sort -r --version-sort | head -n1").and_return('1.2.3')
     end
 
     it 'if no tag is returned its considered latest' do
-      allow(Fastlane::Actions).to receive(:sh).with("git tag -l '[0-9]*.[0-9]*.[0-9]*' | sort -r --version-sort | head -n1").and_return('')
+      allow(Fastlane::Actions).to receive(:sh).with("git tag | grep '^[0-9]*\.[0-9]*\.[0-9]*$' | sort -r --version-sort | head -n1").and_return('')
       expect(Fastlane::Helper::RevenuecatInternalHelper.newer_than_latest_published_version?('1.0.0')).to be_truthy
     end
 

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -1,4 +1,6 @@
 describe Fastlane::Helper::RevenuecatInternalHelper do
+  let(:get_latest_tag_command) { "git tag | grep '^[0-9]*\.[0-9]*\.[0-9]*$' | sort -r --version-sort | head -n1" }
+
   describe '.replace_version_number' do
     require 'fileutils'
 
@@ -10,7 +12,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
 
     before(:each) do
       allow(Fastlane::Actions).to receive(:sh).with("git fetch --tags -f")
-      allow(Fastlane::Actions).to receive(:sh).with("git tag | grep '^[0-9]*\.[0-9]*\.[0-9]*$' | sort -r --version-sort | head -n1").and_return('1.2.3')
+      allow(Fastlane::Actions).to receive(:sh).with(get_latest_tag_command).and_return('1.2.3')
       Dir.mkdir('./tmp_test_files')
     end
 
@@ -217,11 +219,11 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
   describe '.newer_than_latest_published_version?' do
     before(:each) do
       allow(Fastlane::Actions).to receive(:sh).with("git fetch --tags -f")
-      allow(Fastlane::Actions).to receive(:sh).with("git tag | grep '^[0-9]*\.[0-9]*\.[0-9]*$' | sort -r --version-sort | head -n1").and_return('1.2.3')
+      allow(Fastlane::Actions).to receive(:sh).with(get_latest_tag_command).and_return('1.2.3')
     end
 
     it 'if no tag is returned its considered latest' do
-      allow(Fastlane::Actions).to receive(:sh).with("git tag | grep '^[0-9]*\.[0-9]*\.[0-9]*$' | sort -r --version-sort | head -n1").and_return('')
+      allow(Fastlane::Actions).to receive(:sh).with(get_latest_tag_command).and_return('')
       expect(Fastlane::Helper::RevenuecatInternalHelper.newer_than_latest_published_version?('1.0.0')).to be_truthy
     end
 


### PR DESCRIPTION
This was causing problems when we had some prerelease for a future version shipped. In that case, we don't want to consider that one the latest.