### PR TITLE
feat: add duplicate handling

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/pod_push_with_error_handling.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/pod_push_with_error_handling.rb
@@ -1,35 +1,36 @@
+require 'fastlane/action'
+require 'fastlane_core/ui/ui'
+require 'fastlane_core/configuration/config_item'
+
 module Fastlane
   module Actions
-    class PodPushUnknownError < StandardError; end 
+    class PodPushUnknownError < StandardError; end
 
     class PodPushWithErrorHandlingAction < Action
       def self.run(params)
-        begin
-          UI.message("🚀 Running pod_push with path: #{params[:path]}")
-          
-          output = Fastlane::Actions::PodPushAction.run(
-            path: params[:path],
-            synchronous: params[:synchronous],
-            verbose: params[:verbose],
-            allow_warnings: params[:allow_warnings]
-          )
+        UI.message("🚀 Running pod_push with path: #{params[:path]}")
 
-          return true
-        rescue => e
-          output_str = e.message
+        Fastlane::Actions::PodPushAction.run(
+          path: params[:path],
+          synchronous: params[:synchronous],
+          verbose: params[:verbose],
+          allow_warnings: params[:allow_warnings]
+        )
 
-          if output_str.include?("[!] Unable to accept duplicate entry for:")
-            UI.error("⚠️ Duplicate entry detected. Skipping push.")
-            return false
-          end
+        true
+      rescue StandardError => e
+        output_str = e.message
 
-          UI.user_error!("❌ Pod push failed: #{e.message}")
-          raise PodPushUnknownError, "❌ Pod push failed: #{e.message}"
+        if output_str.include?("[!] Unable to accept duplicate entry for:")
+          UI.error("⚠️ Duplicate entry detected. Skipping push.")
+          return false
         end
+
+        raise PodPushUnknownError, "❌ Pod push failed: #{e.message}"
       end
 
       def self.description
-        "Pushes a podspec to CocoaPods and gracefully handles duplicate entry errors"
+        "Pushes a podspec to CocoaPods with support for synchronous, verbose, and allow_warnings options."
       end
 
       def self.authors
@@ -41,7 +42,7 @@ module Fastlane
       end
 
       def self.details
-        "A custom Fastlane action that calls `pod_push` and catches duplicate entry errors."
+        "A custom Fastlane action that wraps `pod_push` and supports all relevant parameters."
       end
 
       def self.is_supported?(platform)
@@ -60,21 +61,21 @@ module Fastlane
             key: :synchronous,
             description: "Wait for push to complete before returning",
             optional: true,
-            type: Boolean,
+            type: TrueClass,
             default_value: true
           ),
           FastlaneCore::ConfigItem.new(
             key: :verbose,
             description: "Show more debugging output",
             optional: true,
-            type: Boolean,
+            type: TrueClass,
             default_value: false
           ),
           FastlaneCore::ConfigItem.new(
             key: :allow_warnings,
             description: "Allow warnings when pushing the podspec",
             optional: true,
-            type: Boolean,
+            type: TrueClass,
             default_value: false
           )
         ]

--- a/lib/fastlane/plugin/revenuecat_internal/actions/pod_push_with_error_handling.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/pod_push_with_error_handling.rb
@@ -1,15 +1,17 @@
 module Fastlane
   module Actions
-    
+    class PodPushUnknownError < StandardError; end 
+
     class PodPushWithErrorHandlingAction < Action
       def self.run(params)
         begin
-          # Capture the output of pod_push
           UI.message("🚀 Running pod_push with path: #{params[:path]}")
           
           output = Fastlane::Actions::PodPushAction.run(
             path: params[:path],
-            synchronous: true 
+            synchronous: params[:synchronous],
+            verbose: params[:verbose],
+            allow_warnings: params[:allow_warnings]
           )
 
           return true
@@ -21,8 +23,8 @@ module Fastlane
             return false
           end
 
-          UI.error("❌ Pod push failed: #{e.message}")
-          UI.user_error!("Pod push failed.")
+          UI.user_error!("❌ Pod push failed: #{e.message}")
+          raise PodPushUnknownError, "❌ Pod push failed: #{e.message}"
         end
       end
 
@@ -31,7 +33,7 @@ module Fastlane
       end
 
       def self.authors
-        ["Your Name"]
+        ["facumenzella"]
       end
 
       def self.return_value
