### PR TITLE
Add links to versions and billing client in hybrid VERSIONS.md

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/update_hybrids_versions_file_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/update_hybrids_versions_file_action.rb
@@ -29,8 +29,8 @@ module Fastlane
           extend_header = lines[0].split('|').length <= 6
 
           if extend_header
-            lines[0] = "#{lines[0].strip} Android Billing Client version |\n"
-            lines[1] = "#{lines[1].strip}--------------------------------|\n"
+            lines[0] = "#{lines[0].strip} Play Billing Library version |\n"
+            lines[1] = "#{lines[1].strip}------------------------------|\n"
             lines.each_with_index do |line, index|
               if index > 1
                 lines[index] = "#{line.strip} |\n"

--- a/lib/fastlane/plugin/revenuecat_internal/actions/update_hybrids_versions_file_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/update_hybrids_versions_file_action.rb
@@ -24,7 +24,11 @@ module Fastlane
 
         File.open(versions_file_path, 'r+') do |file|
           lines = file.each_line.to_a
-          if lines[0].split('|').length <= 6
+          # Determine if the header needs to be extended based on the number of columns
+          # The number 6 comes from new_sdk_version, ios_version, android_version, hybrid_common_version + separators before and after
+          extend_header = lines[0].split('|').length <= 6
+
+          if extend_header
             lines[0] = "#{lines[0].strip} Android Billing Client version |\n"
             lines[1] = "#{lines[1].strip}--------------------------------|\n"
             lines.each_with_index do |line, index|
@@ -33,11 +37,15 @@ module Fastlane
               end
             end
           end
-          lines.insert(2, "| #{new_sdk_version} " \
-                          "| [#{ios_version}](https://github.com/RevenueCat/purchases-ios/releases/tag/#{ios_version}) " \
-                          "| [#{android_version}](https://github.com/RevenueCat/purchases-android/releases/tag/#{android_version}) " \
-                          "| [#{hybrid_common_version}](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/#{hybrid_common_version}) " \
-                          "| [#{billing_client_version}](https://developer.android.com/google/play/billing/release-notes) |\n")
+
+          new_line = [
+            new_sdk_version,
+            "[#{ios_version}](https://github.com/RevenueCat/purchases-ios/releases/tag/#{ios_version})",
+            "[#{android_version}](https://github.com/RevenueCat/purchases-android/releases/tag/#{android_version})",
+            "[#{hybrid_common_version}](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/#{hybrid_common_version})",
+            "[#{billing_client_version}](https://developer.android.com/google/play/billing/release-notes)"
+          ].join(' | ')
+          lines.insert(2, "| #{new_line} |\n")
           file.rewind
           file.write(lines.join)
         end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/update_hybrids_versions_file_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/update_hybrids_versions_file_action.rb
@@ -19,9 +19,25 @@ module Fastlane
         ios_version = Helper::UpdateHybridsVersionsFileHelper.get_ios_version_for_hybrid_common_version(hybrid_common_version)
         UI.message("Obtained ios version #{ios_version} for PHC version #{hybrid_common_version}")
 
+        billing_client_version = Helper::UpdateHybridsVersionsFileHelper.get_android_billing_client_version(android_version)
+        UI.message("Obtained android billing client version #{billing_client_version} for PHC version #{hybrid_common_version}")
+
         File.open(versions_file_path, 'r+') do |file|
           lines = file.each_line.to_a
-          lines.insert(2, "| #{new_sdk_version} | #{ios_version} | #{android_version} | #{hybrid_common_version} |\n")
+          if lines[0].split('|').length <= 6
+            lines[0] = "#{lines[0].strip} Android Billing Client version |\n"
+            lines[1] = "#{lines[1].strip}--------------------------------|\n"
+            lines.each_with_index do |line, index|
+              if index > 1
+                lines[index] = "#{line.strip} |\n"
+              end
+            end
+          end
+          lines.insert(2, "| #{new_sdk_version} " \
+                          "| [#{ios_version}](https://github.com/RevenueCat/purchases-ios/releases/tag/#{ios_version}) " \
+                          "| [#{android_version}](https://github.com/RevenueCat/purchases-android/releases/tag/#{android_version}) " \
+                          "| [#{hybrid_common_version}](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/#{hybrid_common_version}) " \
+                          "| [#{billing_client_version}](https://developer.android.com/google/play/billing/release-notes) |\n")
           file.rewind
           file.write(lines.join)
         end

