### PR TITLE
Add retries when hitting secondary rate limits 

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -136,7 +136,7 @@ module Fastlane
 
       def self.create_pr_if_necessary(title, body, repo_name, base_branch, head_branch, github_pr_token, labels = [], team_reviewers = ['coresdk'])
         repo_with_owner = "RevenueCat/#{repo_name}"
-        existing_pr = Actions::GithubApiAction.run(
+        existing_pr = Helper::GitHubHelper.github_api_call_with_retry(
           api_token: github_pr_token,
           path: "/repos/#{repo_with_owner}/pulls?head=RevenueCat:#{head_branch}&state=open"
         )
@@ -247,11 +247,12 @@ module Fastlane
         end
       end
 
-      def self.get_github_release_tag_names(repo_name)
-        response = Actions::GithubApiAction.run(
+      def self.get_github_release_tag_names(repo_name, github_token = nil)
+        response = Helper::GitHubHelper.github_api_call_with_retry(
           server_url: "https://api.github.com",
           http_method: 'GET',
           path: "repos/RevenueCat/#{repo_name}/releases",
+          api_token: github_token,
           error_handlers: {
             404 => proc do |result|
               UI.user_error!("Repository #{repo_name} cannot be found, please double check its name and that you provided a valid API token (if it's a private repository).")

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -247,7 +247,7 @@ module Fastlane
         end
       end
 
-      def self.get_github_release_tag_names(repo_name, github_token = nil)
+      def self.get_github_release_tag_names(repo_name, github_token)
         response = Helper::GitHubHelper.github_api_call_with_retry(
           server_url: "https://api.github.com",
           http_method: 'GET',

--- a/lib/fastlane/plugin/revenuecat_internal/helper/update_hybrids_versions_file_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/update_hybrids_versions_file_helper.rb
@@ -8,7 +8,7 @@ module Fastlane
 
   module Helper
     class UpdateHybridsVersionsFileHelper
-      def self.get_android_version_for_hybrid_common_version(hybrid_common_version, github_token = nil)
+      def self.get_android_version_for_hybrid_common_version(hybrid_common_version, github_token)
         path = 'android/gradle/libs.versions.toml'
         repo_name = 'purchases-hybrid-common'
         contents = get_contents_file_github(path, repo_name, hybrid_common_version, github_token)
@@ -17,7 +17,7 @@ module Fastlane
         matches[0]
       end
 
-      def self.get_ios_version_for_hybrid_common_version(hybrid_common_version, github_token = nil)
+      def self.get_ios_version_for_hybrid_common_version(hybrid_common_version, github_token)
         path = 'PurchasesHybridCommon.podspec'
         repo_name = 'purchases-hybrid-common'
         contents = get_contents_file_github(path, repo_name, hybrid_common_version, github_token)
@@ -26,7 +26,7 @@ module Fastlane
         matches[0]
       end
 
-      def self.get_android_billing_client_version(android_version, github_token = nil)
+      def self.get_android_billing_client_version(android_version, github_token)
         path = 'gradle/libs.versions.toml'
         repo_name = 'purchases-android'
         contents = get_contents_file_github(path, repo_name, android_version, github_token)
@@ -35,7 +35,7 @@ module Fastlane
         matches[0]
       end
 
-      private_class_method def self.get_contents_file_github(file_path, repo_name, ref = 'main', github_token = nil)
+      private_class_method def self.get_contents_file_github(file_path, repo_name, ref = 'main', github_token)
         path = "/repos/revenuecat/#{repo_name}/contents/#{file_path}?ref=#{ref}"
         response = Helper::GitHubHelper.github_api_call_with_retry(server_url: 'https://api.github.com',
                                                                    path: path,

--- a/lib/fastlane/plugin/revenuecat_internal/helper/update_hybrids_versions_file_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/update_hybrids_versions_file_helper.rb
@@ -2,6 +2,7 @@ require 'base64'
 require 'fastlane_core/ui/ui'
 require 'fastlane/action'
 require 'fastlane/actions/github_api'
+require_relative 'github_helper'
 
 module Fastlane
   UI = FastlaneCore::UI unless Fastlane.const_defined?(:UI)

--- a/lib/fastlane/plugin/revenuecat_internal/helper/update_hybrids_versions_file_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/update_hybrids_versions_file_helper.rb
@@ -38,10 +38,10 @@ module Fastlane
       private_class_method def self.get_contents_file_github(file_path, repo_name, ref = 'main', github_token = nil)
         path = "/repos/revenuecat/#{repo_name}/contents/#{file_path}?ref=#{ref}"
         response = Helper::GitHubHelper.github_api_call_with_retry(server_url: 'https://api.github.com',
-                                                                path: path,
-                                                                http_method: 'GET',
-                                                                body: {},
-                                                                api_token: github_token)
+                                                                   path: path,
+                                                                   http_method: 'GET',
+                                                                   body: {},
+                                                                   api_token: github_token)
         base64_contents = response[:json]['content']
         Base64.decode64(base64_contents)
       end

--- a/lib/fastlane/plugin/revenuecat_internal/helper/update_hybrids_versions_file_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/update_hybrids_versions_file_helper.rb
@@ -8,39 +8,40 @@ module Fastlane
 
   module Helper
     class UpdateHybridsVersionsFileHelper
-      def self.get_android_version_for_hybrid_common_version(hybrid_common_version)
+      def self.get_android_version_for_hybrid_common_version(hybrid_common_version, github_token = nil)
         path = 'android/gradle/libs.versions.toml'
         repo_name = 'purchases-hybrid-common'
-        contents = get_contents_file_github(path, repo_name, hybrid_common_version)
+        contents = get_contents_file_github(path, repo_name, hybrid_common_version, github_token)
         matches = contents.match('purchases = "(.*)"').captures
         UI.user_error!("Could not find android version in #{repo_name} in file '#{path}'") if matches.length != 1
         matches[0]
       end
 
-      def self.get_ios_version_for_hybrid_common_version(hybrid_common_version)
+      def self.get_ios_version_for_hybrid_common_version(hybrid_common_version, github_token = nil)
         path = 'PurchasesHybridCommon.podspec'
         repo_name = 'purchases-hybrid-common'
-        contents = get_contents_file_github(path, repo_name, hybrid_common_version)
+        contents = get_contents_file_github(path, repo_name, hybrid_common_version, github_token)
         matches = contents.match("s.dependency 'RevenueCat', '(.*)'").captures
         UI.user_error!("Could not find ios version in #{repo_name} in file '#{path}'") if matches.length != 1
         matches[0]
       end
 
-      def self.get_android_billing_client_version(android_version)
+      def self.get_android_billing_client_version(android_version, github_token = nil)
         path = 'gradle/libs.versions.toml'
         repo_name = 'purchases-android'
-        contents = get_contents_file_github(path, repo_name, android_version)
+        contents = get_contents_file_github(path, repo_name, android_version, github_token)
         matches = contents.match('billing = "(.*)"').captures
         UI.user_error!("Could not find android billing client version in #{repo_name} in file '#{path}'") if matches.length != 1
         matches[0]
       end
 
-      private_class_method def self.get_contents_file_github(file_path, repo_name, ref = 'main')
+      private_class_method def self.get_contents_file_github(file_path, repo_name, ref = 'main', github_token = nil)
         path = "/repos/revenuecat/#{repo_name}/contents/#{file_path}?ref=#{ref}"
-        response = Actions::GithubApiAction.run(server_url: 'https://api.github.com',
-                                                path: path,
-                                                http_method: 'GET',
-                                                body: {})
+        response = Helper::GitHubHelper.github_api_call_with_retry(server_url: 'https://api.github.com',
+                                                                path: path,
+                                                                http_method: 'GET',
+                                                                body: {},
+                                                                api_token: github_token)
         base64_contents = response[:json]['content']
         Base64.decode64(base64_contents)
       end

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -175,17 +175,17 @@ describe Fastlane::Helper::GitHubHelper do
     context 'when API call hits rate limit but succeeds on retry' do
       it 'retries and succeeds on second attempt' do
         rate_limit_error = StandardError.new('GitHub responded with 403 rate limit exceeded')
-        
+
         expect(Fastlane::Actions::GithubApiAction).to receive(:run)
           .with(api_params)
           .once
           .and_raise(rate_limit_error)
-        
+
         expect(Fastlane::Actions::GithubApiAction).to receive(:run)
           .with(api_params)
           .once
           .and_return(successful_response)
-        
+
         allow_any_instance_of(Object).to receive(:sleep)
 
         result = Fastlane::Helper::GitHubHelper.github_api_call_with_retry(**api_params)
@@ -196,12 +196,12 @@ describe Fastlane::Helper::GitHubHelper do
     context 'when API call exhausts all retries' do
       it 'raises user error after max retries' do
         rate_limit_error = StandardError.new('GitHub responded with 403 rate limit exceeded')
-        
+
         expect(Fastlane::Actions::GithubApiAction).to receive(:run)
           .with(api_params)
           .exactly(4).times # Initial call + 3 retries
           .and_raise(rate_limit_error)
-        
+
         # Allow sleep to be called (we just care that retries happen and final error is raised)
         allow_any_instance_of(Object).to receive(:sleep)
 
@@ -214,7 +214,7 @@ describe Fastlane::Helper::GitHubHelper do
     context 'when API call fails with non-rate-limit error' do
       it 'raises the error immediately without retries' do
         non_rate_limit_error = StandardError.new('Some other error')
-        
+
         expect(Fastlane::Actions::GithubApiAction).to receive(:run)
           .with(api_params)
           .once
@@ -231,7 +231,7 @@ describe Fastlane::Helper::GitHubHelper do
     context 'when API call fails with 403 but not rate limit related' do
       it 'raises the error immediately without retries' do
         auth_error = StandardError.new('GitHub responded with 403 forbidden access')
-        
+
         expect(Fastlane::Actions::GithubApiAction).to receive(:run)
           .with(api_params)
           .once
@@ -248,12 +248,12 @@ describe Fastlane::Helper::GitHubHelper do
     context 'with custom max_retries' do
       it 'respects the custom retry limit' do
         rate_limit_error = StandardError.new('GitHub responded with 403 rate limit exceeded')
-        
+
         expect(Fastlane::Actions::GithubApiAction).to receive(:run)
           .with(api_params)
           .exactly(2).times # Initial call + 1 retry
           .and_raise(rate_limit_error)
-        
+
         allow_any_instance_of(Object).to receive(:sleep)
 
         expect do

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -10,7 +10,7 @@ describe Fastlane::Helper::GitHubHelper do
     end
 
     it 'returns items from response' do
-      allow(Fastlane::Actions::GithubApiAction).to receive(:run)
+      allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
         .with(server_url: server_url,
               path: "/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:#{base_branch}+SHA:#{hash}",
               http_method: http_method,
@@ -36,7 +36,7 @@ describe Fastlane::Helper::GitHubHelper do
     end
 
     it 'sleeps if passing rate limit sleep' do
-      allow(Fastlane::Actions::GithubApiAction).to receive(:run)
+      allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
         .with(server_url: server_url,
               path: "/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:#{base_branch}+SHA:#{hash}",
               http_method: http_method,
@@ -69,7 +69,7 @@ describe Fastlane::Helper::GitHubHelper do
     it 'returns commits from response' do
       allow(Fastlane::Actions::LastGitCommitAction).to receive(:run)
         .and_return(commit_hash: last_commit_sha)
-      allow(Fastlane::Actions::GithubApiAction).to receive(:run)
+      allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
         .with(server_url: server_url,
               path: "/repos/RevenueCat/mock-repo-name/compare/1.11.0...#{last_commit_sha}",
               http_method: http_method,
@@ -123,7 +123,7 @@ describe Fastlane::Helper::GitHubHelper do
         api_token: github_token
       }
 
-      expect(Fastlane::Actions::GithubApiAction).to receive(:run)
+      expect(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
         .with(hash_including(expected_params))
         .and_return(create_release_response)
 
@@ -145,6 +145,121 @@ describe Fastlane::Helper::GitHubHelper do
       body = JSON.parse(github_response[:body])
 
       expect(body).not_to be_nil
+    end
+  end
+
+  describe '.github_api_call_with_retry' do
+    let(:api_params) do
+      {
+        server_url: 'https://api.github.com',
+        path: '/test/path',
+        http_method: 'GET',
+        body: {},
+        api_token: 'test-token'
+      }
+    end
+    let(:successful_response) { { body: '{"success": true}' } }
+
+    context 'when API call succeeds on first try' do
+      it 'returns the response without retries' do
+        expect(Fastlane::Actions::GithubApiAction).to receive(:run)
+          .with(api_params)
+          .once
+          .and_return(successful_response)
+
+        result = Fastlane::Helper::GitHubHelper.github_api_call_with_retry(**api_params)
+        expect(result).to eq(successful_response)
+      end
+    end
+
+    context 'when API call hits rate limit but succeeds on retry' do
+      it 'retries and succeeds on second attempt' do
+        rate_limit_error = StandardError.new('GitHub responded with 403 rate limit exceeded')
+        
+        expect(Fastlane::Actions::GithubApiAction).to receive(:run)
+          .with(api_params)
+          .once
+          .and_raise(rate_limit_error)
+        
+        expect(Fastlane::Actions::GithubApiAction).to receive(:run)
+          .with(api_params)
+          .once
+          .and_return(successful_response)
+        
+        allow_any_instance_of(Object).to receive(:sleep)
+
+        result = Fastlane::Helper::GitHubHelper.github_api_call_with_retry(**api_params)
+        expect(result).to eq(successful_response)
+      end
+    end
+
+    context 'when API call exhausts all retries' do
+      it 'raises user error after max retries' do
+        rate_limit_error = StandardError.new('GitHub responded with 403 rate limit exceeded')
+        
+        expect(Fastlane::Actions::GithubApiAction).to receive(:run)
+          .with(api_params)
+          .exactly(4).times # Initial call + 3 retries
+          .and_raise(rate_limit_error)
+        
+        # Allow sleep to be called (we just care that retries happen and final error is raised)
+        allow_any_instance_of(Object).to receive(:sleep)
+
+        expect do
+          Fastlane::Helper::GitHubHelper.github_api_call_with_retry(**api_params)
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, /GitHub rate limit exceeded and max retries \(3\) reached/)
+      end
+    end
+
+    context 'when API call fails with non-rate-limit error' do
+      it 'raises the error immediately without retries' do
+        non_rate_limit_error = StandardError.new('Some other error')
+        
+        expect(Fastlane::Actions::GithubApiAction).to receive(:run)
+          .with(api_params)
+          .once
+          .and_raise(non_rate_limit_error)
+
+        expect_any_instance_of(Object).not_to receive(:sleep)
+
+        expect do
+          Fastlane::Helper::GitHubHelper.github_api_call_with_retry(**api_params)
+        end.to raise_error(non_rate_limit_error)
+      end
+    end
+
+    context 'when API call fails with 403 but not rate limit related' do
+      it 'raises the error immediately without retries' do
+        auth_error = StandardError.new('GitHub responded with 403 forbidden access')
+        
+        expect(Fastlane::Actions::GithubApiAction).to receive(:run)
+          .with(api_params)
+          .once
+          .and_raise(auth_error)
+
+        expect_any_instance_of(Object).not_to receive(:sleep)
+
+        expect do
+          Fastlane::Helper::GitHubHelper.github_api_call_with_retry(**api_params)
+        end.to raise_error(auth_error)
+      end
+    end
+
+    context 'with custom max_retries' do
+      it 'respects the custom retry limit' do
+        rate_limit_error = StandardError.new('GitHub responded with 403 rate limit exceeded')
+        
+        expect(Fastlane::Actions::GithubApiAction).to receive(:run)
+          .with(api_params)
+          .exactly(2).times # Initial call + 1 retry
+          .and_raise(rate_limit_error)
+        
+        allow_any_instance_of(Object).to receive(:sleep)
+
+        expect do
+          Fastlane::Helper::GitHubHelper.github_api_call_with_retry(max_retries: 1, **api_params)
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, /GitHub rate limit exceeded and max retries \(1\) reached/)
+      end
     end
   end
 end


### PR DESCRIPTION
We believe we are getting secondary rate limits (https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#about-secondary-rate-limits)

Example: https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/30452/workflows/5f7c7b67-0a74-4e9b-85c1-d69109552247/jobs/381378

This PR adds a retry mechanism