### PR TITLE
Add missing GitHub auth in some actions

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/get_latest_github_release_within_same_major_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/get_latest_github_release_within_same_major_action.rb
@@ -9,8 +9,9 @@ module Fastlane
       def self.run(params)
         repo_name = params[:repo_name]
         current_version = Gem::Version.new(params[:current_version])
+        github_token = params[:github_token]
         UI.message("Getting latest release for #{repo_name} on GitHub within same major as #{current_version}")
-        tag_names = Helper::RevenuecatInternalHelper.get_github_release_tag_names(repo_name)
+        tag_names = Helper::RevenuecatInternalHelper.get_github_release_tag_names(repo_name, github_token)
         if tag_names.count == 0
           UI.user_error!("Couldn't find any GitHub release for #{params[:repo_name]}")
         end
@@ -53,7 +54,13 @@ module Fastlane
                                        env_name: "RC_INTERNAL_CURRENT_VERSION",
                                        type: String,
                                        optional: false,
-                                       description: "The current release version to check for next minor or patch")
+                                       description: "The current release version to check for next minor or patch"),
+          FastlaneCore::ConfigItem.new(key: :github_token,
+                                       env_name: "GITHUB_TOKEN",
+                                       description: "GitHub token for API authentication",
+                                       optional: true,
+                                       type: String,
+                                       sensitive: true)
         ]
       end
 

--- a/lib/fastlane/plugin/revenuecat_internal/actions/update_hybrids_versions_file_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/update_hybrids_versions_file_action.rb
@@ -10,16 +10,17 @@ module Fastlane
         versions_file_path = params[:versions_file_path]
         new_sdk_version = params[:new_sdk_version]
         hybrid_common_version = params[:hybrid_common_version]
+        github_token = params[:github_token]
 
         UI.user_error!("VERSIONS.md file not found") unless File.exist?(versions_file_path)
 
-        android_version = Helper::UpdateHybridsVersionsFileHelper.get_android_version_for_hybrid_common_version(hybrid_common_version)
+        android_version = Helper::UpdateHybridsVersionsFileHelper.get_android_version_for_hybrid_common_version(hybrid_common_version, github_token)
         UI.message("Obtained android version #{android_version} for PHC version #{hybrid_common_version}")
 
-        ios_version = Helper::UpdateHybridsVersionsFileHelper.get_ios_version_for_hybrid_common_version(hybrid_common_version)
+        ios_version = Helper::UpdateHybridsVersionsFileHelper.get_ios_version_for_hybrid_common_version(hybrid_common_version, github_token)
         UI.message("Obtained ios version #{ios_version} for PHC version #{hybrid_common_version}")
 
-        billing_client_version = Helper::UpdateHybridsVersionsFileHelper.get_android_billing_client_version(android_version)
+        billing_client_version = Helper::UpdateHybridsVersionsFileHelper.get_android_billing_client_version(android_version, github_token)
         UI.message("Obtained android billing client version #{billing_client_version} for PHC version #{hybrid_common_version}")
 
         File.open(versions_file_path, 'r+') do |file|
@@ -72,7 +73,13 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :hybrid_common_version,
                                        description: "Version of the hybrid common sdk to add to the VERSIONS.md file",
                                        optional: false,
-                                       type: String)
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :github_token,
+                                       env_name: "GITHUB_TOKEN",
+                                       description: "GitHub token for API authentication",
+                                       optional: true,
+                                       type: String,
+                                       sensitive: true)
         ]
       end
 

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -247,11 +247,12 @@ module Fastlane
         end
       end
 
