### PR TITLE
Adds `create_or_checkout_branch`, `commit_all_changes`, `create_pr_if_necessary`

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/commit_all_changes_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/commit_all_changes_action.rb
@@ -1,0 +1,37 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require 'fastlane_core/ui/ui'
+require_relative '../helper/revenuecat_internal_helper'
+
+module Fastlane
+  module Actions
+    class CommitAllChangesAction < Action
+      def self.run(params)
+        commit_message = params[:commit_message]
+
+        Helper::RevenuecatInternalHelper.commit_all_changes(commit_message)
+      end
+
+      def self.description
+        "Commits all changes in the local repository to the current branch. This includes untracked and deleted files."
+      end
+
+      def self.authors
+        ["Jay Shortway"]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :commit_message,
+                                       description: "Commit message",
+                                       optional: false,
+                                       type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/create_or_checkout_branch_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/create_or_checkout_branch_action.rb
@@ -1,0 +1,37 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require 'fastlane_core/ui/ui'
+require_relative '../helper/revenuecat_internal_helper'
+
+module Fastlane
+  module Actions
+    class CreateOrCheckoutBranchAction < Action
+      def self.run(params)
+        branch_name = params[:branch_name]
+
+        Helper::RevenuecatInternalHelper.create_or_checkout_branch(branch_name)
+      end
+
+      def self.description
+        "Creates a new branch or checks out an existing branch. If the branch exists remotely but not locally, it will pull after checkout."
+      end
+
+      def self.authors
+        ["Jay Shortway"]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :branch_name,
+                                       description: "Branch name to create or checkout",
+                                       optional: false,
+                                       type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/create_pr_if_necessary_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/create_pr_if_necessary_action.rb
@@ -1,0 +1,83 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require 'fastlane_core/ui/ui'
+require_relative '../helper/revenuecat_internal_helper'
+
+module Fastlane
+  module Actions
+    class CreatePrIfNecessaryAction < Action
+      def self.run(params)
+        title = params[:title]
+        body = params[:body]
+        repo_name = params[:repo_name]
+        base_branch = params[:base_branch]
+        head_branch = params[:head_branch]
+        github_pr_token = params[:github_pr_token]
+        labels = params[:labels]
+        team_reviewers = params[:team_reviewers]
+
+        Helper::RevenuecatInternalHelper.create_pr_if_necessary(
+          title,
+          body,
+          repo_name,
+          base_branch,
+          head_branch,
+          github_pr_token,
+          labels,
+          team_reviewers
+        )
+      end
+
+      def self.description
+        "Creates a pull request if one doesn't already exist for the specified branch"
+      end
+
+      def self.authors
+        ["Jay Shortway"]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :title,
+                                       description: "Title of the pull request",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :body,
+                                       description: "Body content of the pull request",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :repo_name,
+                                       description: "Name of the repository (without owner)",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :base_branch,
+                                       description: "The branch you want your changes pulled into",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :head_branch,
+                                       description: "The branch where your changes are implemented",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :github_pr_token,
+                                       description: "GitHub API token with PR creation permissions",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :labels,
+                                       description: "Labels to add to the pull request",
+                                       optional: true,
+                                       default_value: [],
+                                       type: Array),
+          FastlaneCore::ConfigItem.new(key: :team_reviewers,
+                                       description: "Teams to request a review from",
+                                       optional: true,
+                                       default_value: ['coresdk'],
+                                       type: Array)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/spec/actions/commit_all_changes_action_spec.rb
+++ b/spec/actions/commit_all_changes_action_spec.rb
@@ -1,0 +1,16 @@
+describe Fastlane::Actions::CommitAllChangesAction do
+  describe '#run' do
+    it 'calls appropriate helper method with expected parameters' do
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:commit_all_changes).with('fake-commit-message').once
+      Fastlane::Actions::CommitAllChangesAction.run(
+        commit_message: 'fake-commit-message'
+      )
+    end
+  end
+
+  describe '#available_options' do
+    it 'has correct number of options' do
+      expect(Fastlane::Actions::CommitAllChangesAction.available_options.size).to eq(1)
+    end
+  end
+end

--- a/spec/actions/create_or_checkout_branch_action_spec.rb
+++ b/spec/actions/create_or_checkout_branch_action_spec.rb
@@ -1,0 +1,16 @@
+describe Fastlane::Actions::CreateOrCheckoutBranchAction do
+  describe '#run' do
+    it 'calls appropriate helper method with expected parameters' do
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_or_checkout_branch).with('test-branch').once
+      Fastlane::Actions::CreateOrCheckoutBranchAction.run(
+        branch_name: 'test-branch'
+      )
+    end
+  end
+
+  describe '#available_options' do
+    it 'has correct number of options' do
+      expect(Fastlane::Actions::CreateOrCheckoutBranchAction.available_options.size).to eq(1)
+    end
+  end
+end

--- a/spec/actions/create_pr_if_necessary_action_spec.rb
+++ b/spec/actions/create_pr_if_necessary_action_spec.rb
@@ -1,0 +1,42 @@
+describe Fastlane::Actions::CreatePrIfNecessaryAction do
+  describe '#run' do
+    it 'calls appropriate helper method with expected parameters' do
+      title = 'Test PR Title'
+      body = 'Test PR Body'
+      repo_name = 'test-repo'
+      base_branch = 'main'
+      head_branch = 'feature-branch'
+      github_pr_token = 'fake-github-token'
+      labels = %w[label1 label2]
+      team_reviewers = %w[team1 team2]
+
+      expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr_if_necessary).with(
+        title,
+        body,
+        repo_name,
+        base_branch,
+        head_branch,
+        github_pr_token,
+        labels,
+        team_reviewers
+      ).once
+
+      Fastlane::Actions::CreatePrIfNecessaryAction.run(
+        title: title,
+        body: body,
+        repo_name: repo_name,
+        base_branch: base_branch,
+        head_branch: head_branch,
+        github_pr_token: github_pr_token,
+        labels: labels,
+        team_reviewers: team_reviewers
+      )
+    end
+  end
+
+  describe '#available_options' do
+    it 'has correct number of options' do
+      expect(Fastlane::Actions::CreatePrIfNecessaryAction.available_options.size).to eq(8)
+    end
+  end
+end


### PR DESCRIPTION
## Description
Adds some utilities used in https://github.com/RevenueCat/purchases-android/pull/2365
- `create_or_checkout_branch` 
- `commit_all_changes` (didn't want to adjust `commit_current_changes` because [it is widely used](https://github.com/search?q=org%3ARevenueCat%20%22commit_current_changes%22&type=code)) 
- `create_pr_if_necessary`