### PR TITLE
Bring back `nil` as default value for parameters to fix plugin

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -247,7 +247,7 @@ module Fastlane
         end
       end
 
-      def self.get_github_release_tag_names(repo_name, github_token)
+      def self.get_github_release_tag_names(repo_name, github_token = nil)
         response = Helper::GitHubHelper.github_api_call_with_retry(
           server_url: "https://api.github.com",
           http_method: 'GET',

--- a/lib/fastlane/plugin/revenuecat_internal/helper/update_hybrids_versions_file_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/update_hybrids_versions_file_helper.rb
@@ -36,7 +36,7 @@ module Fastlane
         matches[0]
       end
 
-      private_class_method def self.get_contents_file_github(file_path, repo_name, ref = 'main', github_token)
+      private_class_method def self.get_contents_file_github(file_path, repo_name, ref = 'main', github_token = nil)
         path = "/repos/revenuecat/#{repo_name}/contents/#{file_path}?ref=#{ref}"
         response = Helper::GitHubHelper.github_api_call_with_retry(server_url: 'https://api.github.com',
                                                                    path: path,


### PR DESCRIPTION
After removing the default value of `nil` for a `github_token` parameter in #90, the whole plugin started to fail. This PR brings back the `= nil` default value

Example of successful execution with this change: https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/30467/workflows/df189710-56b6-47ec-b8fd-19129b69d392