### PR TITLE
Add features sections to changelog and emojis

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -8,7 +8,7 @@ module Fastlane
 
   module Helper
     class GitHubHelper
-      SUPPORTED_PR_LABELS = (%w[breaking build ci docs feat fix perf revenuecatui refactor style test next_release dependencies phc_dependencies minor].map { |label| "pr:#{label}" }).to_set
+      SUPPORTED_PR_LABELS = (%w[breaking build ci docs feat fix perf revenuecatui refactor style test next_release dependencies phc_dependencies minor revenuecatui].map { |label| "pr:#{label}" }).to_set
 
       def self.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch)
         if rate_limit_sleep > 0

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -249,25 +249,25 @@ module Fastlane
 
           case section_name
           when :breaking_changes
-            title = "### Breaking Changes"
+            title = "### 💥 Breaking Changes"
           when :fixes
-            title = "### Bugfixes"
+            title = "### 🐞 Bugfixes"
           when :new_features
-            title = "### New Features"
+            title = "### ✨ New Features"
           when :paywalls
-            title = "### RevenueCatUI"
+            title = "### 🖼️ RevenueCatUI"
           when :performance
-            title = "### Performance Improvements"
+            title = "### ⚡ Performance Improvements"
           when :dependency_updates
-            title = "### Dependency Updates"
+            title = "### 📦 Dependency Updates"
           when :work_in_progress
-            title = "### Work in Progress"
+            title = "### 🚧 Work in Progress"
             wip_sections = prs.map do |subsection, items|
               capitalized_subsection = subsection.split.map(&:capitalize).join(' ')
               "#### #{capitalized_subsection}\n#{items.join("\n")}"
             end
           else
-            title = "### Other Changes"
+            title = "### 🔄 Other Changes"
           end
           if section_name == :work_in_progress
             lines = wip_sections

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -133,15 +133,17 @@ describe Fastlane::Helper::VersioningHelper do
         nil,
         nil
       )
-      expect(changelog).to eq("### ✨ New Features\n" \
+      expect(changelog).to eq("## RevenueCat SDK\n" \
+                              "### ✨ New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
                               "### 🐞 Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
+                              "## RevenueCatUI SDK\n" \
                               "### 🖼 Paywalls\n" \
                               "#### ✨ New Features\n" \
-                              "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
+                              "* `Paywalls`: multi-package horizontal template (#2949) via Toni Rico (@tonidero)\n" \
                               "### 🔄 Other Changes\n" \
-                              "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Nacho Soto (@nachosoto)")
+                              "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Toni Rico (@tonidero)")
     end
 
     it 'generates changelog automatically from github commits including feat section' do
@@ -156,8 +158,10 @@ describe Fastlane::Helper::VersioningHelper do
         nil,
         nil
       )
-      expect(changelog).to eq("### ✨ New Features\n" \
+      expect(changelog).to eq("## RevenueCat SDK\n" \
+                              "### ✨ New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
+                              "## RevenueCatUI SDK\n" \
                               "### Customer Center\n" \
                               "#### ✨ New Features\n" \
                               "* `Customer Center`: contact support (#2949) via aboedo (@nachosoto)\n" \
@@ -166,7 +170,6 @@ describe Fastlane::Helper::VersioningHelper do
                               "### Paywall Components\n" \
                               "#### ✨ New Features\n" \
                               "* `Paywalls Components`: this is amazing (#2949) via aboedo (@nachosoto)\n" \
-                              "### 🔄 Other Changes\n" \
                               "* `Paywalls Components`: another amazing thing (#2949) via aboedo (@nachosoto)")
     end
 
@@ -186,7 +189,8 @@ describe Fastlane::Helper::VersioningHelper do
         hybrid_common_version,
         versions_path
       )
-      expect(changelog).to eq("### 📦 Dependency Updates\n" \
+      expect(changelog).to eq("## RevenueCat SDK\n" \
+                              "### 📦 Dependency Updates\n" \
                               "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.3 (#553) via RevenueCat Git Bot (@RCGitBot)\n" \
                               "\s\s* [Android 5.6.6](https://github.com/RevenueCat/purchases-android/releases/tag/5.6.6)\n" \
                               "\s\s* [iOS 4.15.4](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.4)\n" \
@@ -210,7 +214,8 @@ describe Fastlane::Helper::VersioningHelper do
         hybrid_common_version,
         unity_versions_path
       )
-      expect(changelog).to eq("### 📦 Dependency Updates\n" \
+      expect(changelog).to eq("## RevenueCat SDK\n" \
+                              "### 📦 Dependency Updates\n" \
                               "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.3 (#553) via RevenueCat Git Bot (@RCGitBot)\n" \
                               "\s\s* [Android 5.6.6](https://github.com/RevenueCat/purchases-android/releases/tag/5.6.6)\n" \
                               "\s\s* [iOS 4.15.4](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.4)\n" \
@@ -232,7 +237,8 @@ describe Fastlane::Helper::VersioningHelper do
         hybrid_common_version,
         empty_versions_path
       )
-      expect(changelog).to eq("### 📦 Dependency Updates\n" \
+      expect(changelog).to eq("## RevenueCat SDK\n" \
+                              "### 📦 Dependency Updates\n" \
                               "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.3 (#553) via RevenueCat Git Bot (@RCGitBot)")
     end
 
@@ -251,7 +257,8 @@ describe Fastlane::Helper::VersioningHelper do
         hybrid_common_version,
         broken_versions_path
       )
-      expect(changelog).to eq("### 📦 Dependency Updates\n" \
+      expect(changelog).to eq("## RevenueCat SDK\n" \
+                              "### 📦 Dependency Updates\n" \
                               "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.3 (#553) via RevenueCat Git Bot (@RCGitBot)")
     end
 
@@ -278,7 +285,8 @@ describe Fastlane::Helper::VersioningHelper do
         hybrid_common_version,
         versions_path
       )
-      expect(changelog).to eq("### 📦 Dependency Updates\n" \
+      expect(changelog).to eq("## RevenueCat SDK\n" \
+                              "### 📦 Dependency Updates\n" \
                               "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.3 (#553) via RevenueCat Git Bot (@RCGitBot)\n" \
                               "\s\s* [iOS 4.15.4](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.4)\n" \
                               "\s\s* [iOS 4.15.3](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.3)")
@@ -307,7 +315,8 @@ describe Fastlane::Helper::VersioningHelper do
         hybrid_common_version,
         versions_path
       )
-      expect(changelog).to eq("### 📦 Dependency Updates\n" \
+      expect(changelog).to eq("## RevenueCat SDK\n" \
+                              "### 📦 Dependency Updates\n" \
                               "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.3 (#553) via RevenueCat Git Bot (@RCGitBot)")
     end
 
@@ -322,15 +331,17 @@ describe Fastlane::Helper::VersioningHelper do
         nil,
         nil
       )
-      expect(changelog).to eq("### ✨ New Features\n" \
+      expect(changelog).to eq("## RevenueCat SDK\n" \
+                              "### ✨ New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
                               "### 🐞 Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
+                              "## RevenueCatUI SDK\n" \
                               "### 🖼 Paywalls\n" \
                               "#### ✨ New Features\n" \
-                              "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
+                              "* `Paywalls`: multi-package horizontal template (#2949) via Toni Rico (@tonidero)\n" \
                               "### 🔄 Other Changes\n" \
-                              "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Nacho Soto (@nachosoto)")
+                              "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Toni Rico (@tonidero)")
     end
 
     it 'fails if it finds multiple commits with same sha' do
@@ -372,15 +383,17 @@ describe Fastlane::Helper::VersioningHelper do
         nil,
         nil
       )
-      expect(changelog).to eq("### 💥 Breaking Changes\n" \
+      expect(changelog).to eq("## RevenueCat SDK\n" \
+                              "### 💥 Breaking Changes\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
                               "### 🐞 Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
+                              "## RevenueCatUI SDK\n" \
                               "### 🖼 Paywalls\n" \
                               "#### ✨ New Features\n" \
-                              "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
+                              "* `Paywalls`: multi-package horizontal template (#2949) via Toni Rico (@tonidero)\n" \
                               "### 🔄 Other Changes\n" \
-                              "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Nacho Soto (@nachosoto)")
+                              "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Toni Rico (@tonidero)")
     end
 
     it 'change is classified as Other Changes if pr has no label' do
@@ -401,13 +414,15 @@ describe Fastlane::Helper::VersioningHelper do
         nil,
         nil
       )
-      expect(changelog).to eq("### 🐞 Bugfixes\n" \
+      expect(changelog).to eq("## RevenueCat SDK\n" \
+                              "### 🐞 Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
+                              "## RevenueCatUI SDK\n" \
                               "### 🖼 Paywalls\n" \
                               "#### ✨ New Features\n" \
-                              "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
+                              "* `Paywalls`: multi-package horizontal template (#2949) via Toni Rico (@tonidero)\n" \
                               "### 🔄 Other Changes\n" \
-                              "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Nacho Soto (@nachosoto)\n" \
+                              "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Toni Rico (@tonidero)\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)")
     end
 

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -20,8 +20,8 @@ describe Fastlane::Helper::VersioningHelper do
     let(:get_commits_response) do
       { body: File.read("#{File.dirname(__FILE__)}/../test_files/get_commits_since_last_release.json") }
     end
-    let(:get_commits_response_wip) do
-      { body: File.read("#{File.dirname(__FILE__)}/../test_files/get_commits_since_last_release_wip.json") }
+    let(:get_commits_response_features) do
+      { body: File.read("#{File.dirname(__FILE__)}/../test_files/get_commits_since_last_release_features.json") }
     end
     let(:get_commit_1_response) do
       { body: File.read("#{File.dirname(__FILE__)}/../test_files/get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json") }
@@ -46,6 +46,9 @@ describe Fastlane::Helper::VersioningHelper do
     end
     let(:get_commit_8_response) do
       { body: File.read("#{File.dirname(__FILE__)}/../test_files/get_commit_sha_4625e195a117ad0435864dc8a561e6a0c6052bdd.json") }
+    end
+    let(:get_commit_9_response) do
+      { body: File.read("#{File.dirname(__FILE__)}/../test_files/get_commit_sha_5625e195a117ad0435864dc8a561e6a0c6052bda.json") }
     end
     let(:get_commit_923_response) do
       { body: File.read("#{File.dirname(__FILE__)}/../test_files/get_commit_sha_9237147947bcbce00f36ae3ab51acccc54690782.json") }
@@ -105,7 +108,8 @@ describe Fastlane::Helper::VersioningHelper do
         'cfdd80f73d8c91121313d72227b4cbe283b57c1e' => get_commit_3_response,
         '3625e195a117ad0435864dc8a561e6a0c6052bdf' => get_commit_6_response,
         '2625e195a117ad0435864dc8a561e6a0c6052bda' => get_commit_7_response,
-        '4625e195a117ad0435864dc8a561e6a0c6052bdd' => get_commit_8_response
+        '4625e195a117ad0435864dc8a561e6a0c6052bdd' => get_commit_8_response,
+        '5625e195a117ad0435864dc8a561e6a0c6052bda' => get_commit_9_response
       }
     end
 
@@ -134,13 +138,14 @@ describe Fastlane::Helper::VersioningHelper do
                               "### 🐞 Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
                               "### 🖼 Paywalls\n" \
+                              "#### ✨ New Features\n" \
                               "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
                               "### 🔄 Other Changes\n" \
                               "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Nacho Soto (@nachosoto)")
     end
 
     it 'generates changelog automatically from github commits including feat section' do
-      setup_commit_search_stubs(hashes_to_responses_wip, get_commits_response_wip)
+      setup_commit_search_stubs(hashes_to_responses_wip, get_commits_response_features)
 
       expect_any_instance_of(Object).not_to receive(:sleep)
       changelog = Fastlane::Helper::VersioningHelper.auto_generate_changelog(
@@ -154,9 +159,14 @@ describe Fastlane::Helper::VersioningHelper do
       expect(changelog).to eq("### ✨ New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
                               "### Customer Center\n" \
+                              "#### ✨ New Features\n" \
                               "* `Customer Center`: contact support (#2949) via aboedo (@nachosoto)\n" \
+                              "#### 🐞 Bugfixes\n" \
+                              "* `Customer Center`: a fix (#2949) via aboedo (@nachosoto)\n" \
                               "### Paywall Components\n" \
+                              "#### ✨ New Features\n" \
                               "* `Paywalls Components`: this is amazing (#2949) via aboedo (@nachosoto)\n" \
+                              "### 🔄 Other Changes\n" \
                               "* `Paywalls Components`: another amazing thing (#2949) via aboedo (@nachosoto)")
     end
 
@@ -317,6 +327,7 @@ describe Fastlane::Helper::VersioningHelper do
                               "### 🐞 Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
                               "### 🖼 Paywalls\n" \
+                              "#### ✨ New Features\n" \
                               "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
                               "### 🔄 Other Changes\n" \
                               "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Nacho Soto (@nachosoto)")
@@ -366,6 +377,7 @@ describe Fastlane::Helper::VersioningHelper do
                               "### 🐞 Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
                               "### 🖼 Paywalls\n" \
+                              "#### ✨ New Features\n" \
                               "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
                               "### 🔄 Other Changes\n" \
                               "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Nacho Soto (@nachosoto)")
@@ -392,6 +404,7 @@ describe Fastlane::Helper::VersioningHelper do
       expect(changelog).to eq("### 🐞 Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
                               "### 🖼 Paywalls\n" \
+                              "#### ✨ New Features\n" \
                               "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
                               "### 🔄 Other Changes\n" \
                               "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Nacho Soto (@nachosoto)\n" \

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -137,11 +137,11 @@ describe Fastlane::Helper::VersioningHelper do
                               "### ✨ New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
                               "### 🐞 Bugfixes\n" \
-                              "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
+                              "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n\n" \
                               "## RevenueCatUI SDK\n" \
                               "### 🖼 Paywalls\n" \
                               "#### ✨ New Features\n" \
-                              "* `Paywalls`: multi-package horizontal template (#2949) via Toni Rico (@tonidero)\n" \
+                              "* `Paywalls`: multi-package horizontal template (#2949) via Toni Rico (@tonidero)\n\n" \
                               "### 🔄 Other Changes\n" \
                               "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Toni Rico (@tonidero)")
     end
@@ -160,7 +160,7 @@ describe Fastlane::Helper::VersioningHelper do
       )
       expect(changelog).to eq("## RevenueCat SDK\n" \
                               "### ✨ New Features\n" \
-                              "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
+                              "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n\n" \
                               "## RevenueCatUI SDK\n" \
                               "### Customer Center\n" \
                               "#### ✨ New Features\n" \
@@ -335,11 +335,11 @@ describe Fastlane::Helper::VersioningHelper do
                               "### ✨ New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
                               "### 🐞 Bugfixes\n" \
-                              "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
+                              "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n\n" \
                               "## RevenueCatUI SDK\n" \
                               "### 🖼 Paywalls\n" \
                               "#### ✨ New Features\n" \
-                              "* `Paywalls`: multi-package horizontal template (#2949) via Toni Rico (@tonidero)\n" \
+                              "* `Paywalls`: multi-package horizontal template (#2949) via Toni Rico (@tonidero)\n\n" \
                               "### 🔄 Other Changes\n" \
                               "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Toni Rico (@tonidero)")
     end
