### PR TITLE
Add support for labels with `pr:` prefix

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_phc_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_phc_version_action.rb
@@ -103,7 +103,7 @@ module Fastlane
         Helper::RevenuecatInternalHelper.commit_changes_and_push_current_branch("Version bump for #{new_version_number}")
 
         pr_title = "Updates purchases-hybrid-common to #{new_version_number}"
-        labels = ['phc_dependencies']
+        labels = ['pr:phc_dependencies']
         body = pr_title
         base_branch = "main"
 

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -81,7 +81,7 @@ module Fastlane
         Helper::RevenuecatInternalHelper.commit_changes_and_push_current_branch("Version bump for #{new_version_number}")
 
         pr_title = "Release/#{new_version_number}"
-        label = 'next_release'
+        label = 'pr:next_release'
         body = changelog
 
         if automatic_release

--- a/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/create_next_snapshot_version_action.rb
@@ -19,7 +19,7 @@ module Fastlane
 
         next_version_snapshot = Helper::RevenuecatInternalHelper.calculate_next_snapshot_version(previous_version_number)
         new_branch_name = "bump/#{next_version_snapshot}"
-        label = 'next_release'
+        label = 'pr:next_release'
 
         Helper::RevenuecatInternalHelper.validate_local_config_status_for_bump(new_branch_name, github_pr_token)
 

--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -8,7 +8,7 @@ module Fastlane
 
   module Helper
     class GitHubHelper
-      SUPPORTED_PR_LABELS = %w[breaking build ci docs feat fix perf revenuecatui refactor style test next_release dependencies phc_dependencies minor].to_set
+      SUPPORTED_PR_LABELS = (%w[breaking build ci docs feat fix perf revenuecatui refactor style test next_release dependencies phc_dependencies minor].map { |label| "pr:#{label}" }).to_set
 
       def self.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch)
         if rate_limit_sleep > 0

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -264,15 +264,15 @@ module Fastlane
 
       # rubocop:disable Metrics/PerceivedComplexity
       private_class_method def self.get_section_depending_on_types_of_change(change_types)
-        if change_types.any?("pr:breaking")
+        if change_types.include?("pr:breaking")
           :breaking_changes
-        elsif change_types.any?("pr:revenuecatui")
+        elsif change_types.include?("pr:revenuecatui")
           :paywalls
-        elsif change_types.any?("pr:feat")
+        elsif change_types.include?("pr:feat")
           :new_features
-        elsif change_types.any?("pr:fix")
+        elsif change_types.include?("pr:fix")
           :fixes
-        elsif change_types.any?("pr:perf")
+        elsif change_types.include?("pr:perf")
           :performance
         elsif change_types.any? { |type| type == "pr:dependencies" || type == "pr:phc_dependencies" }
           :dependency_updates

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -15,10 +15,10 @@ module Fastlane
   }
 
   BUMP_PER_LABEL = {
-    major: %w[breaking].to_set,
-    minor: %w[feat minor].to_set,
-    patch: %w[docs fix perf dependencies phc_dependencies revenuecatui].to_set,
-    skip: %w[build ci refactor style test next_release].to_set
+    major: %w[pr:breaking].to_set,
+    minor: %w[pr:feat pr:minor].to_set,
+    patch: %w[pr:docs pr:fix pr:perf pr:dependencies pr:phc_dependencies pr:revenuecatui].to_set,
+    skip: %w[pr:build pr:ci pr:refactor pr:style pr:test pr:next_release].to_set
   }
 
   module Helper
@@ -66,12 +66,12 @@ module Fastlane
             message = "#{item['title']} (##{item['number']})"
             username = item["user"]["login"]
             types_of_change = get_type_of_change_from_pr_info(item)
-            next if types_of_change.include?("next_release")
+            next if types_of_change.include?("pr:next_release")
 
             section = get_section_depending_on_types_of_change(types_of_change)
 
             line = "* #{message} via #{name} (@#{username})"
-            if types_of_change.include?("phc_dependencies")
+            if types_of_change.include?("pr:phc_dependencies")
               # Append links to native releases
               line += native_releases_links(github_token, hybrid_common_version, versions_file_path)
             end