-      def self.get_github_release_tag_names(repo_name)
+      def self.get_github_release_tag_names(repo_name, github_token = nil)
         response = Actions::GithubApiAction.run(
           server_url: "https://api.github.com",
           http_method: 'GET',
           path: "repos/RevenueCat/#{repo_name}/releases",
+          api_token: github_token,
           error_handlers: {
             404 => proc do |result|
               UI.user_error!("Repository #{repo_name} cannot be found, please double check its name and that you provided a valid API token (if it's a private repository).")

--- a/lib/fastlane/plugin/revenuecat_internal/helper/update_hybrids_versions_file_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/update_hybrids_versions_file_helper.rb
@@ -8,39 +8,40 @@ module Fastlane
 
   module Helper
     class UpdateHybridsVersionsFileHelper
-      def self.get_android_version_for_hybrid_common_version(hybrid_common_version)
+      def self.get_android_version_for_hybrid_common_version(hybrid_common_version, github_token)
         path = 'android/gradle/libs.versions.toml'
         repo_name = 'purchases-hybrid-common'
-        contents = get_contents_file_github(path, repo_name, hybrid_common_version)
+        contents = get_contents_file_github(path, repo_name, hybrid_common_version, github_token)
         matches = contents.match('purchases = "(.*)"').captures
         UI.user_error!("Could not find android version in #{repo_name} in file '#{path}'") if matches.length != 1
         matches[0]
       end
 
-      def self.get_ios_version_for_hybrid_common_version(hybrid_common_version)
+      def self.get_ios_version_for_hybrid_common_version(hybrid_common_version, github_token)
         path = 'PurchasesHybridCommon.podspec'
         repo_name = 'purchases-hybrid-common'
-        contents = get_contents_file_github(path, repo_name, hybrid_common_version)
+        contents = get_contents_file_github(path, repo_name, hybrid_common_version, github_token)
         matches = contents.match("s.dependency 'RevenueCat', '(.*)'").captures
         UI.user_error!("Could not find ios version in #{repo_name} in file '#{path}'") if matches.length != 1
         matches[0]
       end
 
-      def self.get_android_billing_client_version(android_version)
+      def self.get_android_billing_client_version(android_version, github_token)
         path = 'gradle/libs.versions.toml'
         repo_name = 'purchases-android'
-        contents = get_contents_file_github(path, repo_name, android_version)
+        contents = get_contents_file_github(path, repo_name, android_version, github_token)
         matches = contents.match('billing = "(.*)"').captures
         UI.user_error!("Could not find android billing client version in #{repo_name} in file '#{path}'") if matches.length != 1
         matches[0]
       end
 
-      private_class_method def self.get_contents_file_github(file_path, repo_name, ref = 'main')
+      private_class_method def self.get_contents_file_github(file_path, repo_name, ref = 'main', github_token = nil)
         path = "/repos/revenuecat/#{repo_name}/contents/#{file_path}?ref=#{ref}"
         response = Actions::GithubApiAction.run(server_url: 'https://api.github.com',
                                                 path: path,
                                                 http_method: 'GET',
-                                                body: {})
+                                                body: {},
+                                                api_token: github_token)
         base64_contents = response[:json]['content']
         Base64.decode64(base64_contents)
       end

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -464,9 +464,9 @@ module Fastlane
           return ""
         end
 
-        new_android_version = Helper::UpdateHybridsVersionsFileHelper.get_android_version_for_hybrid_common_version(phc_version)
+        new_android_version = Helper::UpdateHybridsVersionsFileHelper.get_android_version_for_hybrid_common_version(phc_version, github_token)
         UI.message("Obtained android version #{new_android_version} for PHC version #{phc_version}")
-        new_ios_version = Helper::UpdateHybridsVersionsFileHelper.get_ios_version_for_hybrid_common_version(phc_version)
+        new_ios_version = Helper::UpdateHybridsVersionsFileHelper.get_ios_version_for_hybrid_common_version(phc_version, github_token)
         UI.message("Obtained ios version #{new_ios_version} for PHC version #{phc_version}")
 
         android_releases = Helper::GitHubHelper.get_releases_between_tags(github_token, previous_android_version, new_android_version, REPO_NAME_ANDROID)

--- a/spec/actions/get_latest_github_release_witin_same_major_action_spec.rb
+++ b/spec/actions/get_latest_github_release_witin_same_major_action_spec.rb
@@ -10,6 +10,7 @@ describe Fastlane::Actions::GetLatestGithubReleaseWithinSameMajorAction do
         server_url: "https://api.github.com",
         http_method: 'GET',
         path: "repos/RevenueCat/purchases-ios/releases",
+        api_token: 'mock-github-token',
         error_handlers: anything
       ).and_return(get_releases_purchases_ios_response).once
     end