@@ -387,11 +387,11 @@ describe Fastlane::Helper::VersioningHelper do
                               "### 💥 Breaking Changes\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
                               "### 🐞 Bugfixes\n" \
-                              "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
+                              "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n\n" \
                               "## RevenueCatUI SDK\n" \
                               "### 🖼 Paywalls\n" \
                               "#### ✨ New Features\n" \
-                              "* `Paywalls`: multi-package horizontal template (#2949) via Toni Rico (@tonidero)\n" \
+                              "* `Paywalls`: multi-package horizontal template (#2949) via Toni Rico (@tonidero)\n\n" \
                               "### 🔄 Other Changes\n" \
                               "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Toni Rico (@tonidero)")
     end
@@ -416,11 +416,11 @@ describe Fastlane::Helper::VersioningHelper do
       )
       expect(changelog).to eq("## RevenueCat SDK\n" \
                               "### 🐞 Bugfixes\n" \
-                              "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
+                              "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n\n" \
                               "## RevenueCatUI SDK\n" \
                               "### 🖼 Paywalls\n" \
                               "#### ✨ New Features\n" \
-                              "* `Paywalls`: multi-package horizontal template (#2949) via Toni Rico (@tonidero)\n" \
+                              "* `Paywalls`: multi-package horizontal template (#2949) via Toni Rico (@tonidero)\n\n" \
                               "### 🔄 Other Changes\n" \
                               "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Toni Rico (@tonidero)\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)")

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -129,13 +129,13 @@ describe Fastlane::Helper::VersioningHelper do
         nil,
         nil
       )
-      expect(changelog).to eq("### New Features\n" \
+      expect(changelog).to eq("### ✨ New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
-                              "### RevenueCatUI\n" \
+                              "### 🖼️ RevenueCatUI\n" \
                               "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
-                              "### Bugfixes\n" \
+                              "### 🐞 Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
-                              "### Performance Improvements\n" \
+                              "### ⚡ Performance Improvements\n" \
                               "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Nacho Soto (@nachosoto)")
     end
 
@@ -151,9 +151,9 @@ describe Fastlane::Helper::VersioningHelper do
         nil,
         nil
       )
-      expect(changelog).to eq("### New Features\n" \
+      expect(changelog).to eq("### ✨ New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
-                              "### Work in Progress\n" \
+                              "### 🚧 Work in Progress\n" \
                               "#### Customer Center\n" \
                               "* `Customer Center`: contact support (#2949) via aboedo (@nachosoto)\n" \
                               "#### Paywall Components\n" \
@@ -177,7 +177,7 @@ describe Fastlane::Helper::VersioningHelper do
         hybrid_common_version,
         versions_path
       )
-      expect(changelog).to eq("### Dependency Updates\n" \
+      expect(changelog).to eq("### 📦 Dependency Updates\n" \
                               "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.3 (#553) via RevenueCat Git Bot (@RCGitBot)\n" \
                               "\s\s* [Android 5.6.6](https://github.com/RevenueCat/purchases-android/releases/tag/5.6.6)\n" \
                               "\s\s* [iOS 4.15.4](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.4)\n" \
@@ -201,7 +201,7 @@ describe Fastlane::Helper::VersioningHelper do
         hybrid_common_version,
         unity_versions_path
       )
-      expect(changelog).to eq("### Dependency Updates\n" \
+      expect(changelog).to eq("### 📦 Dependency Updates\n" \
                               "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.3 (#553) via RevenueCat Git Bot (@RCGitBot)\n" \
                               "\s\s* [Android 5.6.6](https://github.com/RevenueCat/purchases-android/releases/tag/5.6.6)\n" \
                               "\s\s* [iOS 4.15.4](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.4)\n" \
@@ -223,7 +223,7 @@ describe Fastlane::Helper::VersioningHelper do
         hybrid_common_version,
         empty_versions_path
       )
-      expect(changelog).to eq("### Dependency Updates\n" \
+      expect(changelog).to eq("### 📦 Dependency Updates\n" \
                               "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.3 (#553) via RevenueCat Git Bot (@RCGitBot)")
     end
 
@@ -242,7 +242,7 @@ describe Fastlane::Helper::VersioningHelper do
         hybrid_common_version,
         broken_versions_path
       )
-      expect(changelog).to eq("### Dependency Updates\n" \
+      expect(changelog).to eq("### 📦 Dependency Updates\n" \
                               "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.3 (#553) via RevenueCat Git Bot (@RCGitBot)")
     end
 
@@ -269,7 +269,7 @@ describe Fastlane::Helper::VersioningHelper do
         hybrid_common_version,
         versions_path
       )
-      expect(changelog).to eq("### Dependency Updates\n" \
+      expect(changelog).to eq("### 📦 Dependency Updates\n" \
                               "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.3 (#553) via RevenueCat Git Bot (@RCGitBot)\n" \
                               "\s\s* [iOS 4.15.4](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.4)\n" \
                               "\s\s* [iOS 4.15.3](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.3)")
@@ -298,7 +298,7 @@ describe Fastlane::Helper::VersioningHelper do
         hybrid_common_version,
         versions_path
       )
-      expect(changelog).to eq("### Dependency Updates\n" \
+      expect(changelog).to eq("### 📦 Dependency Updates\n" \
                               "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.3 (#553) via RevenueCat Git Bot (@RCGitBot)")
     end
 
@@ -313,13 +313,13 @@ describe Fastlane::Helper::VersioningHelper do
         nil,
         nil
       )
-      expect(changelog).to eq("### New Features\n" \
+      expect(changelog).to eq("### ✨ New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
-                              "### RevenueCatUI\n" \
+                              "### 🖼️ RevenueCatUI\n" \
                               "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
-                              "### Bugfixes\n" \
+                              "### 🐞 Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
-                              "### Performance Improvements\n" \
+                              "### ⚡ Performance Improvements\n" \
                               "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Nacho Soto (@nachosoto)")
     end
 
@@ -362,13 +362,13 @@ describe Fastlane::Helper::VersioningHelper do
         nil,
         nil
       )
-      expect(changelog).to eq("### Breaking Changes\n" \
+      expect(changelog).to eq("### 💥 Breaking Changes\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
-                              "### RevenueCatUI\n" \
+                              "### 🖼️ RevenueCatUI\n" \
                               "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
-                              "### Bugfixes\n" \
+                              "### 🐞 Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
-                              "### Performance Improvements\n" \
+                              "### ⚡ Performance Improvements\n" \
                               "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Nacho Soto (@nachosoto)")
     end
 
@@ -390,13 +390,13 @@ describe Fastlane::Helper::VersioningHelper do
         nil,
         nil
       )
-      expect(changelog).to eq("### RevenueCatUI\n" \
+      expect(changelog).to eq("### 🖼️ RevenueCatUI\n" \
                               "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
-                              "### Bugfixes\n" \
+                              "### 🐞 Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
-                              "### Performance Improvements\n" \
+                              "### ⚡ Performance Improvements\n" \
                               "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Nacho Soto (@nachosoto)\n" \
-                              "### Other Changes\n" \
+                              "### 🔄 Other Changes\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)")
     end
 
@@ -420,7 +420,7 @@ describe Fastlane::Helper::VersioningHelper do
         nil,
         nil
       )
-      expect(changelog).to eq("### Other Changes\n" \
+      expect(changelog).to eq("### 🔄 Other Changes\n" \
                               "* Updating great support link via Miguel José Carranza Guisado (@MiguelCarranza)")
     end
 

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -131,15 +131,15 @@ describe Fastlane::Helper::VersioningHelper do
       )
       expect(changelog).to eq("### ✨ New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
-                              "### 🖼️ RevenueCatUI\n" \
-                              "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
                               "### 🐞 Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
-                              "### ⚡ Performance Improvements\n" \
+                              "### 🖼 Paywalls\n" \
+                              "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
+                              "### 🔄 Other Changes\n" \
                               "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Nacho Soto (@nachosoto)")
     end
 
-    it 'generates changelog automatically from github commits including wip section' do
+    it 'generates changelog automatically from github commits including feat section' do
       setup_commit_search_stubs(hashes_to_responses_wip, get_commits_response_wip)
 
       expect_any_instance_of(Object).not_to receive(:sleep)
@@ -153,10 +153,9 @@ describe Fastlane::Helper::VersioningHelper do
       )
       expect(changelog).to eq("### ✨ New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
-                              "### 🚧 Work in Progress\n" \
-                              "#### Customer Center\n" \
+                              "### Customer Center\n" \
                               "* `Customer Center`: contact support (#2949) via aboedo (@nachosoto)\n" \
-                              "#### Paywall Components\n" \
+                              "### Paywall Components\n" \
                               "* `Paywalls Components`: this is amazing (#2949) via aboedo (@nachosoto)\n" \
                               "* `Paywalls Components`: another amazing thing (#2949) via aboedo (@nachosoto)")
     end
@@ -315,11 +314,11 @@ describe Fastlane::Helper::VersioningHelper do
       )
       expect(changelog).to eq("### ✨ New Features\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
-                              "### 🖼️ RevenueCatUI\n" \
-                              "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
                               "### 🐞 Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
-                              "### ⚡ Performance Improvements\n" \
+                              "### 🖼 Paywalls\n" \
+                              "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
+                              "### 🔄 Other Changes\n" \
                               "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Nacho Soto (@nachosoto)")
     end
 
@@ -364,11 +363,11 @@ describe Fastlane::Helper::VersioningHelper do
       )
       expect(changelog).to eq("### 💥 Breaking Changes\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)\n" \
-                              "### 🖼️ RevenueCatUI\n" \
-                              "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
                               "### 🐞 Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
-                              "### ⚡ Performance Improvements\n" \
+                              "### 🖼 Paywalls\n" \
+                              "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
+                              "### 🔄 Other Changes\n" \
                               "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Nacho Soto (@nachosoto)")
     end
 
@@ -390,13 +389,12 @@ describe Fastlane::Helper::VersioningHelper do
         nil,
         nil
       )
