### PR TITLE
Only retry tests that failed but didn't succeed after in-run retry

### DIFF
--- a/fastlane-plugin-revenuecat_internal.gemspec
+++ b/fastlane-plugin-revenuecat_internal.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('rest-client')
 
   spec.add_development_dependency('bundler')
-  spec.add_development_dependency('fastlane')
+  spec.add_development_dependency('fastlane', '>= 2.227.1')
   spec.add_development_dependency('pry')
   spec.add_development_dependency('rake')
   spec.add_development_dependency('rspec')

--- a/fastlane-plugin-revenuecat_internal.gemspec
+++ b/fastlane-plugin-revenuecat_internal.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('rest-client')
 
   spec.add_development_dependency('bundler')
-  spec.add_development_dependency('fastlane', '2.207.0')
+  spec.add_development_dependency('fastlane')
   spec.add_development_dependency('pry')
   spec.add_development_dependency('rake')
   spec.add_development_dependency('rspec')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -91,6 +91,8 @@ lane :sample_flaky_test do
     output_directory: test_artifact_path,
     result_bundle: true,
 
+    number_of_retries: 2,
+
     number_of_flaky_retries: 5
   )
 end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/scan_with_flaky_test_retries.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/scan_with_flaky_test_retries.rb
@@ -217,7 +217,7 @@ module Fastlane
             # Skip tests that have a retry_count attribute and no failure node
             # This indicates they failed initially but succeeded in a retry
             next if test_case['retry_count'] && !test_case.at('failure')
-            
+
             suitename = test_case.parent['name'] # Retrieve the suitename
             classname = test_case['classname']
             name = test_case['name']

--- a/lib/fastlane/plugin/revenuecat_internal/actions/scan_with_flaky_test_retries.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/scan_with_flaky_test_retries.rb
@@ -215,28 +215,28 @@ module Fastlane
 
           # Get all test cases
           all_test_cases = doc.xpath('//testcase')
-          
+
           # Group test cases by their unique identifier (suitename/classname/name)
           test_cases_by_id = {}
-          
+
           all_test_cases.each do |test_case|
             suitename = test_case.parent['name'] # Retrieve the suitename
             classname = test_case['classname']
             name = test_case['name']
             test_id = "#{suitename}/#{classname}/#{name}"
-            
+
             test_cases_by_id[test_id] ||= []
             test_cases_by_id[test_id] << test_case
           end
-          
+
           # For each test, check if it has a failure and no successful retry
           test_cases_by_id.each do |test_id, test_cases|
             # Find test cases with failures
             failed_cases = test_cases.select { |tc| tc.at('failure') }
-            
+
             # Find test cases without failures (successful retries)
             successful_cases = test_cases.select { |tc| !tc.at('failure') }
-            
+
             # If there are failed cases but no successful retries, add to failed tests
             if !failed_cases.empty? && successful_cases.empty?
               failed_tests << test_id

--- a/lib/fastlane/plugin/revenuecat_internal/actions/scan_with_flaky_test_retries.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/scan_with_flaky_test_retries.rb
@@ -207,6 +207,7 @@ module Fastlane
       #
       # @param report_path [String] The path of the junit file
       # @param failed_tests_path [String] The path where failed tests should be saved
+      # rubocop:disable Metrics/PerceivedComplexity
       def self.save_failed_tests(report_path:, failed_tests_path:)
         failed_tests = []
 
@@ -235,7 +236,7 @@ module Fastlane
             failed_cases = test_cases.select { |tc| tc.at('failure') }
 
             # Find test cases without failures (successful retries)
-            successful_cases = test_cases.select { |tc| !tc.at('failure') }
+            successful_cases = test_cases.reject { |tc| tc.at('failure') }
 
             # If there are failed cases but no successful retries, add to failed tests
             if !failed_cases.empty? && successful_cases.empty?
@@ -250,6 +251,7 @@ module Fastlane
           end
         end
       end
+      # rubocop:enable Metrics/PerceivedComplexity
 
       #####################################################
       # @!group Documentation

--- a/lib/fastlane/plugin/revenuecat_internal/actions/scan_with_flaky_test_retries.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/scan_with_flaky_test_retries.rb
@@ -203,6 +203,7 @@ module Fastlane
       end
 
       # Saves all the failed method signatures into a text field from a junit report
+      # Only records tests that failed and didn't succeed in retries
       #
       # @param report_path [String] The path of the junit file
       # @param failed_tests_path [String] The path where failed tests should be saved
@@ -213,6 +214,10 @@ module Fastlane
           doc = Nokogiri::XML(File.open(report_path))
 
           doc.xpath('//testcase[failure]').each do |test_case|
+            # Skip tests that have a retry_count attribute and no failure node
+            # This indicates they failed initially but succeeded in a retry
+            next if test_case['retry_count'] && !test_case.at('failure')
+            
             suitename = test_case.parent['name'] # Retrieve the suitename
             classname = test_case['classname']
             name = test_case['name']


### PR DESCRIPTION
## Motivation

The full retry of `scan` with only failed tests was retrying sometimes when it shouldn't. It was detecting failurs when tests were retried within Xcode that eventually succeeded.

## Description

Only writing failed tests if they don't have a successful run in the suite (this means they did eventually pass)

### Passing on first try

<img width="1800" alt="Screenshot 2025-04-18 at 1 43 26 PM" src="https://github.com/user-attachments/assets/f6564007-70b1-45db-8d33-f878ba4938ab" />


### Retrying after failures

| Failure | Successful retry |
|--------|--------|
| <img width="1412" alt="Screenshot 2025-04-18 at 1 53 53 PM" src="https://github.com/user-attachments/assets/972faf48-9d5a-432f-b0f9-142dff3c8cd2" /> | <img width="1197" alt="Screenshot 2025-04-18 at 1 54 13 PM" src="https://github.com/user-attachments/assets/0f23383a-4d30-4090-93f6-ac75da8d5f17" /> | 
