### PR TITLE
[DX-287] Temporarily forks the fastlane's `SetGithubReleaseAction` to allow support for `make_latest`

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -73,6 +73,114 @@ module Fastlane
           start_tag < version && version <= end_tag && !release["prerelease"]
         end
       end
+
+      # This is a temporary workaround as the fastlane action does not support the `make_latest` parameter
+      def self.create_github_release(params)
+        UI.important("Creating release of #{params[:repository_name]} on tag \"#{params[:tag_name]}\" with name \"#{params[:name]}\".")
+        UI.important("Will also upload assets #{params[:upload_assets]}.") if params[:upload_assets]
+
+        repo_name = params[:repository_name]
+        api_token = params[:api_token]
+        server_url = params[:server_url]
+        tag_name = params[:tag_name]
+
+        payload = {
+          'tag_name' => params[:tag_name],
+          'draft' => !!params[:is_draft],
+          'prerelease' => !!params[:is_prerelease],
+          'generate_release_notes' => !!params[:is_generate_release_notes],
+          'make_latest' => !!params[:make_latest]
+        }
+        payload['name'] = params[:name] if params[:name]
+        payload['body'] = params[:description] if params[:description]
+        payload['target_commitish'] = params[:commitish] if params[:commitish]
+
+        response = Actions::GithubApiAction.run(
+          server_url: server_url,
+          api_token: api_token,
+          http_method: 'POST',
+          path: "repos/#{repo_name}/releases",
+          body: payload,
+          error_handlers: {
+            422 => proc do |result|
+              UI.error(result[:body])
+              UI.error("Release on tag #{tag_name} already exists!")
+              return nil
+            end,
+            404 => proc do |result|
+              UI.error(result[:body])
+              UI.user_error!("Repository #{repo_name} cannot be found, please double check its name and that you provided a valid API token")
+            end,
+            401 => proc do |result|
+              UI.error(result[:body])
+              UI.user_error!("You are not authorized to access #{repo_name}, please make sure you provided a valid API token")
+            end,
+            '*' => proc do |result|
+              UI.user_error!("GitHub responded with #{result[:status]}:#{result[:body]}")
+            end
+          }
+        )
+
+        json = response[:json]
+        html_url = json['html_url']
+        release_id = json['id']
+
+        UI.success("Successfully created release at tag \"#{tag_name}\" on GitHub")
+        UI.important("See release at \"#{html_url}\"")
+
+        assets = params[:upload_assets]
+        if assets && assets.count > 0
+          upload_assets(assets, json['upload_url'], api_token)
+          UI.success("Successfully uploaded assets #{assets} to release \"#{html_url}\"")
+        end
+
+        json || response[:body]
+      end
+
+      def self.upload_assets(assets, upload_url_template, api_token)
+        require 'addressable/template'
+        
+        assets.each do |asset_path|
+          absolute_path = File.absolute_path(asset_path)
+          UI.user_error!("Asset #{absolute_path} doesn't exist") unless File.exist?(absolute_path)
+          
+          if File.directory?(absolute_path)
+            Dir.mktmpdir do |dir|
+              tmpzip = File.join(dir, File.basename(absolute_path) + '.zip')
+              system("cd \"#{File.dirname(absolute_path)}\"; zip -r --symlinks \"#{tmpzip}\" \"#{File.basename(absolute_path)}\" 2>&1 >/dev/null")
+              upload_single_asset(tmpzip, upload_url_template, api_token)
+            end
+          else
+            upload_single_asset(absolute_path, upload_url_template, api_token)
+          end
+        end
+      end
+
+      def self.upload_single_asset(file, url_template, api_token)
+        require 'addressable/template'
+        
+        file_name = File.basename(file)
+        expanded_url = Addressable::Template.new(url_template).expand(name: file_name).to_s
+        headers = { 'Content-Type' => 'application/zip' }
+        
+        UI.important("Uploading #{file_name}")
+        
+        Actions::GithubApiAction.run(
+          api_token: api_token,
+          http_method: 'POST',
+          headers: headers,
+          url: expanded_url,
+          raw_body: File.read(file),
+          error_handlers: {
+            '*' => proc do |result|
+              UI.error("GitHub responded with #{result[:status]}:#{result[:body]}")
+              UI.user_error!("Failed to upload asset #{file_name} to GitHub.")
+            end
+          }
+        )
+        
+        UI.success("Successfully uploaded #{file_name}.")
+      end
     end
   end
 end

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -5,9 +5,9 @@ require 'fastlane/actions/push_to_git_remote'
 require 'fastlane/actions/create_pull_request'
 require 'fastlane/actions/ensure_git_branch'
 require 'fastlane/actions/ensure_git_status_clean'
-require 'fastlane/actions/set_github_release'
 require 'fastlane/actions/reset_git_repo'
 require_relative 'versioning_helper'
+require_relative 'github_helper'
 
 module Fastlane
   UI = FastlaneCore::UI unless Fastlane.const_defined?(:UI)
@@ -145,8 +145,9 @@ module Fastlane
       def self.create_github_release(release_version, release_description, upload_assets, repo_name, github_api_token)
         commit_hash = Actions.last_git_commit_dict[:commit_hash]
         is_prerelease = release_version.include?(DELIMITER_PRERELEASE)
+        is_latest_stable_release = !is_prerelease && newer_than_latest_published_version?(release_version)
 
-        Actions::SetGithubReleaseAction.run(
+        Helper::GitHubHelper.create_github_release(
           repository_name: "RevenueCat/#{repo_name}",
           api_token: github_api_token,
           name: release_version,
@@ -156,6 +157,7 @@ module Fastlane
           upload_assets: upload_assets,
           is_draft: false,
           is_prerelease: is_prerelease,
+          is_latest_stable_release: is_latest_stable_release,
           server_url: 'https://api.github.com'
         )
       end


### PR DESCRIPTION
We have recently realised that [fastlane's `set_github_release`](https://docs.fastlane.tools/actions/set_github_release/) does not support passing the `make_latest` parameter to the body of the request to GitHub's API.

To address this in the quickest way possible, let's fork the implemenation and add support for the new field. This new addition means that we can support marking only the latest stable release as the latest in GitHub.