-      expect(changelog).to eq("### 🖼️ RevenueCatUI\n" \
-                              "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
-                              "### 🐞 Bugfixes\n" \
+      expect(changelog).to eq("### 🐞 Bugfixes\n" \
                               "* Fix replace version without prerelease modifiers (#1751) via Toni Rico (@tonidero)\n" \
-                              "### ⚡ Performance Improvements\n" \
-                              "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Nacho Soto (@nachosoto)\n" \
+                              "### 🖼 Paywalls\n" \
+                              "* `Paywalls`: multi-package horizontal template (#2949) via Nacho Soto (@nachosoto)\n" \
                               "### 🔄 Other Changes\n" \
+                              "* `PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key (#2199) via Nacho Soto (@nachosoto)\n" \
                               "* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)")
     end
 

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -140,17 +140,7 @@ describe Fastlane::Helper::VersioningHelper do
     end
 
     it 'generates changelog automatically from github commits including wip section' do
-      setup_tag_stubs
-      mock_commits_since_last_release('cfdd80f73d8c91121313d72227b4cbe283b57c1e', get_commits_response_wip)
-      hashes_to_responses_wip.each do |hash, response|
-        allow(Fastlane::Actions::GithubApiAction).to receive(:run)
-          .with(server_url: server_url,
-                path: "/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:main+SHA:#{hash}",
-                http_method: http_method,
-                body: {},
-                api_token: 'mock-github-token')
-          .and_return(response)
-      end
+      setup_commit_search_stubs(hashes_to_responses_wip, get_commits_response_wip)
 
       expect_any_instance_of(Object).not_to receive(:sleep)
       changelog = Fastlane::Helper::VersioningHelper.auto_generate_changelog(
@@ -172,18 +162,8 @@ describe Fastlane::Helper::VersioningHelper do
     end
 
     it 'includes native dependencies links automatically' do
-      setup_tag_stubs
-      mock_commits_since_last_release("9237147947bcbce00f36ae3ab51acccc54690782", get_commits_response_hybrid)
       mock_native_releases
-      hashes_to_responses_hybrid.each do |hash, response|
-        allow(Fastlane::Actions::GithubApiAction).to receive(:run)
-          .with(server_url: server_url,
-                path: "/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:main+SHA:#{hash}",
-                http_method: http_method,
-                body: {},
-                api_token: 'mock-github-token')
-          .and_return(response)
-      end
+      setup_commit_search_stubs(hashes_to_responses_hybrid, get_commits_response_hybrid, "9237147947bcbce00f36ae3ab51acccc54690782")
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
         .with(hybrid_common_version).and_return('5.6.6').once
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
@@ -205,18 +185,9 @@ describe Fastlane::Helper::VersioningHelper do
     end
 
     it 'includes native dependencies links automatically. Also works for unity style VERSIONS.md' do
-      setup_tag_stubs
-      mock_commits_since_last_release("9237147947bcbce00f36ae3ab51acccc54690782", get_commits_response_hybrid)
       mock_native_releases
-      hashes_to_responses_hybrid.each do |hash, response|
-        allow(Fastlane::Actions::GithubApiAction).to receive(:run)
-          .with(server_url: server_url,
-                path: "/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:main+SHA:#{hash}",
-                http_method: http_method,
-                body: {},
-                api_token: 'mock-github-token')
-          .and_return(response)
-      end
+      setup_commit_search_stubs(hashes_to_responses_hybrid, get_commits_response_hybrid, "9237147947bcbce00f36ae3ab51acccc54690782")
+
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
         .with(hybrid_common_version).and_return('5.6.6').once
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
@@ -238,20 +209,11 @@ describe Fastlane::Helper::VersioningHelper do
     end
 
     it 'handles empty VERSIONS.md' do
-      setup_tag_stubs
       expect(FastlaneCore::UI).to receive(:error)
         .with("Can't detect iOS and Android version for version 4.5.3 of purchases-hybrid-common. Empty VERSIONS.md")
         .once
-      mock_commits_since_last_release("9237147947bcbce00f36ae3ab51acccc54690782", get_commits_response_hybrid)
-      hashes_to_responses_hybrid.each do |hash, response|
-        allow(Fastlane::Actions::GithubApiAction).to receive(:run)
-          .with(server_url: server_url,
-                path: "/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:main+SHA:#{hash}",
-                http_method: http_method,
-                body: {},
-                api_token: 'mock-github-token')
-          .and_return(response)
-      end
+      setup_commit_search_stubs(hashes_to_responses_hybrid, get_commits_response_hybrid, "9237147947bcbce00f36ae3ab51acccc54690782")
+
       expect_any_instance_of(Object).not_to receive(:sleep)
       changelog = Fastlane::Helper::VersioningHelper.auto_generate_changelog(
         'mock-repo-name',
@@ -266,20 +228,11 @@ describe Fastlane::Helper::VersioningHelper do
     end
 
     it 'handles broken VERSIONS.md' do
-      setup_tag_stubs
       expect(FastlaneCore::UI).to receive(:error)
         .with("Malformed iOS version - for version 4.5.3 of purchases-hybrid-common.")
         .once
-      mock_commits_since_last_release("9237147947bcbce00f36ae3ab51acccc54690782", get_commits_response_hybrid)
-      hashes_to_responses_hybrid.each do |hash, response|
-        allow(Fastlane::Actions::GithubApiAction).to receive(:run)
-          .with(server_url: server_url,
-                path: "/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:main+SHA:#{hash}",
-                http_method: http_method,
-                body: {},
-                api_token: 'mock-github-token')
-          .and_return(response)
-      end
+      setup_commit_search_stubs(hashes_to_responses_hybrid, get_commits_response_hybrid, "9237147947bcbce00f36ae3ab51acccc54690782")
+
       expect_any_instance_of(Object).not_to receive(:sleep)
       changelog = Fastlane::Helper::VersioningHelper.auto_generate_changelog(
         'mock-repo-name',
@@ -295,18 +248,9 @@ describe Fastlane::Helper::VersioningHelper do
 
     it 'includes native dependencies links automatically. only includes new versions' do
       hybrid_common_version = '4.5.3'
-      setup_tag_stubs
-      mock_commits_since_last_release("9237147947bcbce00f36ae3ab51acccc54690782", get_commits_response_hybrid)
       mock_native_releases
-      hashes_to_responses_hybrid.each do |hash, response|
-        allow(Fastlane::Actions::GithubApiAction).to receive(:run)
-          .with(server_url: server_url,
-                path: "/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:main+SHA:#{hash}",
-                http_method: http_method,
-                body: {},
-                api_token: 'mock-github-token')
-          .and_return(response)
-      end
+      setup_commit_search_stubs(hashes_to_responses_hybrid, get_commits_response_hybrid, "9237147947bcbce00f36ae3ab51acccc54690782")
+
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
         .with(hybrid_common_version).and_return('5.6.6').once
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
@@ -333,18 +277,9 @@ describe Fastlane::Helper::VersioningHelper do
 
     it 'includes native dependencies links automatically. skips if no updates to native' do
       hybrid_common_version = '4.5.3'
-      setup_tag_stubs
-      mock_commits_since_last_release("9237147947bcbce00f36ae3ab51acccc54690782", get_commits_response_hybrid)
       mock_native_releases
-      hashes_to_responses_hybrid.each do |hash, response|
-        allow(Fastlane::Actions::GithubApiAction).to receive(:run)
-          .with(server_url: server_url,
-                path: "/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:main+SHA:#{hash}",
-                http_method: http_method,
-                body: {},
-                api_token: 'mock-github-token')
-          .and_return(response)
-      end
+      setup_commit_search_stubs(hashes_to_responses_hybrid, get_commits_response_hybrid, "9237147947bcbce00f36ae3ab51acccc54690782")
+
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
         .with(hybrid_common_version).and_return('5.6.6').once
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
@@ -1037,9 +972,11 @@ describe Fastlane::Helper::VersioningHelper do
       .and_return("0.1.0\n0.1.1\n1.11.0\n1.1.1.1\n1.1.1-alpha.1\n1.10.1")
   end
 
-  def setup_commit_search_stubs(hashes_to_responses)
+  def setup_commit_search_stubs(hashes_to_responses,
+                                commits_response = get_commits_response,
+                                last_release_sha = 'cfdd80f73d8c91121313d72227b4cbe283b57c1e')
     setup_tag_stubs
-    mock_commits_since_last_release('cfdd80f73d8c91121313d72227b4cbe283b57c1e', get_commits_response)
+    mock_commits_since_last_release(last_release_sha, commits_response)
     hashes_to_responses.each do |hash, response|
       allow(Fastlane::Actions::GithubApiAction).to receive(:run)
         .with(server_url: server_url,

--- a/spec/test_files/get_commit_sha_1625e195a117ad0435864dc8a561e6a0c6052bdf.json
+++ b/spec/test_files/get_commit_sha_1625e195a117ad0435864dc8a561e6a0c6052bdf.json
@@ -14,7 +14,7 @@
             "number": 2949,
             "title": "`Paywalls`: multi-package horizontal template",
             "user": {
-                "login": "nachosoto",
+                "login": "tonidero",
                 "id": 808417,
                 "node_id": "MDQ6VXNlcjgwODQxNw==",
                 "avatar_url": "https://avatars.githubusercontent.com/u/808417?v=4",
@@ -39,6 +39,15 @@
                     "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
                     "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
                     "name": "feat:\uD83D\uDDBC Paywalls",
+                    "color": "8E3E6B",
+                    "default": false,
+                    "description": ""
+                },
+                {
+                    "id": 4352868120,
+                    "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
+                    "name": "pr:revenuecatui",
                     "color": "8E3E6B",
                     "default": false,
                     "description": ""

--- a/spec/test_files/get_commit_sha_1625e195a117ad0435864dc8a561e6a0c6052bdf.json
+++ b/spec/test_files/get_commit_sha_1625e195a117ad0435864dc8a561e6a0c6052bdf.json
@@ -38,7 +38,16 @@
                     "id": 4352868120,
                     "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
                     "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
-                    "name": "pr:RevenueCatUI",
+                    "name": "feat:\uD83D\uDDBC Paywalls",
+                    "color": "8E3E6B",
+                    "default": false,
+                    "description": ""
+                },
+                {
+                    "id": 4352868121,
+                    "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
+                    "name": "pr:feat",
                     "color": "8E3E6B",
                     "default": false,
                     "description": ""

--- a/spec/test_files/get_commit_sha_2625e195a117ad0435864dc8a561e6a0c6052bda.json
+++ b/spec/test_files/get_commit_sha_2625e195a117ad0435864dc8a561e6a0c6052bda.json
@@ -47,6 +47,15 @@
                     "id": 4352868120,
                     "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
                     "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
+                    "name": "pr:revenuecatui",
+                    "color": "8E3E6B",
+                    "default": false,
+                    "description": ""
+                },
+                {
+                    "id": 4352868120,
+                    "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
                     "name": "pr:feat",
                     "color": "8E3E6B",
                     "default": false,

--- a/spec/test_files/get_commit_sha_2625e195a117ad0435864dc8a561e6a0c6052bda.json
+++ b/spec/test_files/get_commit_sha_2625e195a117ad0435864dc8a561e6a0c6052bda.json
@@ -1,0 +1,85 @@
+{
+    "total_count": 1,
+    "incomplete_results": false,
+    "items": [
+        {
+            "url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949",
+            "repository_url": "https://api.github.com/repos/RevenueCat/purchases-ios",
+            "labels_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/labels{/name}",
+            "comments_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/comments",
+            "events_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/events",
+            "html_url": "https://github.com/RevenueCat/purchases-ios/pull/2949",
+            "id": 1293434654,
+            "node_id": "PR_kwDOBnB8hc46z_fk",
+            "number": 2949,
+            "title": "`Customer Center`: contact support",
+            "user": {
+                "login": "nachosoto",
+                "id": 808417,
+                "node_id": "MDQ6VXNlcjgwODQxNw==",
+                "avatar_url": "https://avatars.githubusercontent.com/u/808417?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/nachosoto",
+                "html_url": "https://github.com/nachosoto",
+                "followers_url": "https://api.github.com/users/nachosoto/followers",
+                "following_url": "https://api.github.com/users/nachosoto/following{/other_user}",
+                "gists_url": "https://api.github.com/users/nachosoto/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/nachosoto/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/nachosoto/subscriptions",
+                "organizations_url": "https://api.github.com/users/nachosoto/orgs",
+                "repos_url": "https://api.github.com/users/nachosoto/repos",
+                "events_url": "https://api.github.com/users/nachosoto/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/nachosoto/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "labels": [
+                {
+                    "id": 4352868120,
+                    "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
+                    "name": "Customer Center:wip",
+                    "color": "8E3E6B",
+                    "default": false,
+                    "description": ""
+                }
+            ],
+            "state": "closed",
+            "locked": false,
+            "assignee": null,
+            "assignees": [],
+            "milestone": null,
+            "comments": 0,
+            "created_at": "2022-07-04T17:32:45Z",
+            "updated_at": "2022-07-05T04:49:19Z",
+            "closed_at": "2022-07-05T04:49:18Z",
+            "author_association": "CONTRIBUTOR",
+            "active_lock_reason": null,
+            "draft": false,
+            "pull_request": {
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/pulls/2949",
+                "html_url": "https://github.com/RevenueCat/purchases-ios/pull/2949",
+                "diff_url": "https://github.com/RevenueCat/purchases-ios/pull/2949.diff",
+                "patch_url": "https://github.com/RevenueCat/purchases-ios/pull/2949.patch",
+                "merged_at": "2022-07-05T04:49:18Z"
+            },
+            "body": "![image](https://github.com/RevenueCat/purchases-ios/assets/685609/a5cc3f4b-99d0-40a2-8a85-82f243383978)",
+            "reactions": {
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/reactions",
+                "total_count": 0,
+                "+1": 0,
+                "-1": 0,
+                "laugh": 0,
+                "hooray": 0,
+                "confused": 0,
+                "heart": 0,
+                "rocket": 0,
+                "eyes": 0
+            },
+            "timeline_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/timeline",
+            "performed_via_github_app": null,
+            "state_reason": null,
+            "score": 1.0
+        }
+    ]
+}

--- a/spec/test_files/get_commit_sha_2625e195a117ad0435864dc8a561e6a0c6052bda.json
+++ b/spec/test_files/get_commit_sha_2625e195a117ad0435864dc8a561e6a0c6052bda.json
@@ -38,7 +38,7 @@
                     "id": 4352868120,
                     "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
                     "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
-                    "name": "Customer Center:wip",
+                    "name": "feat:Customer Center",
                     "color": "8E3E6B",
                     "default": false,
                     "description": ""

--- a/spec/test_files/get_commit_sha_3625e195a117ad0435864dc8a561e6a0c6052bdf.json
+++ b/spec/test_files/get_commit_sha_3625e195a117ad0435864dc8a561e6a0c6052bdf.json
@@ -47,6 +47,15 @@
                     "id": 4352868120,
                     "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
                     "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
+                    "name": "pr:revenuecatui",
+                    "color": "8E3E6B",
+                    "default": false,
+                    "description": ""
+                },
+                {
+                    "id": 4352868120,
+                    "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
                     "name": "pr:feat",
                     "color": "8E3E6B",
                     "default": false,

--- a/spec/test_files/get_commit_sha_3625e195a117ad0435864dc8a561e6a0c6052bdf.json
+++ b/spec/test_files/get_commit_sha_3625e195a117ad0435864dc8a561e6a0c6052bdf.json
@@ -42,6 +42,15 @@
                     "color": "8E3E6B",
                     "default": false,
                     "description": ""
+                },
+                {
+                    "id": 4352868120,
+                    "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
+                    "name": "pr:feat",
+                    "color": "8E3E6B",
+                    "default": false,
+                    "description": ""
                 }
             ],
             "state": "closed",

--- a/spec/test_files/get_commit_sha_3625e195a117ad0435864dc8a561e6a0c6052bdf.json
+++ b/spec/test_files/get_commit_sha_3625e195a117ad0435864dc8a561e6a0c6052bdf.json
@@ -1,0 +1,85 @@
+{
+    "total_count": 1,
+    "incomplete_results": false,
+    "items": [
+        {
+            "url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949",
+            "repository_url": "https://api.github.com/repos/RevenueCat/purchases-ios",
+            "labels_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/labels{/name}",
+            "comments_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/comments",
+            "events_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/events",
+            "html_url": "https://github.com/RevenueCat/purchases-ios/pull/2949",
+            "id": 1293434654,
+            "node_id": "PR_kwDOBnB8hc46z_fk",
+            "number": 2949,
+            "title": "`Paywalls Components`: this is amazing",
+            "user": {
+                "login": "nachosoto",
+                "id": 808417,
+                "node_id": "MDQ6VXNlcjgwODQxNw==",
+                "avatar_url": "https://avatars.githubusercontent.com/u/808417?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/nachosoto",
+                "html_url": "https://github.com/nachosoto",
+                "followers_url": "https://api.github.com/users/nachosoto/followers",
+                "following_url": "https://api.github.com/users/nachosoto/following{/other_user}",
+                "gists_url": "https://api.github.com/users/nachosoto/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/nachosoto/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/nachosoto/subscriptions",
+                "organizations_url": "https://api.github.com/users/nachosoto/orgs",
+                "repos_url": "https://api.github.com/users/nachosoto/repos",
+                "events_url": "https://api.github.com/users/nachosoto/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/nachosoto/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "labels": [
+                {
+                    "id": 4352868120,
+                    "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
+                    "name": "Paywall Components:wip",
+                    "color": "8E3E6B",
+                    "default": false,
+                    "description": ""
+                }
+            ],
+            "state": "closed",
+            "locked": false,
+            "assignee": null,
+            "assignees": [],
+            "milestone": null,
+            "comments": 0,
+            "created_at": "2022-07-04T17:32:45Z",
+            "updated_at": "2022-07-05T04:49:19Z",
+            "closed_at": "2022-07-05T04:49:18Z",
+            "author_association": "CONTRIBUTOR",
+            "active_lock_reason": null,
+            "draft": false,
+            "pull_request": {
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/pulls/2949",
+                "html_url": "https://github.com/RevenueCat/purchases-ios/pull/2949",
+                "diff_url": "https://github.com/RevenueCat/purchases-ios/pull/2949.diff",
+                "patch_url": "https://github.com/RevenueCat/purchases-ios/pull/2949.patch",
+                "merged_at": "2022-07-05T04:49:18Z"
+            },
+            "body": "![image](https://github.com/RevenueCat/purchases-ios/assets/685609/a5cc3f4b-99d0-40a2-8a85-82f243383978)",
+            "reactions": {
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/reactions",
+                "total_count": 0,
+                "+1": 0,
+                "-1": 0,
+                "laugh": 0,
+                "hooray": 0,
+                "confused": 0,
+                "heart": 0,
+                "rocket": 0,
+                "eyes": 0
+            },
+            "timeline_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/timeline",
+            "performed_via_github_app": null,
+            "state_reason": null,
+            "score": 1.0
+        }
+    ]
+}

--- a/spec/test_files/get_commit_sha_3625e195a117ad0435864dc8a561e6a0c6052bdf.json
+++ b/spec/test_files/get_commit_sha_3625e195a117ad0435864dc8a561e6a0c6052bdf.json
@@ -38,7 +38,7 @@
                     "id": 4352868120,
                     "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
                     "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
-                    "name": "Paywall Components:wip",
+                    "name": "feat:Paywall Components",
                     "color": "8E3E6B",
                     "default": false,
                     "description": ""

--- a/spec/test_files/get_commit_sha_4625e195a117ad0435864dc8a561e6a0c6052bdd.json
+++ b/spec/test_files/get_commit_sha_4625e195a117ad0435864dc8a561e6a0c6052bdd.json
@@ -42,6 +42,24 @@
                     "color": "8E3E6B",
                     "default": false,
                     "description": ""
+                },
+                {
+                    "id": 4352868120,
+                    "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
+                    "name": "pr:revenuecatui",
+                    "color": "8E3E6B",
+                    "default": false,
+                    "description": ""
+                },
+                {
+                    "id": 4352868120,
+                    "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
+                    "name": "pr:feat",
+                    "color": "8E3E6B",
+                    "default": false,
+                    "description": ""
                 }
             ],
             "state": "closed",

--- a/spec/test_files/get_commit_sha_4625e195a117ad0435864dc8a561e6a0c6052bdd.json
+++ b/spec/test_files/get_commit_sha_4625e195a117ad0435864dc8a561e6a0c6052bdd.json
@@ -38,7 +38,7 @@
                     "id": 4352868120,
                     "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
                     "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
-                    "name": "Paywall Components:wip",
+                    "name": "feat:Paywall Components",
                     "color": "8E3E6B",
                     "default": false,
                     "description": ""

--- a/spec/test_files/get_commit_sha_4625e195a117ad0435864dc8a561e6a0c6052bdd.json
+++ b/spec/test_files/get_commit_sha_4625e195a117ad0435864dc8a561e6a0c6052bdd.json
@@ -1,0 +1,85 @@
+{
+    "total_count": 1,
+    "incomplete_results": false,
+    "items": [
+        {
+            "url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949",
+            "repository_url": "https://api.github.com/repos/RevenueCat/purchases-ios",
+            "labels_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/labels{/name}",
+            "comments_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/comments",
+            "events_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/events",
+            "html_url": "https://github.com/RevenueCat/purchases-ios/pull/2949",
+            "id": 1293434654,
+            "node_id": "PR_kwDOBnB8hc46z_fk",
+            "number": 2949,
+            "title": "`Paywalls Components`: another amazing thing",
+            "user": {
+                "login": "nachosoto",
+                "id": 808417,
+                "node_id": "MDQ6VXNlcjgwODQxNw==",
+                "avatar_url": "https://avatars.githubusercontent.com/u/808417?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/nachosoto",
+                "html_url": "https://github.com/nachosoto",
+                "followers_url": "https://api.github.com/users/nachosoto/followers",
+                "following_url": "https://api.github.com/users/nachosoto/following{/other_user}",
+                "gists_url": "https://api.github.com/users/nachosoto/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/nachosoto/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/nachosoto/subscriptions",
+                "organizations_url": "https://api.github.com/users/nachosoto/orgs",
+                "repos_url": "https://api.github.com/users/nachosoto/repos",
+                "events_url": "https://api.github.com/users/nachosoto/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/nachosoto/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "labels": [
+                {
+                    "id": 4352868120,
+                    "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
+                    "name": "Paywall Components:wip",
+                    "color": "8E3E6B",
+                    "default": false,
+                    "description": ""
+                }
+            ],
+            "state": "closed",
+            "locked": false,
+            "assignee": null,
+            "assignees": [],
+            "milestone": null,
+            "comments": 0,
+            "created_at": "2022-07-04T17:32:45Z",
+            "updated_at": "2022-07-05T04:49:19Z",
+            "closed_at": "2022-07-05T04:49:18Z",
+            "author_association": "CONTRIBUTOR",
+            "active_lock_reason": null,
+            "draft": false,
+            "pull_request": {
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/pulls/2949",
+                "html_url": "https://github.com/RevenueCat/purchases-ios/pull/2949",
+                "diff_url": "https://github.com/RevenueCat/purchases-ios/pull/2949.diff",
+                "patch_url": "https://github.com/RevenueCat/purchases-ios/pull/2949.patch",
+                "merged_at": "2022-07-05T04:49:18Z"
+            },
+            "body": "![image](https://github.com/RevenueCat/purchases-ios/assets/685609/a5cc3f4b-99d0-40a2-8a85-82f243383978)",
+            "reactions": {
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/reactions",
+                "total_count": 0,
+                "+1": 0,
+                "-1": 0,
+                "laugh": 0,
+                "hooray": 0,
+                "confused": 0,
+                "heart": 0,
+                "rocket": 0,
+                "eyes": 0
+            },
+            "timeline_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/2949/timeline",
+            "performed_via_github_app": null,
+            "state_reason": null,
+            "score": 1.0
+        }
+    ]
+}

--- a/spec/test_files/get_commit_sha_5625e195a117ad0435864dc8a561e6a0c6052bda.json
+++ b/spec/test_files/get_commit_sha_5625e195a117ad0435864dc8a561e6a0c6052bda.json
@@ -51,6 +51,15 @@
                     "color": "8E3E6B",
                     "default": false,
                     "description": ""
+                },
+                {
+                    "id": 4352868120,
+                    "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
+                    "name": "pr:revenuecatui",
+                    "color": "8E3E6B",
+                    "default": false,
+                    "description": ""
                 }
             ],
             "state": "closed",

