### PR TITLE
Add `pr:other` label to PR created by `insert_changelog_of_older_version_action`

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/insert_changelog_of_older_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/insert_changelog_of_older_version_action.rb
@@ -59,7 +59,7 @@ module Fastlane
 
             pr_title = "Changelog update for #{sdk_version}"
             pr_body = changelog_content
-            Helper::RevenuecatInternalHelper.create_pr(pr_title, pr_body, repo_name, base_branch, changelog_update_branch_name, github_pr_token, ["pr:changelog_ignore"])
+            Helper::RevenuecatInternalHelper.create_pr(pr_title, pr_body, repo_name, base_branch, changelog_update_branch_name, github_pr_token, ["pr:other", "pr:changelog_ignore"])
 
             UI.success("Successfully created PR for changelog update of version #{sdk_version}")
           end

--- a/spec/actions/insert_changelog_of_older_version_action_spec.rb
+++ b/spec/actions/insert_changelog_of_older_version_action_spec.rb
@@ -62,7 +62,7 @@ describe Fastlane::Actions::InsertChangelogOfOlderVersionAction do
         .once
 
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr)
-        .with("Changelog update for #{sdk_version}", changelog_content, repo_name, base_branch, changelog_update_branch_name, github_pr_token, ["pr:changelog_ignore"])
+        .with("Changelog update for #{sdk_version}", changelog_content, repo_name, base_branch, changelog_update_branch_name, github_pr_token, ["pr:other", "pr:changelog_ignore"])
         .once
 
       expect(FastlaneCore::UI).to receive(:success)


### PR DESCRIPTION
As the title says