--- a/lib/fastlane/plugin/revenuecat_internal/helper/update_hybrids_versions_file_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/update_hybrids_versions_file_helper.rb
@@ -26,6 +26,15 @@ module Fastlane
         matches[0]
       end
 
+      def self.get_android_billing_client_version(android_version)
+        path = 'gradle/libs.versions.toml'
+        repo_name = 'purchases-android'
+        contents = get_contents_file_github(path, repo_name, android_version)
+        matches = contents.match('billing = "(.*)"').captures
+        UI.user_error!("Could not find android billing client version in #{repo_name} in file '#{path}'") if matches.length != 1
+        matches[0]
+      end
+
       private_class_method def self.get_contents_file_github(file_path, repo_name, ref = 'main')
         path = "/repos/revenuecat/#{repo_name}/contents/#{file_path}?ref=#{ref}"
         response = Actions::GithubApiAction.run(server_url: 'https://api.github.com',

--- a/spec/actions/update_hybrids_versions_file_action_spec.rb
+++ b/spec/actions/update_hybrids_versions_file_action_spec.rb
@@ -14,6 +14,32 @@ describe Fastlane::Actions::UpdateHybridsVersionsFileAction do
     end
 
     it 'updates versions file with correct versions' do
+      initial_value = "| Version | iOS version | Android version | common version | Android Billing Client version |\n" \
+                      "--------------------------------------------------------------------------------------------|\n" \
+                      "| 1.5.0 | 1.3.5 | 2.1.1 | 1.0.8 | |\n" \
+                      "| 1.0.0 | 1.3.4 | 2.0.1 | 1.0.5 | |\n"
+      File.write(versions_path, initial_value)
+      expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
+        .with(hybrid_common_version).and_return('2.1.2').once
+      expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
+        .with(hybrid_common_version).and_return('1.4.1').once
+      expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_billing_client_version)
+        .with('2.1.2').and_return('6.2.1').once
+      Fastlane::Actions::UpdateHybridsVersionsFileAction.run(
+        versions_file_path: versions_path,
+        new_sdk_version: '1.5.1',
+        hybrid_common_version: hybrid_common_version
+      )
+      updated_versions_content = File.read(versions_path)
+      expected_content = "| Version | iOS version | Android version | common version | Android Billing Client version |\n" \
+                         "--------------------------------------------------------------------------------------------|\n" \
+                         "| 1.5.1 | [1.4.1](https://github.com/RevenueCat/purchases-ios/releases/tag/1.4.1) | [2.1.2](https://github.com/RevenueCat/purchases-android/releases/tag/2.1.2) | [1.1.0](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/1.1.0) | [6.2.1](https://developer.android.com/google/play/billing/release-notes) |\n" \
+                         "| 1.5.0 | 1.3.5 | 2.1.1 | 1.0.8 | |\n" \
+                         "| 1.0.0 | 1.3.4 | 2.0.1 | 1.0.5 | |\n"
+      expect(updated_versions_content).to eq(expected_content)
+    end
+
+    it 'updates versions file with correct versions if android billing client column does not exist' do
       initial_value = "| Version | iOS version | Android version | common version |\n" \
                       "------------------------------------------------------------\n" \
                       "| 1.5.0 | 1.3.5 | 2.1.1 | 1.0.8 |\n" \
@@ -23,17 +49,19 @@ describe Fastlane::Actions::UpdateHybridsVersionsFileAction do
         .with(hybrid_common_version).and_return('2.1.2').once
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
         .with(hybrid_common_version).and_return('1.4.1').once
+      expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_billing_client_version)
+        .with('2.1.2').and_return('6.2.1').once
       Fastlane::Actions::UpdateHybridsVersionsFileAction.run(
         versions_file_path: versions_path,
         new_sdk_version: '1.5.1',
         hybrid_common_version: hybrid_common_version
       )
       updated_versions_content = File.read(versions_path)
