### PR TITLE
nit: add only one newline when inserting changelog latest

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -106,7 +106,7 @@ module Fastlane
         main_changelog_data = File.read(changelog_path)
 
         version_header = "## #{version_number}"
-        data_to_insert = "#{version_header}\n#{old_version_changelog_contents}\n\n"
+        data_to_insert = "#{version_header}\n#{old_version_changelog_contents}\n" # changelog.latest usually ends with a newline already
 
         # Compare versions ignoring prerelease and build metadata.
         new_core_version = Gem::Version.new(get_core_version(version_number))

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -571,7 +571,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       File.write(changelog_path, existing_changelog)
 
       version_to_insert = '1.11.0'
-      changelog_content = "* Bug fixes\n* Performance improvements"
+      changelog_content = "* Bug fixes\n* Performance improvements\n"
 
       Fastlane::Helper::RevenuecatInternalHelper.insert_old_version_changelog_in_current_branch(
         version_to_insert,
@@ -589,7 +589,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       File.write(changelog_path, existing_changelog)
 
       version_to_insert = '1.11.0'
-      changelog_content = "* New features"
+      changelog_content = "* New features\n"
 
       Fastlane::Helper::RevenuecatInternalHelper.insert_old_version_changelog_in_current_branch(
         version_to_insert,
@@ -607,7 +607,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       File.write(changelog_path, existing_changelog)
 
       version_to_insert = '1.10.0'
-      changelog_content = "* Old bug fixes"
+      changelog_content = "* Old bug fixes\n"
 
       Fastlane::Helper::RevenuecatInternalHelper.insert_old_version_changelog_in_current_branch(
         version_to_insert,
@@ -624,7 +624,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       File.write(changelog_path, "")
 
       version_to_insert = '1.10.0'
-      changelog_content = "* Initial release"
+      changelog_content = "* Initial release\n"
 
       Fastlane::Helper::RevenuecatInternalHelper.insert_old_version_changelog_in_current_branch(
         version_to_insert,
@@ -642,7 +642,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       File.write(changelog_path, existing_changelog)
 
       version_to_insert = '1.0.0'
-      changelog_content = "* First version"
+      changelog_content = "* First version\n"
 
       Fastlane::Helper::RevenuecatInternalHelper.insert_old_version_changelog_in_current_branch(
         version_to_insert,
@@ -680,7 +680,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       File.write(changelog_path, existing_changelog)
 
       version_to_insert = '1.11.0+4.5.3'
-      changelog_content = "* Version with build metadata"
+      changelog_content = "* Version with build metadata\n"
 
       Fastlane::Helper::RevenuecatInternalHelper.insert_old_version_changelog_in_current_branch(
         version_to_insert,
@@ -698,7 +698,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       File.write(changelog_path, existing_changelog)
 
       version_to_insert = '1.11.0-beta.1'
-      changelog_content = "* Beta version"
+      changelog_content = "* Beta version\n"
 
       Fastlane::Helper::RevenuecatInternalHelper.insert_old_version_changelog_in_current_branch(
         version_to_insert,
@@ -716,7 +716,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       File.write(changelog_path, existing_changelog)
 
       version_to_insert = '1.11.0+4.5.3'
-      changelog_content = "* Middle version"
+      changelog_content = "* Middle version\n"
 
       Fastlane::Helper::RevenuecatInternalHelper.insert_old_version_changelog_in_current_branch(
         version_to_insert,
@@ -734,7 +734,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       File.write(changelog_path, existing_changelog)
 
       version_to_insert = '1.13.0'
-      changelog_content = "* Last version of v1"
+      changelog_content = "* Last version of v1\n"
 
       Fastlane::Helper::RevenuecatInternalHelper.insert_old_version_changelog_in_current_branch(
         version_to_insert,
@@ -752,7 +752,7 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
       File.write(changelog_path, existing_changelog)
 
       version_to_insert = '1.12.0'
-      changelog_content = "* Fits between 1.13.0 and 1.11.0"
+      changelog_content = "* Fits between 1.13.0 and 1.11.0\n"
 
       Fastlane::Helper::RevenuecatInternalHelper.insert_old_version_changelog_in_current_branch(
         version_to_insert,


### PR DESCRIPTION
Follow up of #89 

Fixes formatting by only appending one newline when inserting CHANGELOG.latest.md into `main`'s CHANGELOG.md. The reason for this change is that our CHANGELOG.latest.md files already end with a newline `\n`, so we only need to append 1 newline instead of 2 to have the correct formatting (the correct separation with the previous version changelog)

<details>
<summary>Before this PR (notice the extra newline before "## 6.2.13")</summary>

```
The changelog diff would be:
diff --git a/CHANGELOG.md b/CHANGELOG.md
index fe20e6b..a92595f 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,23 @@ Using the SDK with your own IAP code is still supported in v7. Other than updati
 * Bump danger from 9.5.1 to 9.5.3 (#687) via dependabot[bot]
 (@dependabot[bot]) via RevenueCat Git Bot
 
+## 6.3.0
+## RevenueCat SDK
+### 📦 Dependency Updates
+* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 14.2.0 (#690) via RevenueCat Git Bot (@RCGitBot)
+  * [Android 8.22.0](https://github.com/RevenueCat/purchases-android/releases/tag/8.22.0)
+  * [Android 8.21.0](https://github.com/RevenueCat/purchases-android/releases/tag/8.21.0)
+  * [iOS 5.32.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.32.0)
+  * [iOS 5.31.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.31.0)
+* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 14.1.0 (#688) via RevenueCat Git Bot (@RCGitBot)
+  * [Android 8.22.0](https://github.com/RevenueCat/purchases-android/releases/tag/8.22.0)
+  * [Android 8.21.0](https://github.com/RevenueCat/purchases-android/releases/tag/8.21.0)
+  * [iOS 5.32.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.32.0)
+  * [iOS 5.31.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.31.0)
+
+### 🔄 Other Changes
+* Bump danger from 9.5.1 to 9.5.3 (#687) via dependabot[bot] (@dependabot[bot])
+
+
 ## 6.2.13
 ## RevenueCat SDK
 ### 📦 Dependency Updates
```
</details>

<details>
<summary>After the PR (no extra newline before "## 6.2.13"):</summary>
```
The changelog diff would be:
diff --git a/CHANGELOG.md b/CHANGELOG.md
index fe20e6b..a92595f 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,23 @@ Using the SDK with your own IAP code is still supported in v7. Other than updati
 * Bump danger from 9.5.1 to 9.5.3 (#687) via dependabot[bot]
 (@dependabot[bot]) via RevenueCat Git Bot

+## 6.3.0
+## RevenueCat SDK
+### 📦 Dependency Updates
+* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 14.2.0 (#690) via RevenueCat Git Bot (@RCGitBot)
+  * [Android 8.22.0](https://github.com/RevenueCat/purchases-android/releases/tag/8.22.0)
+  * [Android 8.21.0](https://github.com/RevenueCat/purchases-android/releases/tag/8.21.0)
+  * [iOS 5.32.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.32.0)
+  * [iOS 5.31.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.31.0)
+* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 14.1.0 (#688) via RevenueCat Git Bot (@RCGitBot)
+  * [Android 8.22.0](https://github.com/RevenueCat/purchases-android/releases/tag/8.22.0)
+  * [Android 8.21.0](https://github.com/RevenueCat/purchases-android/releases/tag/8.21.0)
+  * [iOS 5.32.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.32.0)
+  * [iOS 5.31.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.31.0)
+
+### 🔄 Other Changes
+* Bump danger from 9.5.1 to 9.5.3 (#687) via dependabot[bot] (@dependabot[bot])
+
+
 ## 6.2.13
 ## RevenueCat SDK
 ### 📦 Dependency Updates
```
</details>