### PR TITLE
Use correct `GITHUB_TOKEN`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -37,7 +37,7 @@ lane :sample_create_github_release_action do |options|
   create_github_release(
     version: 'release_version_number',
     repo_name: 'repo-name',
-    github_api_token: 'github-api-token', # This can also be obtained from ENV RC_INTERNAL_GITHUB_TOKEN
+    github_api_token: 'github-api-token', # This can also be obtained from ENV GITHUB_TOKEN
     changelog_latest_path: './path-to/CHANGELOG.latest.md',
     upload_assets: ['./file-to-upload.txt', './file-to-upload-2.rb']
   )

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -175,7 +175,7 @@ module Fastlane
                                        optional: false,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :github_token,
-                                       env_name: "RC_INTERNAL_GITHUB_TOKEN",
+                                       env_name: "GITHUB_TOKEN",
                                        description: "Github token to use to prepopulate the changelog",
                                        optional: true,
                                        type: String),

--- a/lib/fastlane/plugin/revenuecat_internal/actions/check_github_authentication_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/check_github_authentication_action.rb
@@ -37,7 +37,7 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :github_token,
-                                       env_name: "RC_INTERNAL_GITHUB_TOKEN",
+                                       env_name: "GITHUB_TOKEN",
                                        description: "GitHub token to check authentication for",
                                        optional: true,
                                        type: String)

--- a/lib/fastlane/plugin/revenuecat_internal/actions/create_github_release_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/create_github_release_action.rb
@@ -48,7 +48,7 @@ module Fastlane
                                        optional: false,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :github_api_token,
-                                       env_name: "RC_INTERNAL_GITHUB_TOKEN",
+                                       env_name: "GITHUB_TOKEN",
                                        description: "Github token to use to create the release",
                                        optional: false,
                                        type: String),

--- a/lib/fastlane/plugin/revenuecat_internal/actions/determine_next_version_using_labels_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/determine_next_version_using_labels_action.rb
@@ -31,7 +31,7 @@ module Fastlane
                                        optional: false,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :github_token,
-                                       env_name: "RC_INTERNAL_GITHUB_TOKEN",
+                                       env_name: "GITHUB_TOKEN",
                                        description: "Github token to use to prepopulate the changelog",
                                        optional: true,
                                        type: String),

--- a/spec/actions/check_github_authentication_action_spec.rb
+++ b/spec/actions/check_github_authentication_action_spec.rb
@@ -75,7 +75,7 @@ describe Fastlane::Actions::CheckGithubAuthenticationAction do
     it 'has github_token option with correct configuration' do
       option = Fastlane::Actions::CheckGithubAuthenticationAction.available_options.first
       expect(option.key).to eq(:github_token)
-      expect(option.env_name).to eq("RC_INTERNAL_GITHUB_TOKEN")
+      expect(option.env_name).to eq("GITHUB_TOKEN")
       expect(option.optional).to be true
     end
   end


### PR DESCRIPTION
We were referencing `RC_INTERNAL_GITHUB_TOKEN` in a bunch of lanes, and it is not set in any repository. Repositories have `GITHUB_TOKEN` set though, so replacing it with that one.

I still think we should probably unify and remove `GITHUB_PULL_REQUEST_API_TOKEN` as well, since I can't think of a reason why we would need changelog generation and PR tokens to be different