### PR TITLE
ReplaceVersionNumber: Make stable version substitution work with versions not matching previous version

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_phc_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_phc_version_action.rb
@@ -62,9 +62,9 @@ module Fastlane
                                        optional: false,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :files_to_update,
-                                       description: 'Hash of files that contain the version number and need to have it' \
-                                                    'updated to the pattern that contains the version in the file.' \
-                                                    'Mark the version in the pattern using {x}.' \
+                                       description: 'Hash of files that contain the version number and need to have it ' \
+                                                    'updated to the pattern that contains the version in the file. ' \
+                                                    'Mark the version in the pattern using {x}. ' \
                                                     'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: false,
                                        type: Hash),

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -116,7 +116,8 @@ module Fastlane
                                        env_name: "RC_INTERNAL_FILES_TO_UPDATE_ON_LATEST_STABLE_RELEASES",
                                        description: 'Hash of files that contain the version number and only need to' \
                                                     'be updated on stable releases (no prereleases) and on the latest' \
-                                                    'major (no hotfixes).' \
+                                                    'major (no hotfixes). Note that the version will be updated as' \
+                                                    'long as it matches a semver stable version, even if its not the previous version' \
                                                     'Mark the version in the pattern using {x}.' \
                                                     'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: true,

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -96,29 +96,29 @@ module Fastlane
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :files_to_update,
                                        env_name: "RC_INTERNAL_FILES_TO_UPDATE_VERSION",