@@ -17,7 +18,8 @@ describe Fastlane::Actions::GetLatestGithubReleaseWithinSameMajorAction do
     it 'returns highest version within same major, but not highest version' do
       latest_version = Fastlane::Actions::GetLatestGithubReleaseWithinSameMajorAction.run(
         repo_name: repo_name,
-        current_version: '4.7.0'
+        current_version: '4.7.0',
+        github_token: 'mock-github-token'
       )
       expect(latest_version).to eq('4.9.1')
     end
@@ -25,7 +27,8 @@ describe Fastlane::Actions::GetLatestGithubReleaseWithinSameMajorAction do
     it 'returns highest version within same major, if highest version available' do
       latest_version = Fastlane::Actions::GetLatestGithubReleaseWithinSameMajorAction.run(
         repo_name: repo_name,
-        current_version: '5.9.0'
+        current_version: '5.9.0',
+        github_token: 'mock-github-token'
       )
       expect(latest_version).to eq('5.10.0')
     end
@@ -34,7 +37,8 @@ describe Fastlane::Actions::GetLatestGithubReleaseWithinSameMajorAction do
       expect do
         Fastlane::Actions::GetLatestGithubReleaseWithinSameMajorAction.run(
           repo_name: repo_name,
-          current_version: '6.0.0'
+          current_version: '6.0.0',
+          github_token: 'mock-github-token'
         )
       end.to raise_exception(StandardError)
     end
@@ -42,7 +46,7 @@ describe Fastlane::Actions::GetLatestGithubReleaseWithinSameMajorAction do
 
   describe '#available_options' do
     it 'has correct number of options' do
-      expect(Fastlane::Actions::GetLatestGithubReleaseWithinSameMajorAction.available_options.size).to eq(2)
+      expect(Fastlane::Actions::GetLatestGithubReleaseWithinSameMajorAction.available_options.size).to eq(3)
     end
   end
 end

--- a/spec/actions/update_hybrids_versions_file_action_spec.rb
+++ b/spec/actions/update_hybrids_versions_file_action_spec.rb
@@ -20,15 +20,16 @@ describe Fastlane::Actions::UpdateHybridsVersionsFileAction do
                       "| 1.0.0 | 1.3.4 | 2.0.1 | 1.0.5 | |\n"
       File.write(versions_path, initial_value)
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
-        .with(hybrid_common_version).and_return('2.1.2').once
+        .with(hybrid_common_version, 'mock-github-token').and_return('2.1.2').once
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
-        .with(hybrid_common_version).and_return('1.4.1').once
+        .with(hybrid_common_version, 'mock-github-token').and_return('1.4.1').once
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_billing_client_version)
-        .with('2.1.2').and_return('6.2.1').once
+        .with('2.1.2', 'mock-github-token').and_return('6.2.1').once
       Fastlane::Actions::UpdateHybridsVersionsFileAction.run(
         versions_file_path: versions_path,
         new_sdk_version: '1.5.1',
-        hybrid_common_version: hybrid_common_version
+        hybrid_common_version: hybrid_common_version,
+        github_token: 'mock-github-token'
       )
       updated_versions_content = File.read(versions_path)
       expected_content = "| Version | iOS version | Android version | common version | Play Billing Library version |\n" \
