### PR TITLE
Fixes bump detection for pr:force_patch and pr:force_minor

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -8,7 +8,7 @@ module Fastlane
 
   module Helper
     class GitHubHelper
-      SUPPORTED_PR_LABELS = (%w[breaking build ci docs feat fix perf revenuecatui refactor style test next_release dependencies phc_dependencies minor revenuecatui].map { |label| "pr:#{label}" }).to_set
+      SUPPORTED_PR_LABELS = (%w[breaking build ci docs feat fix perf revenuecatui refactor style test next_release dependencies phc_dependencies force_minor force_patch revenuecatui].map { |label| "pr:#{label}" }).to_set
 
       def self.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch)
         if rate_limit_sleep > 0

--- a/spec/test_files/patch_get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json
+++ b/spec/test_files/patch_get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json
@@ -37,8 +37,8 @@
                 {
                     "id": 4352868120,
                     "node_id": "LB_kwDOBnB8hc8AABACA3N_HQ",
-                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/pr:phc_dependencies",
-                    "name": "pr:phc_dependencies",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/pr:other",
+                    "name": "pr:other",
                     "color": "8E3E6B",
                     "default": false,
                     "description": ""
@@ -46,8 +46,8 @@
                 {
                     "id": 4352868120,
                     "node_id": "LA_kwDOBnB8hc8AAAACA3N_HD",
-                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/pr:force_minor",
-                    "name": "pr:force_minor",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/pr:force_patch",
+                    "name": "pr:force_patch",
                     "color": "8B3E6C",
                     "default": false,
                     "description": ""


### PR DESCRIPTION
As the title says. I noticed that `pr:force_minor` wasn't working in https://github.com/RevenueCat/purchases-kmp/pull/219#issuecomment-2376221971. 
  
Added tests to verify `pr:force_minor` and `pr:force_patch`. The fix was to add those labels to `SUPPORTED_PR_LABELS`. 