@@ -264,17 +264,17 @@ module Fastlane
 
       # rubocop:disable Metrics/PerceivedComplexity
       private_class_method def self.get_section_depending_on_types_of_change(change_types)
-        if change_types.include?("breaking")
+        if change_types.any?("pr:breaking")
           :breaking_changes
-        elsif change_types.include?("revenuecatui")
+        elsif change_types.any?("pr:revenuecatui")
           :paywalls
-        elsif change_types.include?("feat")
+        elsif change_types.any?("pr:feat")
           :new_features
-        elsif change_types.include?("fix")
+        elsif change_types.any?("pr:fix")
           :fixes
-        elsif change_types.include?("perf")
+        elsif change_types.any?("pr:perf")
           :performance
-        elsif change_types.include?("dependencies") || change_types.include?("phc_dependencies")
+        elsif change_types.any? { |type| type == "pr:dependencies" || type == "pr:phc_dependencies" }
           :dependency_updates
         else
           :other

--- a/spec/actions/bump_phc_version_action_spec.rb
+++ b/spec/actions/bump_phc_version_action_spec.rb
@@ -10,7 +10,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
     let(:base_branch) { 'main' }
     let(:new_version) { '1.13.0' }
     let(:new_branch_name) { 'bump-phc/1.13.0' }
-    let(:labels) { ['phc_dependencies'] }
+    let(:labels) { ['pr:phc_dependencies'] }
 
     it 'fails if version is invalid' do
       allow(FastlaneCore::UI).to receive(:interactive?).and_return(true)
@@ -193,7 +193,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         .once
       message = "Updates purchases-hybrid-common to 1.12.1"
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr)
-        .with(message, message, mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, ['phc_dependencies'])
+        .with(message, message, mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, ['pr:phc_dependencies'])
         .once
 
       Fastlane::Actions::BumpPhcVersionAction.run(

--- a/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
+++ b/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
@@ -12,7 +12,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
     let(:base_branch) { 'main' }
     let(:new_version) { '1.13.0' }
     let(:new_branch_name) { 'release/1.13.0' }
-    let(:labels) { ['next_release'] }
+    let(:labels) { ['pr:next_release'] }
     let(:hybrid_common_version) { '4.5.3' }
     let(:versions_file_path) { '../VERSIONS.md' }
 

--- a/spec/actions/create_next_snapshot_version_action_spec.rb
+++ b/spec/actions/create_next_snapshot_version_action_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane::Actions::CreateNextSnapshotVersionAction do
     let(:base_branch) { 'main' }
     let(:next_version) { '1.13.0-SNAPSHOT' }
     let(:new_branch_name) { 'bump/1.13.0-SNAPSHOT' }
-    let(:labels) { ['next_release'] }
+    let(:labels) { ['pr:next_release'] }
 
     it 'calls all the appropriate methods with appropriate parameters' do
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:validate_local_config_status_for_bump)

--- a/spec/test_files/breaking_get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json
+++ b/spec/test_files/breaking_get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json
@@ -38,7 +38,7 @@
                     "id": 4352868120,
                     "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
                     "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/fix",
-                    "name": "fix",
+                    "name": "pr:fix",
                     "color": "8E3E6B",
                     "default": false,
                     "description": ""
@@ -47,7 +47,7 @@
                     "id": 4352868120,
                     "node_id": "LA_kwDOBnB8hc8AAAACA3N_HD",
                     "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/breaking",
-                    "name": "breaking",
+                    "name": "pr:breaking",
                     "color": "8B3E6C",
                     "default": false,
                     "description": ""

--- a/spec/test_files/get_commit_sha_0e67cdb1c7582ce3e2fd00367acc24db6242c6d6.json
+++ b/spec/test_files/get_commit_sha_0e67cdb1c7582ce3e2fd00367acc24db6242c6d6.json
@@ -38,7 +38,7 @@
                     "id": 4352868120,
                     "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
                     "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/fix",
-                    "name": "fix",
+                    "name": "pr:fix",
                     "color": "8E3E6B",
                     "default": false,
                     "description": ""