@@ -46,15 +47,16 @@ describe Fastlane::Actions::UpdateHybridsVersionsFileAction do
                       "| 1.0.0 | 1.3.4 | 2.0.1 | 1.0.5 |\n"
       File.write(versions_path, initial_value)
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
-        .with(hybrid_common_version).and_return('2.1.2').once
+        .with(hybrid_common_version, 'mock-github-token').and_return('2.1.2').once
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
-        .with(hybrid_common_version).and_return('1.4.1').once
+        .with(hybrid_common_version, 'mock-github-token').and_return('1.4.1').once
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_billing_client_version)
-        .with('2.1.2').and_return('6.2.1').once
+        .with('2.1.2', 'mock-github-token').and_return('6.2.1').once
       Fastlane::Actions::UpdateHybridsVersionsFileAction.run(
         versions_file_path: versions_path,
         new_sdk_version: '1.5.1',
-        hybrid_common_version: hybrid_common_version
+        hybrid_common_version: hybrid_common_version,
+        github_token: 'mock-github-token'
       )
       updated_versions_content = File.read(versions_path)
       expected_content = "| Version | iOS version | Android version | common version | Play Billing Library version |\n" \
@@ -80,15 +82,16 @@ describe Fastlane::Actions::UpdateHybridsVersionsFileAction do
                       "------------------------------------------------------------------------------------------|\n"
       File.write(versions_path, initial_value)
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
-        .with(hybrid_common_version).and_return('2.1.2').once
+        .with(hybrid_common_version, 'mock-github-token').and_return('2.1.2').once
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
-        .with(hybrid_common_version).and_return('1.4.1').once
+        .with(hybrid_common_version, 'mock-github-token').and_return('1.4.1').once
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_billing_client_version)
-        .with('2.1.2').and_return('6.2.1').once
+        .with('2.1.2', 'mock-github-token').and_return('6.2.1').once
       Fastlane::Actions::UpdateHybridsVersionsFileAction.run(
         versions_file_path: versions_path,
         new_sdk_version: '1.5.1',
-        hybrid_common_version: hybrid_common_version
+        hybrid_common_version: hybrid_common_version,
+        github_token: 'mock-github-token'
       )
       updated_versions_content = File.read(versions_path)
       expected_content = "| Version | iOS version | Android version | common version | Play Billing Library version |\n" \
@@ -100,7 +103,7 @@ describe Fastlane::Actions::UpdateHybridsVersionsFileAction do
 
   describe '#available_options' do
     it 'has correct number of options' do
-      expect(Fastlane::Actions::UpdateHybridsVersionsFileAction.available_options.size).to eq(3)
+      expect(Fastlane::Actions::UpdateHybridsVersionsFileAction.available_options.size).to eq(4)
     end
   end
 end

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -1057,9 +1057,10 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
         server_url: "https://api.github.com",
         http_method: 'GET',
         path: "repos/RevenueCat/purchases-ios/releases",
+        api_token: 'mock-github-token',
         error_handlers: anything
       ).and_return(get_releases_purchases_ios_response).once
-      tag_names = Fastlane::Helper::RevenuecatInternalHelper.get_github_release_tag_names(repo_name)
+      tag_names = Fastlane::Helper::RevenuecatInternalHelper.get_github_release_tag_names(repo_name, 'mock-github-token')
       expect(tag_names.count).to eq(3)
       expect(tag_names).to include('4.9.1')
       expect(tag_names).to include('4.9.0')

--- a/spec/helper/update_hybrids_versions_file_helper_spec.rb
+++ b/spec/helper/update_hybrids_versions_file_helper_spec.rb
@@ -9,9 +9,10 @@ describe Fastlane::Helper::UpdateHybridsVersionsFileHelper do
         server_url: "https://api.github.com",
         http_method: 'GET',
         path: "/repos/revenuecat/purchases-hybrid-common/contents/android/gradle/libs.versions.toml?ref=8.10.0-beta.8",
-        body: {}
+        body: {},
+        api_token: 'mock-github-token'
       ).and_return(get_contents_android_build_gradle_response).once
-      version = Fastlane::Helper::UpdateHybridsVersionsFileHelper.get_android_version_for_hybrid_common_version('8.10.0-beta.8')
+      version = Fastlane::Helper::UpdateHybridsVersionsFileHelper.get_android_version_for_hybrid_common_version('8.10.0-beta.8', 'mock-github-token')
       expect(version).to eq('7.3.1')
     end
   end