-                                       description: 'Hash of files that contain the version number and need to have it' \
-                                                    'updated to the patterns that contains the version in the file.' \
-                                                    'Mark the version in the pattern using {x}.' \
+                                       description: 'Hash of files that contain the version number and need to have it ' \
+                                                    'updated to the patterns that contains the version in the file. ' \
+                                                    'Mark the version in the pattern using {x}. ' \
                                                     'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: false,
                                        type: Hash),
           FastlaneCore::ConfigItem.new(key: :files_to_update_without_prerelease_modifiers,
                                        env_name: "RC_INTERNAL_FILES_TO_UPDATE_VERSION_WITHOUT_PRERELEASE_MODIFIERS",
-                                       description: 'Hash of files that contain the version number without pre-release' \
-                                                    'modifier and need to have it updated, to the patterns that' \
-                                                    'contains the version in the file.' \
-                                                    'Mark the version in the pattern using {x}.' \
+                                       description: 'Hash of files that contain the version number without pre-release ' \
+                                                    'modifier and need to have it updated, to the patterns that ' \
+                                                    'contains the version in the file. ' \
+                                                    'Mark the version in the pattern using {x}. ' \
                                                     'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: true,
                                        default_value: {},
                                        type: Hash),
           FastlaneCore::ConfigItem.new(key: :files_to_update_on_latest_stable_releases,
                                        env_name: "RC_INTERNAL_FILES_TO_UPDATE_ON_LATEST_STABLE_RELEASES",
-                                       description: 'Hash of files that contain the version number and only need to' \
-                                                    'be updated on stable releases (no prereleases) and on the latest' \
-                                                    'major (no hotfixes). Note that the version will be updated as' \
-                                                    'long as it matches a semver stable version, even if its not the previous version' \
-                                                    'Mark the version in the pattern using {x}.' \
+                                       description: 'Hash of files that contain the version number and only need to ' \
+                                                    'be updated on stable releases (no prereleases) and on the latest ' \
+                                                    'major (no hotfixes). Note that the version will be updated as ' \
+                                                    'long as it matches a semver stable version, even if its not the previous version ' \
+                                                    'Mark the version in the pattern using {x}. ' \
                                                     'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: true,
                                        default_value: {},

--- a/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
@@ -62,18 +62,18 @@ module Fastlane
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :files_to_update,
                                        env_name: "RC_INTERNAL_FILES_TO_UPDATE_VERSION",
-                                       description: 'Hash of files that contain the version number and need to have it' \
-                                                    'updated to the patterns that contains the version in the file.' \
-                                                    'Mark the version in the pattern using {x}.' \
+                                       description: 'Hash of files that contain the version number and need to have it ' \
+                                                    'updated to the patterns that contains the version in the file. ' \
+                                                    'Mark the version in the pattern using {x}. ' \
                                                     'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: false,
                                        type: Hash),
           FastlaneCore::ConfigItem.new(key: :files_to_update_without_prerelease_modifiers,
                                        env_name: "RC_INTERNAL_FILES_TO_UPDATE_VERSION_WITHOUT_PRERELEASE_MODIFIERS",
-                                       description: 'Hash of files that contain the version number without pre-release' \
-                                                    'modifier and need to have it updated, to the patterns that' \
-                                                    'contains the version in the file.' \
-                                                    'Mark the version in the pattern using {x}.' \
+                                       description: 'Hash of files that contain the version number without pre-release ' \
+                                                    'modifier and need to have it updated, to the patterns that ' \
+                                                    'contains the version in the file. ' \
+                                                    'Mark the version in the pattern using {x}. ' \
                                                     'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: true,
                                        default_value: {},

--- a/lib/fastlane/plugin/revenuecat_internal/actions/replace_version_number_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/replace_version_number_action.rb
@@ -38,28 +38,28 @@ module Fastlane
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :files_to_update,
                                        env_name: "RC_INTERNAL_FILES_TO_UPDATE_VERSION",
-                                       description: 'Hash of files that contain the version number and need to have it' \
-                                                    'updated to the patterns that contains the version in the file.' \
-                                                    'Mark the version in the pattern using {x}.' \
+                                       description: 'Hash of files that contain the version number and need to have it ' \
+                                                    'updated to the patterns that contains the version in the file. ' \
+                                                    'Mark the version in the pattern using {x}. ' \
                                                     'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: false,
                                        type: Hash),
           FastlaneCore::ConfigItem.new(key: :files_to_update_without_prerelease_modifiers,
                                        env_name: "RC_INTERNAL_FILES_TO_UPDATE_VERSION_WITHOUT_PRERELEASE_MODIFIERS",
-                                       description: 'Hash of files that contain the version number without pre-release' \
-                                                    'modifier and need to have it updated, to the patterns that' \
-                                                    'contains the version in the file.' \
-                                                    'Mark the version in the pattern using {x}.' \
+                                       description: 'Hash of files that contain the version number without pre-release ' \
+                                                    'modifier and need to have it updated, to the patterns that ' \
+                                                    'contains the version in the file. ' \
+                                                    'Mark the version in the pattern using {x}. ' \
                                                     'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: true,
                                        default_value: {},
                                        type: Hash),
           FastlaneCore::ConfigItem.new(key: :files_to_update_on_latest_stable_releases,
                                        env_name: "RC_INTERNAL_FILES_TO_UPDATE_ON_LATEST_STABLE_RELEASES",
-                                       description: 'Hash of files that contain the version number and need to update' \
-                                                    'it only on stable releases (no prereleases) and on the latest' \
-                                                    'major (no hotfixes).' \
-                                                    'Mark the version in the pattern using {x}.' \
+                                       description: 'Hash of files that contain the version number and need to update ' \
+                                                    'it only on stable releases (no prereleases) and on the latest ' \
+                                                    'major (no hotfixes). ' \
+                                                    'Mark the version in the pattern using {x}. ' \
                                                     'For example: { "./pubspec.yaml" => ["version: {x}"] }',
                                        optional: true,
                                        default_value: {},

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -29,7 +29,7 @@ module Fastlane
         end
         if !files_to_update_on_latest_stable_releases.empty? && newer_than_latest_published_version?(new_version_number) && !Gem::Version.new(new_version_number).prerelease?
           files_to_update_on_latest_stable_releases.each do |file_to_update, patterns|
-            replace_in(previous_version_number_without_prerelease_modifiers, new_version_number_without_prerelease_modifiers, file_to_update, patterns)
+            replace_stable_version_number_using_regex(new_version_number_without_prerelease_modifiers, file_to_update, patterns)
           end
         end
       end
@@ -214,6 +214,19 @@ module Fastlane
           UI.error("Branch '#{new_branch}' already exists in remote repository.")
           UI.user_error!("Please make sure it doesn't have any unsaved changes and delete it to continue.")
         end
+      end
+
+      private_class_method def self.replace_stable_version_number_using_regex(new_text, path, patterns = ['{x}'])
+        original_text = File.read(path)
+        replaced_text = original_text
+        semver_regex = /(\d+\.\d+\.\d+)/
+        patterns.each do |pattern|
+          previous_regex = Regexp.new(pattern.gsub('{x}', semver_regex.source))
+          replaced_new_text = pattern.gsub('{x}', new_text)
+          replaced_text = replaced_text.gsub(previous_regex, replaced_new_text)
+        end
+
+        File.write(path, replaced_text)
       end
     end
   end

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -214,6 +214,38 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
 
       expect(File.read(file_to_update_on_latest_stable_release_5)).to eq('Contains version: 1.2.4')
     end
+
+    it 'does update files on latest stable release if previous version does not match previous version given' do
+      File.write(file_to_update_on_latest_stable_release_5, '<meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/7.10.7/index.html" />')
+
+      Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
+        '1.2.3',
+        '1.2.4',
+        {},
+        {},
+        {
+          file_to_update_on_latest_stable_release_5 => ["url=https://sdk.revenuecat.com/android/{x}/index.html"]
+        }
+      )
+
+      expect(File.read(file_to_update_on_latest_stable_release_5)).to eq('<meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/1.2.4/index.html" />')
+    end
+
+    it 'does not update files on latest stable release if old version does not match a stable semver version' do
+      File.write(file_to_update_on_latest_stable_release_5, '<meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/7.10.7-SNAPSHOT/index.html" />')
+
+      Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
+        '1.2.3',
+        '1.2.4',
+        {},
+        {},
+        {
+          file_to_update_on_latest_stable_release_5 => ["url=https://sdk.revenuecat.com/android/{x}/index.html"]
+        }
+      )
+
+      expect(File.read(file_to_update_on_latest_stable_release_5)).to eq('<meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/7.10.7-SNAPSHOT/index.html" />')
+    end
   end
 
   describe '.newer_than_latest_published_version?' do

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -216,7 +216,10 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
     end
 
     it 'does update files on latest stable release if previous version does not match previous version given' do