@@ -53,6 +55,27 @@ module Fastlane
             description: "Path to the .podspec file",
             optional: false,
             type: String
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :synchronous,
+            description: "Wait for push to complete before returning",
+            optional: true,
+            type: Boolean,
+            default_value: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :verbose,
+            description: "Show more debugging output",
+            optional: true,
+            type: Boolean,
+            default_value: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :allow_warnings,
+            description: "Allow warnings when pushing the podspec",
+            optional: true,
+            type: Boolean,
+            default_value: false
           )
         ]
       end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/pod_push_with_error_handling.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/pod_push_with_error_handling.rb
@@ -1,6 +1,7 @@
 require 'fastlane/action'
 require 'fastlane_core/ui/ui'
 require 'fastlane_core/configuration/config_item'
+require 'fastlane/actions/pod_push'
 require_relative '../helper/revenuecat_internal_helper'
 
 module Fastlane

--- a/lib/fastlane/plugin/revenuecat_internal/actions/pod_push_with_error_handling.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/pod_push_with_error_handling.rb
@@ -1,6 +1,7 @@
 require 'fastlane/action'
 require 'fastlane_core/ui/ui'
 require 'fastlane_core/configuration/config_item'
+require_relative '../helper/revenuecat_internal_helper'
 
 module Fastlane
   module Actions

--- a/spec/actions/pod_push_with_error_handling.rb
+++ b/spec/actions/pod_push_with_error_handling.rb
@@ -1,0 +1,61 @@
+module Fastlane
+  module Actions
+    
+    class PodPushWithErrorHandlingAction < Action
+      def self.run(params)
+        begin
+          # Capture the output of pod_push
+          UI.message("🚀 Running pod_push with path: #{params[:path]}")
+          
+          output = Fastlane::Actions::PodPushAction.run(
+            path: params[:path],
+            synchronous: true 
+          )
+
+          return true
+        rescue => e
+          output_str = e.message
+
+          if output_str.include?("[!] Unable to accept duplicate entry for:")
+            UI.error("⚠️ Duplicate entry detected. Skipping push.")
+            return false
+          end
+
+          UI.error("❌ Pod push failed: #{e.message}")
+          UI.user_error!("Pod push failed.")
+        end
+      end
+
+      def self.description
+        "Pushes a podspec to CocoaPods and gracefully handles duplicate entry errors"
+      end
+
+      def self.authors
+        ["Your Name"]
+      end
+
+      def self.return_value
+        "Returns false if the push is skipped due to a duplicate entry, true if successful."
+      end
+
+      def self.details
+        "A custom Fastlane action that calls `pod_push` and catches duplicate entry errors."
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :path,
+            description: "Path to the .podspec file",
+            optional: false,
+            type: String
+          )
+        ]
+      end
+    end
+  end
+end

--- a/spec/actions/pod_push_with_error_handling_action_spec.rb
+++ b/spec/actions/pod_push_with_error_handling_action_spec.rb
@@ -1,0 +1,54 @@
+require 'fastlane'
+require 'fastlane_core/ui/ui'
+
+describe Fastlane::Actions::PodPushWithErrorHandlingAction do
+  describe '#run' do
+    let(:podspec_path) { 'RevenueCat.podspec' }
+
+    before do
+      allow(FastlaneCore::UI).to receive(:message) # Suppress UI messages
+      allow(FastlaneCore::UI).to receive(:error)
+      allow(FastlaneCore::UI).to receive(:user_error!)
+    end
+
+    it 'returns true when pod push succeeds' do
+      allow(Fastlane::Actions::PodPushAction).to receive(:run).and_return("Successfully pushed")
+
+      result = Fastlane::Actions::PodPushWithErrorHandlingAction.run(path: podspec_path)
+
+      expect(result).to eq(true)
+      expect(Fastlane::Actions::PodPushAction).to have_received(:run).once
+    end
+
+    it 'catches duplicate entry error and returns false' do
+      error_message = "[!] Unable to accept duplicate entry for: RevenueCat"
+      allow(Fastlane::Actions::PodPushAction).to receive(:run).and_raise(StandardError.new(error_message))
+
+      result = Fastlane::Actions::PodPushWithErrorHandlingAction.run(path: podspec_path)
+
+      expect(result).to eq(false)
+      expect(FastlaneCore::UI).to have_received(:error).with("⚠️ Duplicate entry detected. Skipping push.")
+    end
+
+
+    it 'raises a PodPushUnknownError for other failures' do
+      error_message = "Some unexpected failure"
+      allow(Fastlane::Actions::PodPushAction).to receive(:run).and_raise(StandardError.new(error_message))
+
+      expect do
+        Fastlane::Actions::PodPushWithErrorHandlingAction.run(path: podspec_path)
+      end.to raise_error(Fastlane::Actions::PodPushUnknownError, "❌ Pod push failed: Some unexpected failure")
+    end
+  end
+
+  describe '#available_options' do
+    it 'requires a path parameter' do
+      options = Fastlane::Actions::PodPushWithErrorHandlingAction.available_options
+      path_option = options.find { |opt| opt.key == :path }
+
+      expect(path_option).not_to be_nil
+      expect(path_option.optional).to eq(false)
+      expect(path_option.data_type).to eq(String)
+    end
+  end
+end