@@ -26,9 +27,10 @@ describe Fastlane::Helper::UpdateHybridsVersionsFileHelper do
         server_url: "https://api.github.com",
         http_method: 'GET',
         path: "/repos/revenuecat/purchases-hybrid-common/contents/PurchasesHybridCommon.podspec?ref=3.3.0",
-        body: {}
+        body: {},
+        api_token: 'mock-github-token'
       ).and_return(get_contents_ios_phc_podspec_3_3_0_response).once
-      version = Fastlane::Helper::UpdateHybridsVersionsFileHelper.get_ios_version_for_hybrid_common_version('3.3.0')
+      version = Fastlane::Helper::UpdateHybridsVersionsFileHelper.get_ios_version_for_hybrid_common_version('3.3.0', 'mock-github-token')
       expect(version).to eq('4.9.0')
     end
   end

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -181,9 +181,9 @@ describe Fastlane::Helper::VersioningHelper do
       mock_native_releases
       setup_commit_search_stubs(hashes_to_responses_hybrid, get_commits_response_hybrid, "9237147947bcbce00f36ae3ab51acccc54690782")
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
-        .with(hybrid_common_version).and_return('5.6.6').once
+        .with(hybrid_common_version, 'mock-github-token').and_return('5.6.6').once
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
-        .with(hybrid_common_version).and_return('4.15.4').once
+        .with(hybrid_common_version, 'mock-github-token').and_return('4.15.4').once
       expect_any_instance_of(Object).not_to receive(:sleep)
       changelog = Fastlane::Helper::VersioningHelper.auto_generate_changelog(
         'mock-repo-name',
@@ -206,9 +206,9 @@ describe Fastlane::Helper::VersioningHelper do
       setup_commit_search_stubs(hashes_to_responses_hybrid, get_commits_response_hybrid, "9237147947bcbce00f36ae3ab51acccc54690782")
 
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
-        .with(hybrid_common_version).and_return('5.6.6').once
+        .with(hybrid_common_version, 'mock-github-token').and_return('5.6.6').once
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
-        .with(hybrid_common_version).and_return('4.15.4').once
+        .with(hybrid_common_version, 'mock-github-token').and_return('4.15.4').once
       expect_any_instance_of(Object).not_to receive(:sleep)
       changelog = Fastlane::Helper::VersioningHelper.auto_generate_changelog(
         'mock-repo-name',
@@ -272,9 +272,9 @@ describe Fastlane::Helper::VersioningHelper do
       setup_commit_search_stubs(hashes_to_responses_hybrid, get_commits_response_hybrid, "9237147947bcbce00f36ae3ab51acccc54690782")
 
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
-        .with(hybrid_common_version).and_return('5.6.6').once
+        .with(hybrid_common_version, 'mock-github-token').and_return('5.6.6').once
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
-        .with(hybrid_common_version).and_return('4.15.4').once
+        .with(hybrid_common_version, 'mock-github-token').and_return('4.15.4').once
       # Making the latest android version match the current one
       expect(File).to receive(:readlines).with(versions_path)
                                          .and_return(["| Version | iOS version | Android version | Common files version |\n",
@@ -302,9 +302,9 @@ describe Fastlane::Helper::VersioningHelper do
       setup_commit_search_stubs(hashes_to_responses_hybrid, get_commits_response_hybrid, "9237147947bcbce00f36ae3ab51acccc54690782")
 
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
-        .with(hybrid_common_version).and_return('5.6.6').once
+        .with(hybrid_common_version, 'mock-github-token').and_return('5.6.6').once
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
-        .with(hybrid_common_version).and_return('4.15.4').once
+        .with(hybrid_common_version, 'mock-github-token').and_return('4.15.4').once
       # Making the latest android version match the current one
       expect(File).to receive(:readlines).with(versions_path)
                                          .and_return(["| Version | iOS version | Android version | Common files version |\n",


### PR DESCRIPTION
`GetLatestGithubReleaseWithinSameMajorAction ` and `UpdateHybridsVersionsFileAction` were using unauthenticated GitHub requests