-      expected_content = "| Version | iOS version | Android version | common version |\n" \
-                         "------------------------------------------------------------\n" \
-                         "| 1.5.1 | 1.4.1 | 2.1.2 | 1.1.0 |\n" \
-                         "| 1.5.0 | 1.3.5 | 2.1.1 | 1.0.8 |\n" \
-                         "| 1.0.0 | 1.3.4 | 2.0.1 | 1.0.5 |\n"
+      expected_content = "| Version | iOS version | Android version | common version | Android Billing Client version |\n" \
+                         "--------------------------------------------------------------------------------------------|\n" \
+                         "| 1.5.1 | [1.4.1](https://github.com/RevenueCat/purchases-ios/releases/tag/1.4.1) | [2.1.2](https://github.com/RevenueCat/purchases-android/releases/tag/2.1.2) | [1.1.0](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/1.1.0) | [6.2.1](https://developer.android.com/google/play/billing/release-notes) |\n" \
+                         "| 1.5.0 | 1.3.5 | 2.1.1 | 1.0.8 | |\n" \
+                         "| 1.0.0 | 1.3.4 | 2.0.1 | 1.0.5 | |\n"
       expect(updated_versions_content).to eq(expected_content)
     end
 
@@ -48,22 +76,24 @@ describe Fastlane::Actions::UpdateHybridsVersionsFileAction do
     end
 
     it 'works for no previous versions added' do
-      initial_value = "| Version | iOS version | Android version | common version |\n" \
-                      "------------------------------------------------------------\n"
+      initial_value = "| Version | iOS version | Android version | common version | Android Billing Client version |\n" \
+                      "--------------------------------------------------------------------------------------------|\n"
       File.write(versions_path, initial_value)
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
         .with(hybrid_common_version).and_return('2.1.2').once
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
         .with(hybrid_common_version).and_return('1.4.1').once
+      expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_billing_client_version)
+        .with('2.1.2').and_return('6.2.1').once
       Fastlane::Actions::UpdateHybridsVersionsFileAction.run(
         versions_file_path: versions_path,
         new_sdk_version: '1.5.1',
         hybrid_common_version: hybrid_common_version
       )
       updated_versions_content = File.read(versions_path)
-      expected_content = "| Version | iOS version | Android version | common version |\n" \
-                         "------------------------------------------------------------\n" \
-                         "| 1.5.1 | 1.4.1 | 2.1.2 | 1.1.0 |\n"
+      expected_content = "| Version | iOS version | Android version | common version | Android Billing Client version |\n" \
+                         "--------------------------------------------------------------------------------------------|\n" \
+                         "| 1.5.1 | [1.4.1](https://github.com/RevenueCat/purchases-ios/releases/tag/1.4.1) | [2.1.2](https://github.com/RevenueCat/purchases-android/releases/tag/2.1.2) | [1.1.0](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/1.1.0) | [6.2.1](https://developer.android.com/google/play/billing/release-notes) |\n"
       expect(updated_versions_content).to eq(expected_content)
     end
   end

--- a/spec/actions/update_hybrids_versions_file_action_spec.rb
+++ b/spec/actions/update_hybrids_versions_file_action_spec.rb
@@ -14,8 +14,8 @@ describe Fastlane::Actions::UpdateHybridsVersionsFileAction do
     end
 
     it 'updates versions file with correct versions' do
-      initial_value = "| Version | iOS version | Android version | common version | Android Billing Client version |\n" \
-                      "--------------------------------------------------------------------------------------------|\n" \
+      initial_value = "| Version | iOS version | Android version | common version | Play Billing Library version |\n" \
+                      "------------------------------------------------------------------------------------------|\n" \
                       "| 1.5.0 | 1.3.5 | 2.1.1 | 1.0.8 | |\n" \
                       "| 1.0.0 | 1.3.4 | 2.0.1 | 1.0.5 | |\n"
       File.write(versions_path, initial_value)