--- a/spec/test_files/get_commit_sha_1285b6df6fb756d8b31337be9dabbf3ec5c0bbfe.json
+++ b/spec/test_files/get_commit_sha_1285b6df6fb756d8b31337be9dabbf3ec5c0bbfe.json
@@ -37,8 +37,8 @@
                 {
                     "id": 2141594729,
                     "node_id": "MDU6TGFiZWwyMTQxNTk0NzI5",
-                    "url": "https://api.github.com/repos/RevenueCat/purchases-hybrid-common/labels/next_release",
-                    "name": "next_release",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-hybrid-common/labels/pr:next_release",
+                    "name": "pr:next_release",
                     "color": "e11d21",
                     "default": false,
                     "description": null

--- a/spec/test_files/get_commit_sha_1625e195a117ad0435864dc8a561e6a0c6052bdf.json
+++ b/spec/test_files/get_commit_sha_1625e195a117ad0435864dc8a561e6a0c6052bdf.json
@@ -38,7 +38,7 @@
                     "id": 4352868120,
                     "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
                     "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
-                    "name": "RevenueCatUI",
+                    "name": "pr:RevenueCatUI",
                     "color": "8E3E6B",
                     "default": false,
                     "description": ""

--- a/spec/test_files/get_commit_sha_32320acc1d6afae30a965d7add32700313123431.json
+++ b/spec/test_files/get_commit_sha_32320acc1d6afae30a965d7add32700313123431.json
@@ -37,8 +37,8 @@
                 {
                     "id": 3165687060,
                     "node_id": "MDU6TGFiZWwzMTY1Njg3MDYw",
-                    "url": "https://api.github.com/repos/RevenueCat/purchases-flutter/labels/phc_dependencies",
-                    "name": "phc_dependencies",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-flutter/labels/pr:phc_dependencies",
+                    "name": "pr:phc_dependencies",
                     "color": "0366d6",
                     "default": false,
                     "description": "Pull requests that update a dependency file"

--- a/spec/test_files/get_commit_sha_5920c32646f918a2484da8aa38ccc5e9337cc449.json
+++ b/spec/test_files/get_commit_sha_5920c32646f918a2484da8aa38ccc5e9337cc449.json
@@ -37,8 +37,8 @@
                 {
                     "id": 2141594741,
                     "node_id": "MDU6TGFiZWwyMTQxNTk0NzQx",
-                    "url": "https://api.github.com/repos/RevenueCat/purchases-flutter/labels/next_release",
-                    "name": "next_release",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-flutter/labels/pr:next_release",
+                    "name": "pr:next_release",
                     "color": "e11d21",
                     "default": false,
                     "description": null

--- a/spec/test_files/get_commit_sha_6d37c766b6da55dcab67c201c93ba3d4ca538e55.json
+++ b/spec/test_files/get_commit_sha_6d37c766b6da55dcab67c201c93ba3d4ca538e55.json
@@ -38,7 +38,7 @@
           "id": 4396681492,
           "node_id": "LA_kwDOBnB8hc8AAAABBhAJFA",
           "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/refactor",
-          "name": "refactor",
+          "name": "pr:refactor",
           "color": "e99695",
           "default": false,
           "description": "A code change that neither fixes a bug nor adds a feature"

--- a/spec/test_files/get_commit_sha_75763d3f1604aa5d633e70e46299b1f2813cb163.json
+++ b/spec/test_files/get_commit_sha_75763d3f1604aa5d633e70e46299b1f2813cb163.json
@@ -37,8 +37,8 @@
                 {
                     "id": 2141594741,
                     "node_id": "MDU6TGFiZWwyMTQxNTk0NzQx",
-                    "url": "https://api.github.com/repos/RevenueCat/purchases-flutter/labels/next_release",
-                    "name": "next_release",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-flutter/labels/pr:next_release",
+                    "name": "pr:next_release",
                     "color": "e11d21",
                     "default": false,
                     "description": null

--- a/spec/test_files/get_commit_sha_7d77decbcc9098145d1efd4c2de078b6121c8906.json
+++ b/spec/test_files/get_commit_sha_7d77decbcc9098145d1efd4c2de078b6121c8906.json
@@ -38,7 +38,7 @@
           "id": 4352868120,
           "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
           "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/fix",
-          "name": "fix",
+          "name": "pr:fix",
           "color": "8E3E6B",
           "default": false,
           "description": ""

--- a/spec/test_files/get_commit_sha_819dc620db5608fb952c852038a3560554161707.json
+++ b/spec/test_files/get_commit_sha_819dc620db5608fb952c852038a3560554161707.json
@@ -38,7 +38,7 @@
           "id": 4396672443,
           "node_id": "LA_kwDOBnB8hc8AAAABBg_luw",
           "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/ci",
-          "name": "ci",
+          "name": "pr:ci",
           "color": "506B91",
           "default": false,
           "description": "Changes to our CI configuration files and scripts"

--- a/spec/test_files/get_commit_sha_9237147947bcbce00f36ae3ab51acccc54690782.json
+++ b/spec/test_files/get_commit_sha_9237147947bcbce00f36ae3ab51acccc54690782.json
@@ -37,8 +37,8 @@
                 {
                     "id": 2141594741,
                     "node_id": "MDU6TGFiZWwyMTQxNTk0NzQx",
-                    "url": "https://api.github.com/repos/RevenueCat/purchases-flutter/labels/next_release",
-                    "name": "next_release",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-flutter/labels/pr:next_release",
+                    "name": "pr:next_release",
                     "color": "e11d21",
                     "default": false,
                     "description": null

--- a/spec/test_files/get_commit_sha_9a289e554fe384e6987b086fad047671058cf044.json
+++ b/spec/test_files/get_commit_sha_9a289e554fe384e6987b086fad047671058cf044.json
@@ -38,7 +38,7 @@
                     "id": 4352868120,
                     "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
                     "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/perf",
-                    "name": "perf",
+                    "name": "pr:perf",
                     "color": "8E3E6B",
                     "default": false,
                     "description": ""

--- a/spec/test_files/get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json
+++ b/spec/test_files/get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json
@@ -38,7 +38,7 @@
                     "id": 4352868120,
                     "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
                     "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/fix",
-                    "name": "fix",
+                    "name": "pr:fix",
                     "color": "8E3E6B",
                     "default": false,
                     "description": ""
@@ -47,7 +47,7 @@
                     "id": 4352868124,
                     "node_id": "LA_kwDOBnB8hc8AAAACA3N_HQ",
                     "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/feat",
-                    "name": "feat",
+                    "name": "pr:feat",
                     "color": "8B3E6B",
                     "default": false,
                     "description": ""

--- a/spec/test_files/get_commit_sha_cfdd80f73d8c91121313d72227b4cbe283b57c1e.json
+++ b/spec/test_files/get_commit_sha_cfdd80f73d8c91121313d72227b4cbe283b57c1e.json
@@ -37,8 +37,8 @@
                 {
                     "id": 4352868120,
                     "node_id": "LB_xwDOBnB8hc8AABACA3N_HQ",
-                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/next_release",
-                    "name": "next_release",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/pr:next_release",
+                    "name": "pr:next_release",
                     "color": "8E3A6B",
                     "default": false,
                     "description": ""

--- a/spec/test_files/minor_get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json
+++ b/spec/test_files/minor_get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json
@@ -37,8 +37,8 @@
                 {
                     "id": 4352868120,
                     "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
-                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/phc_dependencies",
-                    "name": "phc_dependencies",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/pr:phc_dependencies",
+                    "name": "pr:phc_dependencies",
                     "color": "8E3E6B",
                     "default": false,
                     "description": ""
@@ -47,7 +47,7 @@
                     "id": 4352868120,
                     "node_id": "LA_kwDOBnB8hc8AAAACA3N_HD",
                     "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/minor",
-                    "name": "minor",
+                    "name": "pr:minor",
                     "color": "8B3E6C",
                     "default": false,
                     "description": ""


### PR DESCRIPTION
We are going to add `pr:` as a prefix for Pull Request labels. This PR adds support for both versions, while we transition all repos to use `pr:` labels