--- a/spec/actions/pod_push_with_error_handling_action_spec.rb
+++ b/spec/actions/pod_push_with_error_handling_action_spec.rb
@@ -30,7 +30,6 @@ describe Fastlane::Actions::PodPushWithErrorHandlingAction do
       expect(FastlaneCore::UI).to have_received(:error).with("⚠️ Duplicate entry detected. Skipping push.")
     end
 
-
     it 'raises a PodPushUnknownError for other failures' do
       error_message = "Some unexpected failure"
       allow(Fastlane::Actions::PodPushAction).to receive(:run).and_raise(StandardError.new(error_message))


### PR DESCRIPTION
This adds an action that takes into account duplicate pods. 
Next step would be to add a retry if it fails due to timeouts.

In the main Fastfile, instead of adding `pod_push` we should call `pod_push_with_error_handling(path: "RevenueCat.podspec")`

Example output:

```
[14:36:17]: ------------------------------
[14:36:17]: --- Step: default_platform ---
[14:36:17]: ------------------------------
[14:36:17]: Driving the lane 'ios push_revenuecat_pod' 🚀
[14:36:17]: -----------------------------
[14:36:17]: --- Step: setup_circle_ci ---
[14:36:17]: -----------------------------
[14:36:17]: Not running on CI, skipping CI setup
[14:36:17]: ------------------------------------------
[14:36:17]: --- Step: pod_push_with_error_handling ---
[14:36:17]: ------------------------------------------
[14:36:17]: 🚀 Running pod_push with path: RevenueCat.podspec
[14:36:17]: $ pod trunk push 'RevenueCat.podspec' --synchronous
[14:36:17]: ▸ Updating spec repo `cocoapods`
[14:36:17]: ▸ Validating podspec
[14:38:41]: ▸  -> RevenueCat (5.19.0)
[14:38:41]: ▸ - NOTE  | xcodebuild:  note: Using codesigning identity override: -
[14:38:41]: ▸ - NOTE  | xcodebuild:  note: Building targets in dependency order
[14:38:41]: ▸ - NOTE  | xcodebuild:  note: Target dependency graph (4 targets)
[14:38:41]: ▸ - NOTE  | xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'RevenueCat' from project 'Pods')
[14:38:41]: ▸ - NOTE  | xcodebuild:  note: Signing static framework with --generate-pre-encrypt-hashes (in target 'Pods-App' from project 'Pods')
[14:38:41]: ▸ - NOTE  | xcodebuild:  note: Metadata extraction skipped. No AppIntents.framework dependency found. (in target 'App' from project 'App')
[14:38:41]: ▸ - NOTE  | xcodebuild:  note: Disabling previews because SWIFT_VERSION is set and SWIFT_OPTIMIZATION_LEVEL=-O, expected -Onone (in target 'App' from project 'App')
[14:38:41]: ▸ - NOTE  | xcodebuild:  note: Disabling previews because SWIFT_VERSION is set and SWIFT_OPTIMIZATION_LEVEL=-O, expected -Onone (in target 'Pods-App' from project 'Pods')
[14:38:41]: ▸ - NOTE  | xcodebuild:  note: Disabling previews because SWIFT_VERSION is set and SWIFT_OPTIMIZATION_LEVEL=-O, expected -Onone (in target 'RevenueCat' from project 'Pods')
[14:38:41]: ▸ - NOTE  | xcodebuild:  note: Disabling previews because SWIFT_VERSION is set and SWIFT_OPTIMIZATION_LEVEL=-O, expected -Onone (in target 'RevenueCat-RevenueCat' from project 'Pods')
[14:38:41]: ▸ - NOTE  | xcodebuild:  note: Using codesigning identity override:
[14:38:41]: ▸ [!] Unable to accept duplicate entry for: RevenueCat (5.19.0)
[14:38:41]: ⚠️ Duplicate entry detected. Skipping push.
[14:38:41]: ✅ Pod push was skipped due to a duplicate entry.
```
