### PR TITLE
Add `current_version` parameter to `DetermineNextVersionUsingLabelsAction`

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/determine_next_version_using_labels_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/determine_next_version_using_labels_action.rb
@@ -11,8 +11,9 @@ module Fastlane
         github_token = params[:github_token]
         rate_limit_sleep = params[:github_rate_limit]
         include_prereleases = false
+        current_version = params[:current_version]
 
-        Helper::VersioningHelper.determine_next_version_using_labels(repo_name, github_token, rate_limit_sleep, include_prereleases)
+        Helper::VersioningHelper.determine_next_version_using_labels(repo_name, github_token, rate_limit_sleep, include_prereleases, current_version)
       end
 
       def self.description
@@ -40,7 +41,11 @@ module Fastlane
                                        description: "Sets a rate limiter for github requests when creating the changelog",
                                        optional: true,
                                        default_value: 0,
-                                       type: Integer)
+                                       type: Integer),
+          FastlaneCore::ConfigItem.new(key: :current_version,
+                                       description: "Current version of the SDK",
+                                       optional: true,
+                                       type: String)
         ]
       end
 

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -31,7 +31,7 @@ module Fastlane
       ANDROID_VERSION_COLUMN = 3
       PHC_VERSION_COLUMN = 4
 
-      def self.determine_next_version_using_labels(repo_name, github_token, rate_limit_sleep, include_prereleases, current_version = nil)
+      def self.determine_next_version_using_labels(repo_name, github_token, rate_limit_sleep, include_prereleases, current_version)
         old_version = latest_version_number(include_prereleases: include_prereleases, current_version: current_version)
         UI.important("Determining next version after #{old_version}")
 

--- a/spec/actions/determine_next_version_using_labels_action_spec.rb
+++ b/spec/actions/determine_next_version_using_labels_action_spec.rb
@@ -3,17 +3,19 @@ describe Fastlane::Actions::DetermineNextVersionUsingLabelsAction do
     let(:mock_repo_name) { 'mock-repo-name' }
     let(:mock_github_token) { 'mock-github-token' }
     let(:new_version) { '1.13.0' }
+    let(:current_version) { '1.12.0' }
 
     it 'calls all the appropriate methods with appropriate parameters' do
       expect(Fastlane::Helper::VersioningHelper).to receive(:determine_next_version_using_labels)
-        .with(mock_repo_name, mock_github_token, 3, false)
+        .with(mock_repo_name, mock_github_token, 3, false, current_version)
         .and_return(new_version)
         .once
 
       calculated_version = Fastlane::Actions::DetermineNextVersionUsingLabelsAction.run(
         repo_name: mock_repo_name,
         github_token: mock_github_token,
-        github_rate_limit: 3
+        github_rate_limit: 3,
+        current_version: current_version
       )
       expect(calculated_version).to eq(new_version)
     end
@@ -21,7 +23,7 @@ describe Fastlane::Actions::DetermineNextVersionUsingLabelsAction do
 
   describe '#available_options' do
     it 'has correct number of options' do
-      expect(Fastlane::Actions::DetermineNextVersionUsingLabelsAction.available_options.size).to eq(3)
+      expect(Fastlane::Actions::DetermineNextVersionUsingLabelsAction.available_options.size).to eq(4)
     end
   end
 end

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -783,7 +783,8 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         0,
-        false
+        false,
+        nil
       )
       expect(next_version).to eq("1.11.1")
       expect(type_of_bump).to eq(:patch)
@@ -802,7 +803,8 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         0,
-        false
+        false,
+        nil
       )
       expect(next_version).to eq("1.11.1")
       expect(type_of_bump).to eq(:patch)
@@ -836,7 +838,8 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         0,
-        false
+        false,
+        nil
       )
       expect(next_version).to eq("1.11.0")
       expect(type_of_bump).to eq(:skip)
@@ -850,7 +853,8 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         0,
-        false
+        false,
+        nil
       )
       expect(next_version).to eq("1.12.0")
       expect(type_of_bump).to eq(:minor)
@@ -876,7 +880,8 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         0,
-        false
+        false,
+        nil
       )
       expect(next_version).to eq("1.12.0")
       expect(type_of_bump).to eq(:minor)
@@ -922,7 +927,8 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         0,
-        false
+        false,
+        nil
       )
       expect(next_version).to eq("2.0.0")
       expect(type_of_bump).to eq(:major)
@@ -982,7 +988,8 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         3,
-        false
+        false,
+        nil
       )
       expect(next_version).to eq("1.12.0")
       expect(type_of_bump).to eq(:minor)
@@ -1003,7 +1010,8 @@ describe Fastlane::Helper::VersioningHelper do
           'mock-repo-name',
           'mock-github-token',
           0,
-          false
+          false,
+          nil
         )
       end.to raise_exception(StandardError)
     end
@@ -1016,7 +1024,8 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         0,
-        false
+        false,
+        nil
       )
       expect(next_version).to eq("1.11.0")
       expect(type_of_bump).to eq(:skip)
@@ -1038,7 +1047,8 @@ describe Fastlane::Helper::VersioningHelper do
         'mock-repo-name',
         'mock-github-token',
         0,
-        false
+        false,
+        nil
       )
       expect(next_version).to eq("2.0.0")
       expect(type_of_bump).to eq(:major)


### PR DESCRIPTION
This PR adds the `current_version` parameter to `DetermineNextVersionUsingLabelsAction`. It's an optional parameter.

I forgot to add ir when implementing #85 (Allow automatic bump in older majors).