### PR TITLE
Sync to spm repo

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/git_clone_and_push.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/git_clone_and_push.rb
@@ -1,0 +1,39 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require_relative '../helper/revenuecat_internal_helper'
+require_relative '../helper/versioning_helper'
+
+module Fastlane
+  module Actions
+    class GitCloneAndPushAction < Action
+      def self.run(params)
+        source_repo = params[:source_repo]
+        destination_repo = params[:destination_repo]
+
+        Helper::RevenuecatInternalHelper.git_clone_source_to_dest(source_repo, destination_repo)
+      end
+
+      def self.description
+        "Makes a lightweight clone containing only on the main branch's history."
+      end
+
+      def self.authors
+        ["James Borthwick"]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :source_repo,
+                                       description: "The source repository URL",
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :destination_repo,
+                                       description: "The destination repository URL",
+                                       is_string: true)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/git_clone_and_push.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/git_clone_and_push.rb
@@ -35,5 +35,6 @@ module Fastlane
       def self.is_supported?(platform)
         [:ios, :mac].include?(platform)
       end
+    end
   end
 end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/git_clone_and_push_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/git_clone_and_push_action.rb
@@ -14,7 +14,7 @@ module Fastlane
       end
 
       def self.description
-        "Makes a lightweight clone containing only on the main branch's history."
+        "Makes a lightweight clone containing only on the main branch's history. Includes Git tags."
       end
 
       def self.authors
@@ -25,15 +25,17 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :source_repo,
                                        description: "The source repository URL",
-                                       is_string: true),
+                                       optional: false,
+                                       type: String),
           FastlaneCore::ConfigItem.new(key: :destination_repo,
                                        description: "The destination repository URL",
-                                       is_string: true)
+                                       optional: false,
+                                       type: String)
         ]
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac].include?(platform)
+        true
       end
     end
   end

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -202,6 +202,19 @@ module Fastlane
             .map { |item| item['tag_name'] }
       end
 
+      def self.git_clone_source_to_dest(source_repo, destination_repo)
+        Actions.sh("git clone #{source_repo}")
+        repo_name = source_repo.split('/').last.gsub('.git', '')
+
+        Dir.chdir(repo_name) do
+          Actions.sh("git fetch --tags")
+          Actions.sh("git remote set-url origin #{destination_repo}")
+
+          Actions.sh("git push origin")
+          Actions.sh("git push --tags")
+        end
+      end
+
       private_class_method def self.ensure_new_branch_local_remote(new_branch)
         local_branches = Actions.sh('git', 'branch', '--list', new_branch)
         unless local_branches.empty?

--- a/spec/actions/git_clone_and_push_action_spec.rb
+++ b/spec/actions/git_clone_and_push_action_spec.rb
@@ -1,0 +1,17 @@
+describe Fastlane::Actions::CommitCurrentChangesAction do
+  describe '#run' do
+    it 'calls appropriate actions with expected parameters' do
+      expect(Fastlane::Actions).to receive(:sh).with('git add -u').once
+      expect(Fastlane::Actions).to receive(:sh).with("git commit -m 'fake-commit-message'").once
+      Fastlane::Actions::CommitCurrentChangesAction.run(
+        commit_message: 'fake-commit-message'
+      )
+    end
+  end
+
+  describe '#available_options' do
+    it 'has correct number of options' do
+      expect(Fastlane::Actions::CommitCurrentChangesAction.available_options.size).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
Use fastlane to sync the iOS repo to its SPM variant. This is used by the changes made in this [purchases-ios PR](https://github.com/RevenueCat/purchases-ios/pull/3926).