### PR TITLE
Fix changelog generation when there are commits without PRs

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -110,8 +110,7 @@ module Fastlane
             UI.important("Cannot find pull request associated to #{sha}. Using commit information and adding it to the Other section")
             message = commit["commit"]["message"]
             name = commit["commit"]["author"]["name"]
-            username = commit["author"]["login"]
-            line = "* #{message} via #{name} (@#{username})"
+            line = "* #{message} via #{name}"
             changelog_sections[:other].push(line)
           else
             UI.user_error!("Cannot generate changelog. Multiple commits found for #{sha}")

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -447,7 +447,7 @@ describe Fastlane::Helper::VersioningHelper do
         nil
       )
       expect(changelog).to eq("### 🔄 Other Changes\n" \
-                              "* Updating great support link via Miguel José Carranza Guisado (@MiguelCarranza)")
+                              "* Updating great support link via Miguel José Carranza Guisado")
     end
 
     def mock_native_releases


### PR DESCRIPTION
From some tests, the `author` field in the Github response is null on commits that were merged without a PR. This was causing the automation to fail with a 
```
versioning_helper.rb:113:in `block in auto_generate_changelog': \e[31m[!] undefined method `[]' for nil:NilClass\e[0m (NoMethodError)
``` 

error.

I didn't see another way to get the username, so I just removed it from the changelog for now