-      File.write(file_to_update_on_latest_stable_release_5, '<meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/7.10.7/index.html" />')
+      original_text = '<meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/7.10.7/index.html" />'
+      expected_text = '<meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/1.2.4/index.html" />'
+
+      File.write(file_to_update_on_latest_stable_release_5, original_text)
 
       Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
         '1.2.3',
@@ -228,11 +231,13 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
         }
       )
 
-      expect(File.read(file_to_update_on_latest_stable_release_5)).to eq('<meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/1.2.4/index.html" />')
+      expect(File.read(file_to_update_on_latest_stable_release_5)).to eq(expected_text)
     end
 
     it 'does not update files on latest stable release if old version does not match a stable semver version' do
-      File.write(file_to_update_on_latest_stable_release_5, '<meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/7.10.7-SNAPSHOT/index.html" />')
+      original_text = '<meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/7.10.7-SNAPSHOT/index.html" />'
+
+      File.write(file_to_update_on_latest_stable_release_5, original_text)
 
       Fastlane::Helper::RevenuecatInternalHelper.replace_version_number(
         '1.2.3',
@@ -244,7 +249,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
         }
       )
 
-      expect(File.read(file_to_update_on_latest_stable_release_5)).to eq('<meta http-equiv="refresh" content="0; url=https://sdk.revenuecat.com/android/7.10.7-SNAPSHOT/index.html" />')
+      expect(File.read(file_to_update_on_latest_stable_release_5)).to eq(original_text)
     end
   end
 


### PR DESCRIPTION
We noticed that the files that we were using the latest stable versions weren't being updated correctly because the "previous_version" did not match the previous version that we give to the job, since that would be the version of the latest stable version at that point in time. 

This allows that piece of substitution to work with any stable semver version instead of having to specific the previous version specifically.