@@ -31,8 +31,8 @@ describe Fastlane::Actions::UpdateHybridsVersionsFileAction do
         hybrid_common_version: hybrid_common_version
       )
       updated_versions_content = File.read(versions_path)
-      expected_content = "| Version | iOS version | Android version | common version | Android Billing Client version |\n" \
-                         "--------------------------------------------------------------------------------------------|\n" \
+      expected_content = "| Version | iOS version | Android version | common version | Play Billing Library version |\n" \
+                         "------------------------------------------------------------------------------------------|\n" \
                          "| 1.5.1 | [1.4.1](https://github.com/RevenueCat/purchases-ios/releases/tag/1.4.1) | [2.1.2](https://github.com/RevenueCat/purchases-android/releases/tag/2.1.2) | [1.1.0](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/1.1.0) | [6.2.1](https://developer.android.com/google/play/billing/release-notes) |\n" \
                          "| 1.5.0 | 1.3.5 | 2.1.1 | 1.0.8 | |\n" \
                          "| 1.0.0 | 1.3.4 | 2.0.1 | 1.0.5 | |\n"
@@ -57,8 +57,8 @@ describe Fastlane::Actions::UpdateHybridsVersionsFileAction do
         hybrid_common_version: hybrid_common_version
       )
       updated_versions_content = File.read(versions_path)
-      expected_content = "| Version | iOS version | Android version | common version | Android Billing Client version |\n" \
-                         "--------------------------------------------------------------------------------------------|\n" \
+      expected_content = "| Version | iOS version | Android version | common version | Play Billing Library version |\n" \
+                         "------------------------------------------------------------------------------------------|\n" \
                          "| 1.5.1 | [1.4.1](https://github.com/RevenueCat/purchases-ios/releases/tag/1.4.1) | [2.1.2](https://github.com/RevenueCat/purchases-android/releases/tag/2.1.2) | [1.1.0](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/1.1.0) | [6.2.1](https://developer.android.com/google/play/billing/release-notes) |\n" \
                          "| 1.5.0 | 1.3.5 | 2.1.1 | 1.0.8 | |\n" \
                          "| 1.0.0 | 1.3.4 | 2.0.1 | 1.0.5 | |\n"
@@ -76,8 +76,8 @@ describe Fastlane::Actions::UpdateHybridsVersionsFileAction do
     end
 
     it 'works for no previous versions added' do
-      initial_value = "| Version | iOS version | Android version | common version | Android Billing Client version |\n" \
-                      "--------------------------------------------------------------------------------------------|\n"
+      initial_value = "| Version | iOS version | Android version | common version | Play Billing Library version |\n" \
+                      "------------------------------------------------------------------------------------------|\n"
       File.write(versions_path, initial_value)
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
         .with(hybrid_common_version).and_return('2.1.2').once
@@ -91,8 +91,8 @@ describe Fastlane::Actions::UpdateHybridsVersionsFileAction do
         hybrid_common_version: hybrid_common_version
       )
       updated_versions_content = File.read(versions_path)
-      expected_content = "| Version | iOS version | Android version | common version | Android Billing Client version |\n" \
-                         "--------------------------------------------------------------------------------------------|\n" \
+      expected_content = "| Version | iOS version | Android version | common version | Play Billing Library version |\n" \
+                         "------------------------------------------------------------------------------------------|\n" \
                          "| 1.5.1 | [1.4.1](https://github.com/RevenueCat/purchases-ios/releases/tag/1.4.1) | [2.1.2](https://github.com/RevenueCat/purchases-android/releases/tag/2.1.2) | [1.1.0](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/1.1.0) | [6.2.1](https://developer.android.com/google/play/billing/release-notes) |\n"
       expect(updated_versions_content).to eq(expected_content)
     end


### PR DESCRIPTION
To make it easier to navigate, we want to add links to the releases in the `VERSIONS.md` file of the hybrids + what version of the billing client it uses. This PR adds both of those, so it also auto-migrates existing VERSIONS.md files with the new column

After merging this, we need to fix the `purchases-unity` job since that one already has an extra column. Just updating the `VERSIONS.md` to have the new column should be enough.