--- a/spec/test_files/get_commit_sha_5625e195a117ad0435864dc8a561e6a0c6052bda.json
+++ b/spec/test_files/get_commit_sha_5625e195a117ad0435864dc8a561e6a0c6052bda.json
@@ -12,7 +12,7 @@
             "id": 1293434654,
             "node_id": "PR_kwDOBnB8hc46z_fk",
             "number": 2949,
-            "title": "`Customer Center`: contact support",
+            "title": "`Customer Center`: a fix",
             "user": {
                 "login": "nachosoto",
                 "id": 808417,
@@ -47,7 +47,7 @@
                     "id": 4352868120,
                     "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
                     "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/RevenueCatUI",
-                    "name": "pr:feat",
+                    "name": "pr:fix",
                     "color": "8E3E6B",
                     "default": false,
                     "description": ""

--- a/spec/test_files/get_commit_sha_6d37c766b6da55dcab67c201c93ba3d4ca538e55.json
+++ b/spec/test_files/get_commit_sha_6d37c766b6da55dcab67c201c93ba3d4ca538e55.json
@@ -38,7 +38,7 @@
           "id": 4396681492,
           "node_id": "LA_kwDOBnB8hc8AAAABBhAJFA",
           "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/refactor",
-          "name": "pr:refactor",
+          "name": "pr:ci",
           "color": "e99695",
           "default": false,
           "description": "A code change that neither fixes a bug nor adds a feature"

--- a/spec/test_files/get_commit_sha_819dc620db5608fb952c852038a3560554161707.json
+++ b/spec/test_files/get_commit_sha_819dc620db5608fb952c852038a3560554161707.json
@@ -38,7 +38,7 @@
           "id": 4396672443,
           "node_id": "LA_kwDOBnB8hc8AAAABBg_luw",
           "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/ci",
-          "name": "pr:ci",
+          "name": "pr:other",
           "color": "506B91",
           "default": false,
           "description": "Changes to our CI configuration files and scripts"

--- a/spec/test_files/get_commit_sha_9a289e554fe384e6987b086fad047671058cf044.json
+++ b/spec/test_files/get_commit_sha_9a289e554fe384e6987b086fad047671058cf044.json
@@ -14,7 +14,7 @@
             "number": 2199,
             "title": "`PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key",
             "user": {
-                "login": "nachosoto",
+                "login": "tonidero",
                 "id": 808417,
                 "node_id": "MDQ6VXNlcjgwODQxNw==",
                 "avatar_url": "https://avatars.githubusercontent.com/u/808417?v=4",

--- a/spec/test_files/get_commits_since_last_release.json
+++ b/spec/test_files/get_commits_since_last_release.json
@@ -330,8 +330,8 @@
             "node_id": "C_kwDOBnB8hdoAKDBlNjdjZGIxYzc1ODJjZTNlMmZkMDAzNjdhY2MyNGRiNjI0MmM2ZDY",
             "commit": {
                 "author": {
-                    "name": "Nacho Soto",
-                    "email": "ignacio@revenuecat.com",
+                    "name": "Toni Rico",
+                    "email": "antonio.rico.diez@revenuecat.com",
                     "date": "2023-01-15T04:49:17Z"
                 },
                 "committer": {
@@ -409,8 +409,8 @@
             "node_id": "C_kwDOBnB8hdoAKDBlNjdjZGIxYzc1ODJjZTNlMmZkMDAzNjdhY2MyNGRiNjI0MmM2ZDY",
             "commit": {
                 "author": {
-                    "name": "Nacho Soto",
-                    "email": "ignacio@revenuecat.com",
+                    "name": "Toni Rico",
+                    "email": "antonio.rico.diez@revenuecat.com",
                     "date": "2023-01-15T04:49:17Z"
                 },
                 "committer": {

--- a/spec/test_files/get_commits_since_last_release_features.json
+++ b/spec/test_files/get_commits_since_last_release_features.json
@@ -247,6 +247,85 @@
             ]
         },
         {
+            "sha": "5625e195a117ad0435864dc8a561e6a0c6052bda",
+            "node_id": "C_kwDOBnB8hdoAKGE3MmMwNDM1ZWNmNzEyNDhmMzExOTAwNDc1ZTg4MWNjMDdhYzJlYWY",
+            "commit": {
+                "author": {
+                    "name": "aboedo",
+                    "email": "andresboedo@gmail.com",
+                    "date": "2022-07-04T14:36:41Z"
+                },
+                "committer": {
+                    "name": "GitHub",
+                    "email": "noreply@github.com",
+                    "date": "2022-07-04T14:36:41Z"
+                },
+                "message": "`Customer Center`: contact support",
+                "tree": {
+                    "sha": "051c6736cff89107bd32cb3b8baa64627c7eac8a",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/git/trees/051c6736cff89107bd32cb3b8baa64627c7eac8a"
+                },
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/git/commits/a72c0435ecf71248f311900475e881cc07ac2eaf",
+                "comment_count": 0,
+                "verification": {
+                    "verified": true,
+                    "reason": "valid",
+                    "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsBcBAABCAAQBQJiwvr5CRBK7hj4Ov3rIwAAaHoIAGNCSoN7wVbeuBBMMr0PutDS\n4m2wl5q6is2hXgjFVZTDAToX6K+6c8FbHtmnOwgzjjEdY3T+ewIWNQ1IZFGDcarx\nzAxbk1r5jsyrrs2wGb53XK/HvT87IpWTARh5g1h+NUCT0/jmyIIReHgxNgSzUzhr\nGlM2MowmwE2qrlV062L33A7NIFP267lIfyriTPUHfmpfKkZN/EKdIcGX+2dtOX49\nFMpVxF1AFsp+GTiDLr6N1LIIByevGRliaQWcGYNvQWoeqG/h7bU87gq9ZeitMCEH\nVizJTA2YiGl4mGIBocTicWAoqauHBrPZmqHd1N4rcW0c3LQLEAIyFX5xk8V24Do=\n=7PGO\n-----END PGP SIGNATURE-----\n",
+                    "payload": "tree 051c6736cff89107bd32cb3b8baa64627c7eac8a\nparent bb8687d51190e42cd48e6cdd8039392f208601c3\nauthor aboedo <andresboedo@gmail.com> 1656945401 -0300\ncommitter GitHub <noreply@github.com> 1656945401 -0300\n\nadded log when setting `autoSyncPurchases` to false (#1749)\n\n"
+                }
+            },
+            "url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/a72c0435ecf71248f311900475e881cc07ac2eaf",
+            "html_url": "https://github.com/RevenueCat/purchases-ios/commit/a72c0435ecf71248f311900475e881cc07ac2eaf",
+            "comments_url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/a72c0435ecf71248f311900475e881cc07ac2eaf/comments",
+            "author": {
+                "login": "aboedo",
+                "id": 3922667,
+                "node_id": "MDQ6VXNlcjM5MjI2Njc=",
+                "avatar_url": "https://avatars.githubusercontent.com/u/3922667?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/aboedo",
+                "html_url": "https://github.com/aboedo",
+                "followers_url": "https://api.github.com/users/aboedo/followers",
+                "following_url": "https://api.github.com/users/aboedo/following{/other_user}",
+                "gists_url": "https://api.github.com/users/aboedo/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/aboedo/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/aboedo/subscriptions",
+                "organizations_url": "https://api.github.com/users/aboedo/orgs",
+                "repos_url": "https://api.github.com/users/aboedo/repos",
+                "events_url": "https://api.github.com/users/aboedo/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/aboedo/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "committer": {
+                "login": "web-flow",
+                "id": 19864447,
+                "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+                "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/web-flow",
+                "html_url": "https://github.com/web-flow",
+                "followers_url": "https://api.github.com/users/web-flow/followers",
+                "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+                "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+                "organizations_url": "https://api.github.com/users/web-flow/orgs",
+                "repos_url": "https://api.github.com/users/web-flow/repos",
+                "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/web-flow/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "parents": [
+                {
+                    "sha": "bb8687d51190e42cd48e6cdd8039392f208601c3",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/bb8687d51190e42cd48e6cdd8039392f208601c3",
+                    "html_url": "https://github.com/RevenueCat/purchases-ios/commit/bb8687d51190e42cd48e6cdd8039392f208601c3"
+                }
+            ]
+        },
+        {
             "sha": "2625e195a117ad0435864dc8a561e6a0c6052bda",
             "node_id": "C_kwDOBnB8hdoAKGE3MmMwNDM1ZWNmNzEyNDhmMzExOTAwNDc1ZTg4MWNjMDdhYzJlYWY",
             "commit": {

--- a/spec/test_files/get_commits_since_last_release_wip.json
+++ b/spec/test_files/get_commits_since_last_release_wip.json
@@ -1,0 +1,748 @@
+{
+    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/compare/4.7.0...HEAD",
+    "html_url": "https://github.com/RevenueCat/purchases-ios/compare/4.7.0...HEAD",
+    "permalink_url": "https://github.com/RevenueCat/purchases-ios/compare/RevenueCat:bb8687d...RevenueCat:cfdd80f",
+    "diff_url": "https://github.com/RevenueCat/purchases-ios/compare/4.7.0...HEAD.diff",
+    "patch_url": "https://github.com/RevenueCat/purchases-ios/compare/4.7.0...HEAD.patch",
+    "base_commit": {
+        "sha": "bb8687d51190e42cd48e6cdd8039392f208601c3",
+        "node_id": "C_kwDOBnB8hdoAKGJiODY4N2Q1MTE5MGU0MmNkNDhlNmNkZDgwMzkzOTJmMjA4NjAxYzM",
+        "commit": {
+            "author": {
+                "name": "NachoSoto",
+                "email": "NachoSoto@users.noreply.github.com",
+                "date": "2022-07-04T14:27:41Z"
+            },
+            "committer": {
+                "name": "GitHub",
+                "email": "noreply@github.com",
+                "date": "2022-07-04T14:27:41Z"
+            },
+            "message": "Release/4.7.0 (#1745)\n\n### Changes:\r\n* Replaced `CustomerInfo.nonSubscriptionTransactions` with a new non-`StoreTransaction` type (#1733) via NachoSoto (@NachoSoto)\r\n* `Purchases.configure`: added overload taking a `Configuration.Builder` (#1720) via NachoSoto (@NachoSoto)\r\n* Extract Attribution logic out of Purchases (#1693) via Joshua Liebowitz (@taquitos)\r\n* Remove create alias (#1695) via Joshua Liebowitz (@taquitos)\r\n\r\nAll attribution APIs can now be accessed from `Purchases.shared.attribution`.\r\n\r\n### Improvements:\r\n* Improved purchasing logs, added promotional offer information (#1725) via NachoSoto (@NachoSoto)\r\n* `PurchasesOrchestrator`: don't log attribute errors if there are none (#1742) via NachoSoto (@NachoSoto)\r\n* `FatalErrorUtil`: don't override `fatalError` on release builds (#1736) via NachoSoto (@NachoSoto)\r\n* `SKPaymentTransaction`: added more context to warnings about missing properties (#1731) via NachoSoto (@NachoSoto)\r\n* New SwiftUI Purchase Tester example (#1722) via Josh Holtz (@joshdholtz)\r\n* update docs for `showManageSubscriptions` (#1729) via aboedo (@aboedo)\r\n* `PurchasesOrchestrator`: unify finish transactions between SK1 and SK2 (#1704) via NachoSoto (@NachoSoto)\r\n* `SubscriberAttribute`: converted into `struct` (#1648) via NachoSoto (@NachoSoto)\r\n* `CacheFetchPolicy.notStaleCachedOrFetched`: added warning to docstring (#1708) via NachoSoto (@NachoSoto)\r\n* Clear cached offerings and products after Storefront changes (2/4) (#1583) via Juanpe Catalán (@Juanpe)\r\n* `ROT13`: optimized initialization and removed magic numbers (#1702) via NachoSoto (@NachoSoto)\r\n\r\n### Fixes:\r\n* `logIn`/`logOut`: sync attributes before aliasing (#1716) via NachoSoto (@NachoSoto)\r\n* `Purchases.customerInfo(fetchPolicy:)`: actually use `fetchPolicy` parameter (#1721) via NachoSoto (@NachoSoto)\r\n* `PurchasesOrchestrator`: fix behavior dealing with `nil` `SKPaymentTransaction.productIdentifier` during purchase (#1680) via NachoSoto (@NachoSoto)\r\n* `PurchasesOrchestrator.handlePurchasedTransaction`: always refresh receipt data (#1703) via NachoSoto (@NachoSoto)",
+            "tree": {
+                "sha": "73157a7b0c3357745693a4feb78a93cb26997682",
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/git/trees/73157a7b0c3357745693a4feb78a93cb26997682"
+            },
+            "url": "https://api.github.com/repos/RevenueCat/purchases-ios/git/commits/bb8687d51190e42cd48e6cdd8039392f208601c3",
+            "comment_count": 0,
+            "verification": {
+                "verified": true,
+                "reason": "valid",
+                "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsBcBAABCAAQBQJiwvjdCRBK7hj4Ov3rIwAAKLAIAI+zlCFSPleYUrhBfrUqkfDr\nnLAA6FqQGKwrDuI+o1hUtHyVYXwLLUN1tHoffyaDrNOA3BvVLgcKqXWT1poi6SDj\nIcCwHH2PV72q0pbIhrnHvzes7Eo9d3ml7bVE0uK7EIvHn18cVaUukHLda6g89q8l\nbTnBl1kr4+juijFoKJfAqBza60bLjLokiLEqgGYleERqJ35HZstmgV4ll9X3B5+0\nok2KnwrCf75iH+n6VQ5tGktQtq3Xb1CW88/FV8RjzcU+NojAIfdxlRUfpnf5EnOu\n9j2QIWa0XojcJAnZ691Deyq1RMR6G2YoeTQBJoqClA7v3Iv1VBvHmYQAvJsspKk=\n=Obu7\n-----END PGP SIGNATURE-----\n",
+                "payload": "tree 73157a7b0c3357745693a4feb78a93cb26997682\nparent 0dfa812b8a9d15d7903b37e1b2252cad88357dd3\nauthor NachoSoto <NachoSoto@users.noreply.github.com> 1656944861 -0700\ncommitter GitHub <noreply@github.com> 1656944861 -0700\n\nRelease/4.7.0 (#1745)\n\n### Changes:\r\n* Replaced `CustomerInfo.nonSubscriptionTransactions` with a new non-`StoreTransaction` type (#1733) via NachoSoto (@NachoSoto)\r\n* `Purchases.configure`: added overload taking a `Configuration.Builder` (#1720) via NachoSoto (@NachoSoto)\r\n* Extract Attribution logic out of Purchases (#1693) via Joshua Liebowitz (@taquitos)\r\n* Remove create alias (#1695) via Joshua Liebowitz (@taquitos)\r\n\r\nAll attribution APIs can now be accessed from `Purchases.shared.attribution`.\r\n\r\n### Improvements:\r\n* Improved purchasing logs, added promotional offer information (#1725) via NachoSoto (@NachoSoto)\r\n* `PurchasesOrchestrator`: don't log attribute errors if there are none (#1742) via NachoSoto (@NachoSoto)\r\n* `FatalErrorUtil`: don't override `fatalError` on release builds (#1736) via NachoSoto (@NachoSoto)\r\n* `SKPaymentTransaction`: added more context to warnings about missing properties (#1731) via NachoSoto (@NachoSoto)\r\n* New SwiftUI Purchase Tester example (#1722) via Josh Holtz (@joshdholtz)\r\n* update docs for `showManageSubscriptions` (#1729) via aboedo (@aboedo)\r\n* `PurchasesOrchestrator`: unify finish transactions between SK1 and SK2 (#1704) via NachoSoto (@NachoSoto)\r\n* `SubscriberAttribute`: converted into `struct` (#1648) via NachoSoto (@NachoSoto)\r\n* `CacheFetchPolicy.notStaleCachedOrFetched`: added warning to docstring (#1708) via NachoSoto (@NachoSoto)\r\n* Clear cached offerings and products after Storefront changes (2/4) (#1583) via Juanpe Catalán (@Juanpe)\r\n* `ROT13`: optimized initialization and removed magic numbers (#1702) via NachoSoto (@NachoSoto)\r\n\r\n### Fixes:\r\n* `logIn`/`logOut`: sync attributes before aliasing (#1716) via NachoSoto (@NachoSoto)\r\n* `Purchases.customerInfo(fetchPolicy:)`: actually use `fetchPolicy` parameter (#1721) via NachoSoto (@NachoSoto)\r\n* `PurchasesOrchestrator`: fix behavior dealing with `nil` `SKPaymentTransaction.productIdentifier` during purchase (#1680) via NachoSoto (@NachoSoto)\r\n* `PurchasesOrchestrator.handlePurchasedTransaction`: always refresh receipt data (#1703) via NachoSoto (@NachoSoto)"
+            }
+        },
+        "url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/bb8687d51190e42cd48e6cdd8039392f208601c3",
+        "html_url": "https://github.com/RevenueCat/purchases-ios/commit/bb8687d51190e42cd48e6cdd8039392f208601c3",
+        "comments_url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/bb8687d51190e42cd48e6cdd8039392f208601c3/comments",
+        "author": {
+            "login": "NachoSoto",
+            "id": 685609,
+            "node_id": "MDQ6VXNlcjY4NTYwOQ==",
+            "avatar_url": "https://avatars.githubusercontent.com/u/685609?v=4",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/NachoSoto",
+            "html_url": "https://github.com/NachoSoto",
+            "followers_url": "https://api.github.com/users/NachoSoto/followers",
+            "following_url": "https://api.github.com/users/NachoSoto/following{/other_user}",
+            "gists_url": "https://api.github.com/users/NachoSoto/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/NachoSoto/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/NachoSoto/subscriptions",
+            "organizations_url": "https://api.github.com/users/NachoSoto/orgs",
+            "repos_url": "https://api.github.com/users/NachoSoto/repos",
+            "events_url": "https://api.github.com/users/NachoSoto/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/NachoSoto/received_events",
+            "type": "User",
+            "site_admin": false
+        },
+        "committer": {
+            "login": "web-flow",
+            "id": 19864447,
+            "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+            "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/web-flow",
+            "html_url": "https://github.com/web-flow",
+            "followers_url": "https://api.github.com/users/web-flow/followers",
+            "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+            "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+            "organizations_url": "https://api.github.com/users/web-flow/orgs",
+            "repos_url": "https://api.github.com/users/web-flow/repos",
+            "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/web-flow/received_events",
+            "type": "User",
+            "site_admin": false
+        },
+        "parents": [
+            {
+                "sha": "0dfa812b8a9d15d7903b37e1b2252cad88357dd3",
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/0dfa812b8a9d15d7903b37e1b2252cad88357dd3",
+                "html_url": "https://github.com/RevenueCat/purchases-ios/commit/0dfa812b8a9d15d7903b37e1b2252cad88357dd3"
+            }
+        ]
+    },
+    "merge_base_commit": {
+        "sha": "bb8687d51190e42cd48e6cdd8039392f208601c3",
+        "node_id": "C_kwDOBnB8hdoAKGJiODY4N2Q1MTE5MGU0MmNkNDhlNmNkZDgwMzkzOTJmMjA4NjAxYzM",
+        "commit": {
+            "author": {
+                "name": "NachoSoto",
+                "email": "NachoSoto@users.noreply.github.com",
+                "date": "2022-07-04T14:27:41Z"
+            },
+            "committer": {
+                "name": "GitHub",
+                "email": "noreply@github.com",
+                "date": "2022-07-04T14:27:41Z"
+            },
+            "message": "Release/4.7.0 (#1745)\n\n### Changes:\r\n* Replaced `CustomerInfo.nonSubscriptionTransactions` with a new non-`StoreTransaction` type (#1733) via NachoSoto (@NachoSoto)\r\n* `Purchases.configure`: added overload taking a `Configuration.Builder` (#1720) via NachoSoto (@NachoSoto)\r\n* Extract Attribution logic out of Purchases (#1693) via Joshua Liebowitz (@taquitos)\r\n* Remove create alias (#1695) via Joshua Liebowitz (@taquitos)\r\n\r\nAll attribution APIs can now be accessed from `Purchases.shared.attribution`.\r\n\r\n### Improvements:\r\n* Improved purchasing logs, added promotional offer information (#1725) via NachoSoto (@NachoSoto)\r\n* `PurchasesOrchestrator`: don't log attribute errors if there are none (#1742) via NachoSoto (@NachoSoto)\r\n* `FatalErrorUtil`: don't override `fatalError` on release builds (#1736) via NachoSoto (@NachoSoto)\r\n* `SKPaymentTransaction`: added more context to warnings about missing properties (#1731) via NachoSoto (@NachoSoto)\r\n* New SwiftUI Purchase Tester example (#1722) via Josh Holtz (@joshdholtz)\r\n* update docs for `showManageSubscriptions` (#1729) via aboedo (@aboedo)\r\n* `PurchasesOrchestrator`: unify finish transactions between SK1 and SK2 (#1704) via NachoSoto (@NachoSoto)\r\n* `SubscriberAttribute`: converted into `struct` (#1648) via NachoSoto (@NachoSoto)\r\n* `CacheFetchPolicy.notStaleCachedOrFetched`: added warning to docstring (#1708) via NachoSoto (@NachoSoto)\r\n* Clear cached offerings and products after Storefront changes (2/4) (#1583) via Juanpe Catalán (@Juanpe)\r\n* `ROT13`: optimized initialization and removed magic numbers (#1702) via NachoSoto (@NachoSoto)\r\n\r\n### Fixes:\r\n* `logIn`/`logOut`: sync attributes before aliasing (#1716) via NachoSoto (@NachoSoto)\r\n* `Purchases.customerInfo(fetchPolicy:)`: actually use `fetchPolicy` parameter (#1721) via NachoSoto (@NachoSoto)\r\n* `PurchasesOrchestrator`: fix behavior dealing with `nil` `SKPaymentTransaction.productIdentifier` during purchase (#1680) via NachoSoto (@NachoSoto)\r\n* `PurchasesOrchestrator.handlePurchasedTransaction`: always refresh receipt data (#1703) via NachoSoto (@NachoSoto)",
+            "tree": {
+                "sha": "73157a7b0c3357745693a4feb78a93cb26997682",
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/git/trees/73157a7b0c3357745693a4feb78a93cb26997682"
+            },
+            "url": "https://api.github.com/repos/RevenueCat/purchases-ios/git/commits/bb8687d51190e42cd48e6cdd8039392f208601c3",
+            "comment_count": 0,
+            "verification": {
+                "verified": true,
+                "reason": "valid",
+                "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsBcBAABCAAQBQJiwvjdCRBK7hj4Ov3rIwAAKLAIAI+zlCFSPleYUrhBfrUqkfDr\nnLAA6FqQGKwrDuI+o1hUtHyVYXwLLUN1tHoffyaDrNOA3BvVLgcKqXWT1poi6SDj\nIcCwHH2PV72q0pbIhrnHvzes7Eo9d3ml7bVE0uK7EIvHn18cVaUukHLda6g89q8l\nbTnBl1kr4+juijFoKJfAqBza60bLjLokiLEqgGYleERqJ35HZstmgV4ll9X3B5+0\nok2KnwrCf75iH+n6VQ5tGktQtq3Xb1CW88/FV8RjzcU+NojAIfdxlRUfpnf5EnOu\n9j2QIWa0XojcJAnZ691Deyq1RMR6G2YoeTQBJoqClA7v3Iv1VBvHmYQAvJsspKk=\n=Obu7\n-----END PGP SIGNATURE-----\n",
+                "payload": "tree 73157a7b0c3357745693a4feb78a93cb26997682\nparent 0dfa812b8a9d15d7903b37e1b2252cad88357dd3\nauthor NachoSoto <NachoSoto@users.noreply.github.com> 1656944861 -0700\ncommitter GitHub <noreply@github.com> 1656944861 -0700\n\nRelease/4.7.0 (#1745)\n\n### Changes:\r\n* Replaced `CustomerInfo.nonSubscriptionTransactions` with a new non-`StoreTransaction` type (#1733) via NachoSoto (@NachoSoto)\r\n* `Purchases.configure`: added overload taking a `Configuration.Builder` (#1720) via NachoSoto (@NachoSoto)\r\n* Extract Attribution logic out of Purchases (#1693) via Joshua Liebowitz (@taquitos)\r\n* Remove create alias (#1695) via Joshua Liebowitz (@taquitos)\r\n\r\nAll attribution APIs can now be accessed from `Purchases.shared.attribution`.\r\n\r\n### Improvements:\r\n* Improved purchasing logs, added promotional offer information (#1725) via NachoSoto (@NachoSoto)\r\n* `PurchasesOrchestrator`: don't log attribute errors if there are none (#1742) via NachoSoto (@NachoSoto)\r\n* `FatalErrorUtil`: don't override `fatalError` on release builds (#1736) via NachoSoto (@NachoSoto)\r\n* `SKPaymentTransaction`: added more context to warnings about missing properties (#1731) via NachoSoto (@NachoSoto)\r\n* New SwiftUI Purchase Tester example (#1722) via Josh Holtz (@joshdholtz)\r\n* update docs for `showManageSubscriptions` (#1729) via aboedo (@aboedo)\r\n* `PurchasesOrchestrator`: unify finish transactions between SK1 and SK2 (#1704) via NachoSoto (@NachoSoto)\r\n* `SubscriberAttribute`: converted into `struct` (#1648) via NachoSoto (@NachoSoto)\r\n* `CacheFetchPolicy.notStaleCachedOrFetched`: added warning to docstring (#1708) via NachoSoto (@NachoSoto)\r\n* Clear cached offerings and products after Storefront changes (2/4) (#1583) via Juanpe Catalán (@Juanpe)\r\n* `ROT13`: optimized initialization and removed magic numbers (#1702) via NachoSoto (@NachoSoto)\r\n\r\n### Fixes:\r\n* `logIn`/`logOut`: sync attributes before aliasing (#1716) via NachoSoto (@NachoSoto)\r\n* `Purchases.customerInfo(fetchPolicy:)`: actually use `fetchPolicy` parameter (#1721) via NachoSoto (@NachoSoto)\r\n* `PurchasesOrchestrator`: fix behavior dealing with `nil` `SKPaymentTransaction.productIdentifier` during purchase (#1680) via NachoSoto (@NachoSoto)\r\n* `PurchasesOrchestrator.handlePurchasedTransaction`: always refresh receipt data (#1703) via NachoSoto (@NachoSoto)"
+            }
+        },
+        "url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/bb8687d51190e42cd48e6cdd8039392f208601c3",
+        "html_url": "https://github.com/RevenueCat/purchases-ios/commit/bb8687d51190e42cd48e6cdd8039392f208601c3",
+        "comments_url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/bb8687d51190e42cd48e6cdd8039392f208601c3/comments",
+        "author": {
+            "login": "NachoSoto",
+            "id": 685609,
+            "node_id": "MDQ6VXNlcjY4NTYwOQ==",
+            "avatar_url": "https://avatars.githubusercontent.com/u/685609?v=4",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/NachoSoto",
+            "html_url": "https://github.com/NachoSoto",
+            "followers_url": "https://api.github.com/users/NachoSoto/followers",
+            "following_url": "https://api.github.com/users/NachoSoto/following{/other_user}",
+            "gists_url": "https://api.github.com/users/NachoSoto/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/NachoSoto/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/NachoSoto/subscriptions",
+            "organizations_url": "https://api.github.com/users/NachoSoto/orgs",
+            "repos_url": "https://api.github.com/users/NachoSoto/repos",
+            "events_url": "https://api.github.com/users/NachoSoto/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/NachoSoto/received_events",
+            "type": "User",
+            "site_admin": false
+        },
+        "committer": {
+            "login": "web-flow",
+            "id": 19864447,
+            "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+            "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/web-flow",
+            "html_url": "https://github.com/web-flow",
+            "followers_url": "https://api.github.com/users/web-flow/followers",
+            "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+            "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+            "organizations_url": "https://api.github.com/users/web-flow/orgs",
+            "repos_url": "https://api.github.com/users/web-flow/repos",
+            "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/web-flow/received_events",
+            "type": "User",
+            "site_admin": false
+        },
+        "parents": [
+            {
+                "sha": "0dfa812b8a9d15d7903b37e1b2252cad88357dd3",
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/0dfa812b8a9d15d7903b37e1b2252cad88357dd3",
+                "html_url": "https://github.com/RevenueCat/purchases-ios/commit/0dfa812b8a9d15d7903b37e1b2252cad88357dd3"
+            }
+        ]
+    },
+    "status": "ahead",
+    "ahead_by": 3,
+    "behind_by": 0,
+    "total_commits": 3,
+    "commits": [
+        {
+            "sha": "4625e195a117ad0435864dc8a561e6a0c6052bdd",
+            "node_id": "C_kwDOBnB8hdoAKGE3MmMwNDM1ZWNmNzEyNDhmMzExOTAwNDc1ZTg4MWNjMDdhYzJlYWY",
+            "commit": {
+                "author": {
+                    "name": "aboedo",
+                    "email": "andresboedo@gmail.com",
+                    "date": "2022-07-04T14:36:41Z"
+                },
+                "committer": {
+                    "name": "GitHub",
+                    "email": "noreply@github.com",
+                    "date": "2022-07-04T14:36:41Z"
+                },
+                "message": "`Customer Center`: contact support",
+                "tree": {
+                    "sha": "051c6736cff89107bd32cb3b8baa64627c7eac8a",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/git/trees/051c6736cff89107bd32cb3b8baa64627c7eac8a"
+                },
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/git/commits/a72c0435ecf71248f311900475e881cc07ac2eaf",
+                "comment_count": 0,
+                "verification": {
+                    "verified": true,
+                    "reason": "valid",
+                    "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsBcBAABCAAQBQJiwvr5CRBK7hj4Ov3rIwAAaHoIAGNCSoN7wVbeuBBMMr0PutDS\n4m2wl5q6is2hXgjFVZTDAToX6K+6c8FbHtmnOwgzjjEdY3T+ewIWNQ1IZFGDcarx\nzAxbk1r5jsyrrs2wGb53XK/HvT87IpWTARh5g1h+NUCT0/jmyIIReHgxNgSzUzhr\nGlM2MowmwE2qrlV062L33A7NIFP267lIfyriTPUHfmpfKkZN/EKdIcGX+2dtOX49\nFMpVxF1AFsp+GTiDLr6N1LIIByevGRliaQWcGYNvQWoeqG/h7bU87gq9ZeitMCEH\nVizJTA2YiGl4mGIBocTicWAoqauHBrPZmqHd1N4rcW0c3LQLEAIyFX5xk8V24Do=\n=7PGO\n-----END PGP SIGNATURE-----\n",
+                    "payload": "tree 051c6736cff89107bd32cb3b8baa64627c7eac8a\nparent bb8687d51190e42cd48e6cdd8039392f208601c3\nauthor aboedo <andresboedo@gmail.com> 1656945401 -0300\ncommitter GitHub <noreply@github.com> 1656945401 -0300\n\nadded log when setting `autoSyncPurchases` to false (#1749)\n\n"
+                }
+            },
+            "url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/a72c0435ecf71248f311900475e881cc07ac2eaf",
+            "html_url": "https://github.com/RevenueCat/purchases-ios/commit/a72c0435ecf71248f311900475e881cc07ac2eaf",
+            "comments_url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/a72c0435ecf71248f311900475e881cc07ac2eaf/comments",
+            "author": {
+                "login": "aboedo",
+                "id": 3922667,
+                "node_id": "MDQ6VXNlcjM5MjI2Njc=",
+                "avatar_url": "https://avatars.githubusercontent.com/u/3922667?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/aboedo",
+                "html_url": "https://github.com/aboedo",
+                "followers_url": "https://api.github.com/users/aboedo/followers",
+                "following_url": "https://api.github.com/users/aboedo/following{/other_user}",
+                "gists_url": "https://api.github.com/users/aboedo/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/aboedo/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/aboedo/subscriptions",
+                "organizations_url": "https://api.github.com/users/aboedo/orgs",
+                "repos_url": "https://api.github.com/users/aboedo/repos",
+                "events_url": "https://api.github.com/users/aboedo/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/aboedo/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "committer": {
+                "login": "web-flow",
+                "id": 19864447,
+                "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+                "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/web-flow",
+                "html_url": "https://github.com/web-flow",
+                "followers_url": "https://api.github.com/users/web-flow/followers",
+                "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+                "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+                "organizations_url": "https://api.github.com/users/web-flow/orgs",
+                "repos_url": "https://api.github.com/users/web-flow/repos",
+                "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/web-flow/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "parents": [
+                {
+                    "sha": "bb8687d51190e42cd48e6cdd8039392f208601c3",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/bb8687d51190e42cd48e6cdd8039392f208601c3",
+                    "html_url": "https://github.com/RevenueCat/purchases-ios/commit/bb8687d51190e42cd48e6cdd8039392f208601c3"
+                }
+            ]
+        },
+        {
+            "sha": "2625e195a117ad0435864dc8a561e6a0c6052bda",
+            "node_id": "C_kwDOBnB8hdoAKGE3MmMwNDM1ZWNmNzEyNDhmMzExOTAwNDc1ZTg4MWNjMDdhYzJlYWY",
+            "commit": {
+                "author": {
+                    "name": "aboedo",
+                    "email": "andresboedo@gmail.com",
+                    "date": "2022-07-04T14:36:41Z"
+                },
+                "committer": {
+                    "name": "GitHub",
+                    "email": "noreply@github.com",
+                    "date": "2022-07-04T14:36:41Z"
+                },
+                "message": "`Customer Center`: contact support",
+                "tree": {
+                    "sha": "051c6736cff89107bd32cb3b8baa64627c7eac8a",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/git/trees/051c6736cff89107bd32cb3b8baa64627c7eac8a"
+                },
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/git/commits/a72c0435ecf71248f311900475e881cc07ac2eaf",
+                "comment_count": 0,
+                "verification": {
+                    "verified": true,
+                    "reason": "valid",
+                    "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsBcBAABCAAQBQJiwvr5CRBK7hj4Ov3rIwAAaHoIAGNCSoN7wVbeuBBMMr0PutDS\n4m2wl5q6is2hXgjFVZTDAToX6K+6c8FbHtmnOwgzjjEdY3T+ewIWNQ1IZFGDcarx\nzAxbk1r5jsyrrs2wGb53XK/HvT87IpWTARh5g1h+NUCT0/jmyIIReHgxNgSzUzhr\nGlM2MowmwE2qrlV062L33A7NIFP267lIfyriTPUHfmpfKkZN/EKdIcGX+2dtOX49\nFMpVxF1AFsp+GTiDLr6N1LIIByevGRliaQWcGYNvQWoeqG/h7bU87gq9ZeitMCEH\nVizJTA2YiGl4mGIBocTicWAoqauHBrPZmqHd1N4rcW0c3LQLEAIyFX5xk8V24Do=\n=7PGO\n-----END PGP SIGNATURE-----\n",
+                    "payload": "tree 051c6736cff89107bd32cb3b8baa64627c7eac8a\nparent bb8687d51190e42cd48e6cdd8039392f208601c3\nauthor aboedo <andresboedo@gmail.com> 1656945401 -0300\ncommitter GitHub <noreply@github.com> 1656945401 -0300\n\nadded log when setting `autoSyncPurchases` to false (#1749)\n\n"
+                }
+            },
+            "url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/a72c0435ecf71248f311900475e881cc07ac2eaf",
+            "html_url": "https://github.com/RevenueCat/purchases-ios/commit/a72c0435ecf71248f311900475e881cc07ac2eaf",
+            "comments_url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/a72c0435ecf71248f311900475e881cc07ac2eaf/comments",
+            "author": {
+                "login": "aboedo",
+                "id": 3922667,
+                "node_id": "MDQ6VXNlcjM5MjI2Njc=",
+                "avatar_url": "https://avatars.githubusercontent.com/u/3922667?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/aboedo",
+                "html_url": "https://github.com/aboedo",
+                "followers_url": "https://api.github.com/users/aboedo/followers",
+                "following_url": "https://api.github.com/users/aboedo/following{/other_user}",
+                "gists_url": "https://api.github.com/users/aboedo/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/aboedo/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/aboedo/subscriptions",
+                "organizations_url": "https://api.github.com/users/aboedo/orgs",
+                "repos_url": "https://api.github.com/users/aboedo/repos",
+                "events_url": "https://api.github.com/users/aboedo/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/aboedo/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "committer": {
+                "login": "web-flow",
+                "id": 19864447,
+                "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+                "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/web-flow",
+                "html_url": "https://github.com/web-flow",
+                "followers_url": "https://api.github.com/users/web-flow/followers",
+                "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+                "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+                "organizations_url": "https://api.github.com/users/web-flow/orgs",
+                "repos_url": "https://api.github.com/users/web-flow/repos",
+                "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/web-flow/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "parents": [
+                {
+                    "sha": "bb8687d51190e42cd48e6cdd8039392f208601c3",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/bb8687d51190e42cd48e6cdd8039392f208601c3",
+                    "html_url": "https://github.com/RevenueCat/purchases-ios/commit/bb8687d51190e42cd48e6cdd8039392f208601c3"
+                }
+            ]
+        },
+        {
+            "sha": "3625e195a117ad0435864dc8a561e6a0c6052bdf",
+            "node_id": "C_kwDOBnB8hdoAKGE3MmMwNDM1ZWNmNzEyNDhmMzExOTAwNDc1ZTg4MWNjMDdhYzJlYWY",
+            "commit": {
+                "author": {
+                    "name": "aboedo",
+                    "email": "andresboedo@gmail.com",
+                    "date": "2022-07-04T14:36:41Z"
+                },
+                "committer": {
+                    "name": "GitHub",
+                    "email": "noreply@github.com",
+                    "date": "2022-07-04T14:36:41Z"
+                },
+                "message": "`Paywalls Components`: this is amazing",
+                "tree": {
+                    "sha": "051c6736cff89107bd32cb3b8baa64627c7eac8a",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/git/trees/051c6736cff89107bd32cb3b8baa64627c7eac8a"
+                },
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/git/commits/a72c0435ecf71248f311900475e881cc07ac2eaf",
+                "comment_count": 0,
+                "verification": {
+                    "verified": true,
+                    "reason": "valid",
+                    "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsBcBAABCAAQBQJiwvr5CRBK7hj4Ov3rIwAAaHoIAGNCSoN7wVbeuBBMMr0PutDS\n4m2wl5q6is2hXgjFVZTDAToX6K+6c8FbHtmnOwgzjjEdY3T+ewIWNQ1IZFGDcarx\nzAxbk1r5jsyrrs2wGb53XK/HvT87IpWTARh5g1h+NUCT0/jmyIIReHgxNgSzUzhr\nGlM2MowmwE2qrlV062L33A7NIFP267lIfyriTPUHfmpfKkZN/EKdIcGX+2dtOX49\nFMpVxF1AFsp+GTiDLr6N1LIIByevGRliaQWcGYNvQWoeqG/h7bU87gq9ZeitMCEH\nVizJTA2YiGl4mGIBocTicWAoqauHBrPZmqHd1N4rcW0c3LQLEAIyFX5xk8V24Do=\n=7PGO\n-----END PGP SIGNATURE-----\n",
+                    "payload": "tree 051c6736cff89107bd32cb3b8baa64627c7eac8a\nparent bb8687d51190e42cd48e6cdd8039392f208601c3\nauthor aboedo <andresboedo@gmail.com> 1656945401 -0300\ncommitter GitHub <noreply@github.com> 1656945401 -0300\n\nadded log when setting `autoSyncPurchases` to false (#1749)\n\n"
+                }
+            },
+            "url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/a72c0435ecf71248f311900475e881cc07ac2eaf",
+            "html_url": "https://github.com/RevenueCat/purchases-ios/commit/a72c0435ecf71248f311900475e881cc07ac2eaf",
+            "comments_url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/a72c0435ecf71248f311900475e881cc07ac2eaf/comments",
+            "author": {
+                "login": "aboedo",
+                "id": 3922667,
+                "node_id": "MDQ6VXNlcjM5MjI2Njc=",
+                "avatar_url": "https://avatars.githubusercontent.com/u/3922667?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/aboedo",
+                "html_url": "https://github.com/aboedo",
+                "followers_url": "https://api.github.com/users/aboedo/followers",
+                "following_url": "https://api.github.com/users/aboedo/following{/other_user}",
+                "gists_url": "https://api.github.com/users/aboedo/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/aboedo/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/aboedo/subscriptions",
+                "organizations_url": "https://api.github.com/users/aboedo/orgs",
+                "repos_url": "https://api.github.com/users/aboedo/repos",
+                "events_url": "https://api.github.com/users/aboedo/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/aboedo/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "committer": {
+                "login": "web-flow",
+                "id": 19864447,
+                "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+                "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/web-flow",
+                "html_url": "https://github.com/web-flow",
+                "followers_url": "https://api.github.com/users/web-flow/followers",
+                "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+                "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+                "organizations_url": "https://api.github.com/users/web-flow/orgs",
+                "repos_url": "https://api.github.com/users/web-flow/repos",
+                "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/web-flow/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "parents": [
+                {
+                    "sha": "bb8687d51190e42cd48e6cdd8039392f208601c3",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/bb8687d51190e42cd48e6cdd8039392f208601c3",
+                    "html_url": "https://github.com/RevenueCat/purchases-ios/commit/bb8687d51190e42cd48e6cdd8039392f208601c3"
+                }
+            ]
+        },
+        {
+            "sha": "a72c0435ecf71248f311900475e881cc07ac2eaf",
+            "node_id": "C_kwDOBnB8hdoAKGE3MmMwNDM1ZWNmNzEyNDhmMzExOTAwNDc1ZTg4MWNjMDdhYzJlYWY",
+            "commit": {
+                "author": {
+                    "name": "aboedo",
+                    "email": "andresboedo@gmail.com",
+                    "date": "2022-07-04T14:36:41Z"
+                },
+                "committer": {
+                    "name": "GitHub",
+                    "email": "noreply@github.com",
+                    "date": "2022-07-04T14:36:41Z"
+                },
+                "message": "added log when setting `autoSyncPurchases` to false (#1749)",
+                "tree": {
+                    "sha": "051c6736cff89107bd32cb3b8baa64627c7eac8a",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/git/trees/051c6736cff89107bd32cb3b8baa64627c7eac8a"
+                },
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/git/commits/a72c0435ecf71248f311900475e881cc07ac2eaf",
+                "comment_count": 0,
+                "verification": {
+                    "verified": true,
+                    "reason": "valid",
+                    "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsBcBAABCAAQBQJiwvr5CRBK7hj4Ov3rIwAAaHoIAGNCSoN7wVbeuBBMMr0PutDS\n4m2wl5q6is2hXgjFVZTDAToX6K+6c8FbHtmnOwgzjjEdY3T+ewIWNQ1IZFGDcarx\nzAxbk1r5jsyrrs2wGb53XK/HvT87IpWTARh5g1h+NUCT0/jmyIIReHgxNgSzUzhr\nGlM2MowmwE2qrlV062L33A7NIFP267lIfyriTPUHfmpfKkZN/EKdIcGX+2dtOX49\nFMpVxF1AFsp+GTiDLr6N1LIIByevGRliaQWcGYNvQWoeqG/h7bU87gq9ZeitMCEH\nVizJTA2YiGl4mGIBocTicWAoqauHBrPZmqHd1N4rcW0c3LQLEAIyFX5xk8V24Do=\n=7PGO\n-----END PGP SIGNATURE-----\n",
+                    "payload": "tree 051c6736cff89107bd32cb3b8baa64627c7eac8a\nparent bb8687d51190e42cd48e6cdd8039392f208601c3\nauthor aboedo <andresboedo@gmail.com> 1656945401 -0300\ncommitter GitHub <noreply@github.com> 1656945401 -0300\n\nadded log when setting `autoSyncPurchases` to false (#1749)\n\n"
+                }
+            },
+            "url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/a72c0435ecf71248f311900475e881cc07ac2eaf",
+            "html_url": "https://github.com/RevenueCat/purchases-ios/commit/a72c0435ecf71248f311900475e881cc07ac2eaf",
+            "comments_url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/a72c0435ecf71248f311900475e881cc07ac2eaf/comments",
+            "author": {
+                "login": "aboedo",
+                "id": 3922667,
+                "node_id": "MDQ6VXNlcjM5MjI2Njc=",
+                "avatar_url": "https://avatars.githubusercontent.com/u/3922667?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/aboedo",
+                "html_url": "https://github.com/aboedo",
+                "followers_url": "https://api.github.com/users/aboedo/followers",
+                "following_url": "https://api.github.com/users/aboedo/following{/other_user}",
+                "gists_url": "https://api.github.com/users/aboedo/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/aboedo/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/aboedo/subscriptions",
+                "organizations_url": "https://api.github.com/users/aboedo/orgs",
+                "repos_url": "https://api.github.com/users/aboedo/repos",
+                "events_url": "https://api.github.com/users/aboedo/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/aboedo/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "committer": {
+                "login": "web-flow",
+                "id": 19864447,
+                "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+                "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/web-flow",
+                "html_url": "https://github.com/web-flow",
+                "followers_url": "https://api.github.com/users/web-flow/followers",
+                "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+                "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+                "organizations_url": "https://api.github.com/users/web-flow/orgs",
+                "repos_url": "https://api.github.com/users/web-flow/repos",
+                "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/web-flow/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "parents": [
+                {
+                    "sha": "bb8687d51190e42cd48e6cdd8039392f208601c3",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/bb8687d51190e42cd48e6cdd8039392f208601c3",
+                    "html_url": "https://github.com/RevenueCat/purchases-ios/commit/bb8687d51190e42cd48e6cdd8039392f208601c3"
+                }
+            ]
+        },
+        {
+            "sha": "cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+            "node_id": "C_kwDOBnB8hdoAKGNmZGQ4MGY3M2Q4YzkxMTIxMzEzZDcyMjI3YjRjYmUyODNiNTdjMWU",
+            "commit": {
+                "author": {
+                    "name": "RevenueCat Releases",
+                    "email": "60164957+revenuecat-ops@users.noreply.github.com",
+                    "date": "2022-07-05T04:50:37Z"
+                },
+                "committer": {
+                    "name": "GitHub",
+                    "email": "noreply@github.com",
+                    "date": "2022-07-05T04:50:37Z"
+                },
+                "message": "Prepare next version: 4.8.0-SNAPSHOT (#1750)\n\n* Preparing for next version\r\n\r\n* Remove prerelease modifiers from plist files\r\n\r\nCo-authored-by: Distiller <distiller@static.198.206.135.57.macminivault.com>\r\nCo-authored-by: Toni Rico <antonio.rico.diez@revenuecat.com>",
+                "tree": {
+                    "sha": "f096af3048224d3e97517cb0fbab72c7441581e1",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/git/trees/f096af3048224d3e97517cb0fbab72c7441581e1"
+                },
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/git/commits/cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+                "comment_count": 0,
+                "verification": {
+                    "verified": true,
+                    "reason": "valid",
+                    "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsBcBAABCAAQBQJiw8MdCRBK7hj4Ov3rIwAAelcIAJD0hVc5TaAolEK+nt9rfI7j\nLlCQ5ngCFUXLsXnh8yDc66XvY6rf8XzRHZfa6ToHTcXU4T+rsBUMVo1B3d4Xcwfm\nQTJO0lz1L3DYRqvM7xA1oTtZOqW96/Lt7NA2BQkJkvxzOjFBXPwVNSdzoUdpus6S\nrJhOUIG01cY3jLcQem5EqNVmAysxvDukv94CRw1KioxKZERdOPOathsNCrDy+U4H\ngS10SSEzmTk4Mm7RL5ps4bAek2JCluIOMd50FG+QRXEsocJ4WlRfh4pU5DfGyZeu\nKm4baaAMiZyPyfcU7VUI0rzHgx4Jo+/g4xu1ectTCg/F2cZbA70oVgbRF5Bxojo=\n=xQh5\n-----END PGP SIGNATURE-----\n",
+                    "payload": "tree f096af3048224d3e97517cb0fbab72c7441581e1\nparent 0e67cdb1c7582ce3e2fd00367acc24db6242c6d6\nauthor RevenueCat Releases <60164957+revenuecat-ops@users.noreply.github.com> 1656996637 +0200\ncommitter GitHub <noreply@github.com> 1656996637 +0200\n\nPrepare next version: 4.8.0-SNAPSHOT (#1750)\n\n* Preparing for next version\r\n\r\n* Remove prerelease modifiers from plist files\r\n\r\nCo-authored-by: Distiller <distiller@static.198.206.135.57.macminivault.com>\r\nCo-authored-by: Toni Rico <antonio.rico.diez@revenuecat.com>"
+                }
+            },
+            "url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+            "html_url": "https://github.com/RevenueCat/purchases-ios/commit/cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+            "comments_url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/cfdd80f73d8c91121313d72227b4cbe283b57c1e/comments",
+            "author": {
+                "login": "revenuecat-ops",
+                "id": 60164957,
+                "node_id": "MDQ6VXNlcjYwMTY0OTU3",
+                "avatar_url": "https://avatars.githubusercontent.com/u/60164957?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/revenuecat-ops",
+                "html_url": "https://github.com/revenuecat-ops",
+                "followers_url": "https://api.github.com/users/revenuecat-ops/followers",
+                "following_url": "https://api.github.com/users/revenuecat-ops/following{/other_user}",
+                "gists_url": "https://api.github.com/users/revenuecat-ops/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/revenuecat-ops/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/revenuecat-ops/subscriptions",
+                "organizations_url": "https://api.github.com/users/revenuecat-ops/orgs",
+                "repos_url": "https://api.github.com/users/revenuecat-ops/repos",
+                "events_url": "https://api.github.com/users/revenuecat-ops/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/revenuecat-ops/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "committer": {
+                "login": "web-flow",
+                "id": 19864447,
+                "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+                "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/web-flow",
+                "html_url": "https://github.com/web-flow",
+                "followers_url": "https://api.github.com/users/web-flow/followers",
+                "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+                "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+                "organizations_url": "https://api.github.com/users/web-flow/orgs",
+                "repos_url": "https://api.github.com/users/web-flow/repos",
+                "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/web-flow/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "parents": [
+                {
+                    "sha": "0e67cdb1c7582ce3e2fd00367acc24db6242c6d6",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/commits/0e67cdb1c7582ce3e2fd00367acc24db6242c6d6",
+                    "html_url": "https://github.com/RevenueCat/purchases-ios/commit/0e67cdb1c7582ce3e2fd00367acc24db6242c6d6"
+                }
+            ]
+        }
+    ],
+    "files": [
+        {
+            "sha": "f4c92234f9e1188f83ab5f3368856ba043f9c037",
+            "filename": ".jazzy.yaml",
+            "status": "modified",
+            "additions": 2,
+            "deletions": 2,
+            "changes": 4,
+            "blob_url": "https://github.com/RevenueCat/purchases-ios/blob/cfdd80f73d8c91121313d72227b4cbe283b57c1e/.jazzy.yaml",
+            "raw_url": "https://github.com/RevenueCat/purchases-ios/raw/cfdd80f73d8c91121313d72227b4cbe283b57c1e/.jazzy.yaml",
+            "contents_url": "https://api.github.com/repos/RevenueCat/purchases-ios/contents/.jazzy.yaml?ref=cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+            "patch": "@@ -2,9 +2,9 @@ clean: true\n author: RevenueCat\n author_url: https://revenuecat.com\n sdk: iphonesimulator\n-module_version: 4.7.0\n+module_version: 4.8.0-SNAPSHOT\n github_url: https://github.com/revenuecat/purchases-ios\n-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/4.7.0\n+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/4.8.0-SNAPSHOT\n output: generated_docs\n include:\n   - \"Sources/**/*\""
+        },
+        {
+            "sha": "b108af6136862e4816b2fdcae187618f61b5bbe0",
+            "filename": ".version",
+            "status": "modified",
+            "additions": 1,
+            "deletions": 1,
+            "changes": 2,
+            "blob_url": "https://github.com/RevenueCat/purchases-ios/blob/cfdd80f73d8c91121313d72227b4cbe283b57c1e/.version",
+            "raw_url": "https://github.com/RevenueCat/purchases-ios/raw/cfdd80f73d8c91121313d72227b4cbe283b57c1e/.version",
+            "contents_url": "https://api.github.com/repos/RevenueCat/purchases-ios/contents/.version?ref=cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+            "patch": "@@ -1 +1 @@\n-4.7.0\n+4.8.0-SNAPSHOT"
+        },
+        {
+            "sha": "aa37ecdaff01405238d989d58a6c8ba0ccfd49f1",
+            "filename": "RevenueCat.podspec",
+            "status": "modified",
+            "additions": 1,
+            "deletions": 1,
+            "changes": 2,
+            "blob_url": "https://github.com/RevenueCat/purchases-ios/blob/cfdd80f73d8c91121313d72227b4cbe283b57c1e/RevenueCat.podspec",
+            "raw_url": "https://github.com/RevenueCat/purchases-ios/raw/cfdd80f73d8c91121313d72227b4cbe283b57c1e/RevenueCat.podspec",
+            "contents_url": "https://api.github.com/repos/RevenueCat/purchases-ios/contents/RevenueCat.podspec?ref=cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+            "patch": "@@ -1,6 +1,6 @@\n Pod::Spec.new do |s|\n   s.name             = \"RevenueCat\"\n-  s.version          = \"4.7.0\"\n+  s.version          = \"4.8.0-SNAPSHOT\"\n   s.summary          = \"Subscription and in-app-purchase backend service.\"\n \n   s.description      = <<-DESC"
+        },
+        {
+            "sha": "ae18ae2099b6995c7e6de993d0621a4ef4e2a31b",
+            "filename": "Sources/Info.plist",
+            "status": "modified",
+            "additions": 1,
+            "deletions": 1,
+            "changes": 2,
+            "blob_url": "https://github.com/RevenueCat/purchases-ios/blob/cfdd80f73d8c91121313d72227b4cbe283b57c1e/Sources%2FInfo.plist",
+            "raw_url": "https://github.com/RevenueCat/purchases-ios/raw/cfdd80f73d8c91121313d72227b4cbe283b57c1e/Sources%2FInfo.plist",
+            "contents_url": "https://api.github.com/repos/RevenueCat/purchases-ios/contents/Sources%2FInfo.plist?ref=cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+            "patch": "@@ -17,7 +17,7 @@\n \t<key>CFBundlePackageType</key>\n \t<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>\n \t<key>CFBundleShortVersionString</key>\n-\t<string>4.7.0</string>\n+\t<string>4.8.0</string>\n \t<key>CFBundleVersion</key>\n \t<string>$(CURRENT_PROJECT_VERSION)</string>\n \t<key>LSApplicationCategoryType</key>"
+        },
+        {
+            "sha": "90a4cbcbe052e92f9184328dbc141e2d0eb56b34",
+            "filename": "Sources/Logging/Strings/ConfigureStrings.swift",
+            "status": "modified",
+            "additions": 11,
+            "deletions": 0,
+            "changes": 11,
+            "blob_url": "https://github.com/RevenueCat/purchases-ios/blob/cfdd80f73d8c91121313d72227b4cbe283b57c1e/Sources%2FLogging%2FStrings%2FConfigureStrings.swift",
+            "raw_url": "https://github.com/RevenueCat/purchases-ios/raw/cfdd80f73d8c91121313d72227b4cbe283b57c1e/Sources%2FLogging%2FStrings%2FConfigureStrings.swift",
+            "contents_url": "https://api.github.com/repos/RevenueCat/purchases-ios/contents/Sources%2FLogging%2FStrings%2FConfigureStrings.swift?ref=cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+            "patch": "@@ -41,6 +41,8 @@ enum ConfigureStrings {\n \n     case invalidAPIKey\n \n+    case autoSyncPurchasesDisabled\n+\n }\n \n extension ConfigureStrings: CustomStringConvertible {\n@@ -82,6 +84,15 @@ extension ConfigureStrings: CustomStringConvertible {\n             \"Ensure that you are using the public app-specific API key, \" +\n             \" which should look like 'appl_1a2b3c4d5e6f7h'.\\n\" +\n             \"See https://rev.cat/auth for more details.\"\n+\n+        case .autoSyncPurchasesDisabled:\n+            return \"Automatic syncing of purchases has been disabled. \\n\" +\n+            \"RevenueCat won’t observe the StoreKit queue, and it will not sync any purchase \\n\" +\n+            \"automatically. Call syncPurchases whenever a new transaction is completed so the \\n\" +\n+            \"receipt is sent to RevenueCat’s backend. Consumables disappear from the receipt \\n\" +\n+            \"after the transaction is finished, so make sure purchases are synced before \\n\" +\n+            \"finishing any consumable transaction, otherwise RevenueCat won’t register the \\n\" +\n+            \"purchase.\"\n         }\n     }\n "
+        },
+        {
+            "sha": "a44b182a97ecbf8cfde7292d7093dcaade536b03",
+            "filename": "Sources/Misc/SystemInfo.swift",
+            "status": "modified",
+            "additions": 1,
+            "deletions": 1,
+            "changes": 2,
+            "blob_url": "https://github.com/RevenueCat/purchases-ios/blob/cfdd80f73d8c91121313d72227b4cbe283b57c1e/Sources%2FMisc%2FSystemInfo.swift",
+            "raw_url": "https://github.com/RevenueCat/purchases-ios/raw/cfdd80f73d8c91121313d72227b4cbe283b57c1e/Sources%2FMisc%2FSystemInfo.swift",
+            "contents_url": "https://api.github.com/repos/RevenueCat/purchases-ios/contents/Sources%2FMisc%2FSystemInfo.swift?ref=cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+            "patch": "@@ -43,7 +43,7 @@ class SystemInfo {\n     }\n \n     static var frameworkVersion: String {\n-        return \"4.7.0\"\n+        return \"4.8.0-SNAPSHOT\"\n     }\n \n     static var systemVersion: String {"
+        },
+        {
+            "sha": "066d774979ada56b1792ce1c65336f38fd46ebb1",
+            "filename": "Sources/Purchasing/Purchases/Purchases.swift",
+            "status": "modified",
+            "additions": 2,
+            "deletions": 0,
+            "changes": 2,
+            "blob_url": "https://github.com/RevenueCat/purchases-ios/blob/cfdd80f73d8c91121313d72227b4cbe283b57c1e/Sources%2FPurchasing%2FPurchases%2FPurchases.swift",
+            "raw_url": "https://github.com/RevenueCat/purchases-ios/raw/cfdd80f73d8c91121313d72227b4cbe283b57c1e/Sources%2FPurchasing%2FPurchases%2FPurchases.swift",
+            "contents_url": "https://api.github.com/repos/RevenueCat/purchases-ios/contents/Sources%2FPurchasing%2FPurchases%2FPurchases.swift?ref=cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+            "patch": "@@ -461,6 +461,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void\n \n         if self.systemInfo.dangerousSettings.autoSyncPurchases {\n             storeKitWrapper.delegate = purchasesOrchestrator\n+        } else {\n+            Logger.warn(Strings.configure.autoSyncPurchasesDisabled)\n         }\n         subscribeToAppStateNotifications()\n         attributionPoster.postPostponedAttributionDataIfNeeded()"
+        },
+        {
+            "sha": "0489939373f96907daaa0d249f380e89bc8848b8",
+            "filename": "Tests/BackendIntegrationTestApp/Info.plist",
+            "status": "modified",
+            "additions": 1,
+            "deletions": 1,
+            "changes": 2,
+            "blob_url": "https://github.com/RevenueCat/purchases-ios/blob/cfdd80f73d8c91121313d72227b4cbe283b57c1e/Tests%2FBackendIntegrationTestApp%2FInfo.plist",
+            "raw_url": "https://github.com/RevenueCat/purchases-ios/raw/cfdd80f73d8c91121313d72227b4cbe283b57c1e/Tests%2FBackendIntegrationTestApp%2FInfo.plist",
+            "contents_url": "https://api.github.com/repos/RevenueCat/purchases-ios/contents/Tests%2FBackendIntegrationTestApp%2FInfo.plist?ref=cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+            "patch": "@@ -17,7 +17,7 @@\n \t<key>CFBundlePackageType</key>\n \t<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>\n \t<key>CFBundleShortVersionString</key>\n-\t<string>4.7.0</string>\n+\t<string>4.8.0</string>\n \t<key>CFBundleVersion</key>\n \t<string>1</string>\n \t<key>LSRequiresIPhoneOS</key>"
+        },
+        {
+            "sha": "8bf01c62ff6c99f543a2978e9868fcd929710d31",
+            "filename": "Tests/BackendIntegrationTests/Info.plist",
+            "status": "modified",
+            "additions": 1,
+            "deletions": 1,
+            "changes": 2,
+            "blob_url": "https://github.com/RevenueCat/purchases-ios/blob/cfdd80f73d8c91121313d72227b4cbe283b57c1e/Tests%2FBackendIntegrationTests%2FInfo.plist",
+            "raw_url": "https://github.com/RevenueCat/purchases-ios/raw/cfdd80f73d8c91121313d72227b4cbe283b57c1e/Tests%2FBackendIntegrationTests%2FInfo.plist",
+            "contents_url": "https://api.github.com/repos/RevenueCat/purchases-ios/contents/Tests%2FBackendIntegrationTests%2FInfo.plist?ref=cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+            "patch": "@@ -15,7 +15,7 @@\n \t<key>CFBundlePackageType</key>\n \t<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>\n \t<key>CFBundleShortVersionString</key>\n-\t<string>4.7.0</string>\n+\t<string>4.8.0</string>\n \t<key>CFBundleVersion</key>\n \t<string>1</string>\n </dict>"
+        },
+        {
+            "sha": "8bf01c62ff6c99f543a2978e9868fcd929710d31",
+            "filename": "Tests/UnitTests/Info.plist",
+            "status": "modified",
+            "additions": 1,
+            "deletions": 1,
+            "changes": 2,
+            "blob_url": "https://github.com/RevenueCat/purchases-ios/blob/cfdd80f73d8c91121313d72227b4cbe283b57c1e/Tests%2FUnitTests%2FInfo.plist",
+            "raw_url": "https://github.com/RevenueCat/purchases-ios/raw/cfdd80f73d8c91121313d72227b4cbe283b57c1e/Tests%2FUnitTests%2FInfo.plist",
+            "contents_url": "https://api.github.com/repos/RevenueCat/purchases-ios/contents/Tests%2FUnitTests%2FInfo.plist?ref=cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+            "patch": "@@ -15,7 +15,7 @@\n \t<key>CFBundlePackageType</key>\n \t<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>\n \t<key>CFBundleShortVersionString</key>\n-\t<string>4.7.0</string>\n+\t<string>4.8.0</string>\n \t<key>CFBundleVersion</key>\n \t<string>1</string>\n </dict>"
+        },
+        {
+            "sha": "fe01d5a799f6f3a5fb10c1b63014d9543ffc7f51",
+            "filename": "Tests/UnitTestsHostApp/Info.plist",
+            "status": "modified",
+            "additions": 1,
+            "deletions": 1,
+            "changes": 2,
+            "blob_url": "https://github.com/RevenueCat/purchases-ios/blob/cfdd80f73d8c91121313d72227b4cbe283b57c1e/Tests%2FUnitTestsHostApp%2FInfo.plist",
+            "raw_url": "https://github.com/RevenueCat/purchases-ios/raw/cfdd80f73d8c91121313d72227b4cbe283b57c1e/Tests%2FUnitTestsHostApp%2FInfo.plist",
+            "contents_url": "https://api.github.com/repos/RevenueCat/purchases-ios/contents/Tests%2FUnitTestsHostApp%2FInfo.plist?ref=cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+            "patch": "@@ -17,7 +17,7 @@\n \t<key>CFBundlePackageType</key>\n \t<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>\n \t<key>CFBundleShortVersionString</key>\n-\t<string>4.7.0</string>\n+\t<string>4.8.0</string>\n \t<key>CFBundleVersion</key>\n \t<string>1</string>\n \t<key>LSRequiresIPhoneOS</key>"
+        },
+        {
+            "sha": "c74a363e1d7d9cd37722f0a92632ef5e6249ea52",
+            "filename": "fastlane/CommonFastfile",
+            "status": "modified",
+            "additions": 4,
+            "deletions": 0,
+            "changes": 4,
+            "blob_url": "https://github.com/RevenueCat/purchases-ios/blob/cfdd80f73d8c91121313d72227b4cbe283b57c1e/fastlane%2FCommonFastfile",
+            "raw_url": "https://github.com/RevenueCat/purchases-ios/raw/cfdd80f73d8c91121313d72227b4cbe283b57c1e/fastlane%2FCommonFastfile",
+            "contents_url": "https://api.github.com/repos/RevenueCat/purchases-ios/contents/fastlane%2FCommonFastfile?ref=cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+            "patch": "@@ -215,13 +215,17 @@ lane :replace_version_number do |options|\n   UI.user_error!(\"missing version\") unless new_version_number\n   files_to_update_string = ENV['FILES_TO_UPDATE_VERSION_STRING']\n   UI.user_error!(\"missing files to update env\") unless files_to_update_string\n+  files_to_update_without_prerelease_modifiers_string = ENV['FILES_TO_UPDATE_VERSION_WITHOUT_PRERELEASE_MODIFIERS_STRING'] || \"\"\n   files_to_update = files_to_update_string.split(\",\")\n+  files_to_update_without_prerelease_modifiers = files_to_update_without_prerelease_modifiers_string.split(\",\")\n   previous_version_number = current_version_number\n   previous_version_number_without_prerelease_modifiers = previous_version_number.split(\"-\")[0]\n   new_version_number_without_prerelease_modifiers = new_version_number.split(\"-\")[0]\n \n   for file_to_update in files_to_update\n     increment_build_number(previous_version_number, new_version_number, file_to_update.strip)\n+  end\n+  for file_to_update in files_to_update_without_prerelease_modifiers\n     increment_build_number(previous_version_number_without_prerelease_modifiers, new_version_number_without_prerelease_modifiers, file_to_update.strip)\n   end\n end"
+        },
+        {
+            "sha": "d80f95a0a8272900d317de6828f6da7d1e7ccb17",
+            "filename": "fastlane/Fastfile",
+            "status": "modified",
+            "additions": 3,
+            "deletions": 3,
+            "changes": 6,
+            "blob_url": "https://github.com/RevenueCat/purchases-ios/blob/cfdd80f73d8c91121313d72227b4cbe283b57c1e/fastlane%2FFastfile",
+            "raw_url": "https://github.com/RevenueCat/purchases-ios/raw/cfdd80f73d8c91121313d72227b4cbe283b57c1e/fastlane%2FFastfile",
+            "contents_url": "https://api.github.com/repos/RevenueCat/purchases-ios/contents/fastlane%2FFastfile?ref=cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+            "patch": "@@ -20,11 +20,11 @@ ENV[\"FILES_TO_UPDATE_VERSION_STRING\"] = \"\n   ../Sources/Misc/SystemInfo.swift,\n   ../.jazzy.yaml,\n   ../.version,\n-  ../Examples/MagicWeather/MagicWeather.xcodeproj/project.pbxproj,\n-  ../Examples/MagicWeatherSwiftUI/Magic Weather SwiftUI.xcodeproj/project.pbxproj,\n   ../scripts/docs/index.html,\n+  ../Sources/Misc/SystemInfo.swift\n+\"\n+ENV[\"FILES_TO_UPDATE_VERSION_WITHOUT_PRERELEASE_MODIFIERS_STRING\"] = \"\n   ../Sources/Info.plist,\n-  ../Sources/Misc/SystemInfo.swift,\n   ../Tests/BackendIntegrationTestApp/Info.plist,\n   ../Tests/BackendIntegrationTests/Info.plist,\n   ../Tests/UnitTests/Info.plist,"
+        },
+        {
+            "sha": "04c3dc5aff302ac940ce04d70975274de00454f6",
+            "filename": "fastlane/README.md",
+            "status": "modified",
+            "additions": 2,
+            "deletions": 2,
+            "changes": 4,
+            "blob_url": "https://github.com/RevenueCat/purchases-ios/blob/cfdd80f73d8c91121313d72227b4cbe283b57c1e/fastlane%2FREADME.md",
+            "raw_url": "https://github.com/RevenueCat/purchases-ios/raw/cfdd80f73d8c91121313d72227b4cbe283b57c1e/fastlane%2FREADME.md",
+            "contents_url": "https://api.github.com/repos/RevenueCat/purchases-ios/contents/fastlane%2FREADME.md?ref=cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+            "patch": "@@ -13,10 +13,10 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do\n \n # Available Actions\n \n-### bump\n+### bump_version_update_changelog_create_pr\n \n ```sh\n-[bundle exec] fastlane bump\n+[bundle exec] fastlane bump_version_update_changelog_create_pr\n ```\n \n Bump version, edit changelog, and create pull request"
+        },
+        {
+            "sha": "2c4395dc8c757c8d99c3b67f00a3ba2d0ff849a6",
+            "filename": "scripts/docs/index.html",
+            "status": "modified",
+            "additions": 1,
+            "deletions": 1,
+            "changes": 2,
+            "blob_url": "https://github.com/RevenueCat/purchases-ios/blob/cfdd80f73d8c91121313d72227b4cbe283b57c1e/scripts%2Fdocs%2Findex.html",
+            "raw_url": "https://github.com/RevenueCat/purchases-ios/raw/cfdd80f73d8c91121313d72227b4cbe283b57c1e/scripts%2Fdocs%2Findex.html",
+            "contents_url": "https://api.github.com/repos/RevenueCat/purchases-ios/contents/scripts%2Fdocs%2Findex.html?ref=cfdd80f73d8c91121313d72227b4cbe283b57c1e",
+            "patch": "@@ -2,7 +2,7 @@\n <!DOCTYPE html>\n <html>\n <head>\n-    <meta http-equiv=\"refresh\" content=\"0; url=https://revenuecat.github.io/purchases-ios-docs/4.7.0/documentation/revenuecat\"/>\n+    <meta http-equiv=\"refresh\" content=\"0; url=https://revenuecat.github.io/purchases-ios-docs/4.8.0-SNAPSHOT/documentation/revenuecat\"/>\n </head>\n <body>\n </body>"
+        }
+    ]
+}

--- a/spec/test_files/minor_get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json
+++ b/spec/test_files/minor_get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json
@@ -47,7 +47,7 @@
                     "id": 4352868120,
                     "node_id": "LA_kwDOBnB8hc8AAAACA3N_HD",
                     "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/minor",
-                    "name": "pr:minor",
+                    "name": "pr:force_minor",
                     "color": "8B3E6C",
                     "default": false,
                     "description": ""


### PR DESCRIPTION
- The changelog is now split between `RevenueCat SDK` and `RevenueCatUI SDK`. Something tagged with `pr:revenuecatui` will go into the `RevenueCatUI` section
- There can be arbitrary feature labels now. For example prs with labels `feat:Customer Center` or `feat:Paywall Components` will be rendered under new sections.
- These new feature sections have subsections for fixes and new features. So a PR should still be tagged with the `pr:` label (for example `feat:Customer Center` and `pr:fix`. If the PR label is not `pr:feat` or `pr:fix` go directly to `Other changes` section (outside of the specific functionality). This is to keep “internal” features in `Other changes`, making the changelog more readable for developers
- I unified the labels: `pr:docs`, `pr:perf` to `pr:fix`. And `pr:build`, `pr:ci`, `pr:refactor`, `pr:style`, `pr:test` to `pr:other`
- If a release only contains `pr:other` prs, it will be skipped.
- Renamed `pr:minor` to `pr:force_minor`. Created `pr:force_patch` to be able to force releases with only `pr:other`

```
## RevenueCat SDK
### ✨ New Features
* added a log when `autoSyncPurchases` is disabled (#1749) via aboedo (@aboedo)

## RevenueCatUI SDK
### Customer Center
#### ✨ New Features
* `Customer Center`: contact support (#2949) via aboedo (@aboedo)
#### 🐞 Bugfixes
* `Customer Center`: a fix (#2949) via aboedo (@aboedo)
### Paywall Components
#### ✨ New Features
* `Paywalls Components`: this is amazing (#2949) via aboedo (@aboedo)

### 🔄 Other Changes
* `Paywalls Components`: another amazing thing (#2949) via aboedo (@aboedo)
```