### PR TITLE
Add update_pr_branch action for updating PR branches via GitHub API

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/update_pr_branch_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/update_pr_branch_action.rb
@@ -1,0 +1,76 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require_relative '../helper/github_helper'
+
+module Fastlane
+  module Actions
+    class UpdatePrBranchAction < Action
+      def self.run(params)
+        github_token = params[:github_token]
+        repo_name = params[:repo_name]
+        branch = params[:branch] || Actions.sh("git rev-parse --abbrev-ref HEAD").strip
+        base_branch = params[:base_branch] || 'main'
+
+        full_repo_name = "RevenueCat/#{repo_name}"
+
+        pr_number = Helper::GitHubHelper.find_open_pr_number(
+          repo_name: full_repo_name,
+          branch: branch,
+          base_branch: base_branch,
+          api_token: github_token
+        )
+
+        Helper::GitHubHelper.update_pr_branch(
+          repo_name: full_repo_name,
+          pr_number: pr_number,
+          api_token: github_token
+        )
+      end
+
+      def self.description
+        "Updates a PR branch by merging the base branch into the head branch"
+      end
+
+      def self.details
+        "Finds the open pull request from the specified branch (or the current git branch) " \
+          "and updates it by merging the base branch into the PR head branch. " \
+          "This is equivalent to clicking 'Update branch' in the GitHub UI."
+      end
+
+      def self.authors
+        ["RevenueCat"]
+      end
+
+      def self.return_value
+        nil
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :github_token,
+                                       env_name: "GITHUB_TOKEN",
+                                       description: "GitHub API token with repo permissions",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :repo_name,
+                                       description: "Name of the repository (without owner, e.g. 'purchases-ios')",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :branch,
+                                       description: "Head branch of the PR. Defaults to the current git branch",
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :base_branch,
+                                       description: "Base branch the PR targets. Defaults to 'main'",
+                                       optional: true,
+                                       default_value: "main",
+                                       type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/update_pr_branch_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/update_pr_branch_action.rb
@@ -9,16 +9,18 @@ module Fastlane
         github_token = params[:github_token]
         repo_name = params[:repo_name]
         branch = params[:branch] || Actions.sh("git rev-parse --abbrev-ref HEAD").strip
-        base_branch = params[:base_branch] || 'main'
+        base_branch = params[:base_branch]
 
         full_repo_name = "RevenueCat/#{repo_name}"
 
-        pr_number = Helper::GitHubHelper.find_open_pr_number(
+        find_pr_params = {
           repo_name: full_repo_name,
           branch: branch,
-          base_branch: base_branch,
           api_token: github_token
-        )
+        }
+        find_pr_params[:base_branch] = base_branch if base_branch
+
+        pr_number = Helper::GitHubHelper.find_unique_open_pr_number(**find_pr_params)
 
         Helper::GitHubHelper.update_pr_branch(
           repo_name: full_repo_name,
@@ -61,9 +63,9 @@ module Fastlane
                                        optional: true,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :base_branch,
-                                       description: "Base branch the PR targets. Defaults to 'main'",
+                                       description: "Base branch the PR targets. When omitted the action auto-detects the PR, " \
+                                                    "failing if multiple open PRs exist for the same head branch",
                                        optional: true,
-                                       default_value: "main",
                                        type: String)
         ]
       end

--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -437,6 +437,28 @@ module Fastlane
         UI.success("PR ##{pr_number} merged successfully")
       end
 
+      # Updates a pull request branch by merging the base branch into the head branch.
+      # This is equivalent to clicking "Update branch" in the GitHub UI.
+      #
+      # @param repo_name [String] Full repo name with owner, e.g. "RevenueCat/purchases-ios"
+      # @param pr_number [Integer] Pull request number
+      # @param api_token [String] GitHub API token with repo permissions
+      def self.update_pr_branch(repo_name:, pr_number:, api_token:)
+        UI.message("Updating branch for PR ##{pr_number}...")
+        github_api_call_with_retry(
+          server_url: "https://api.github.com",
+          http_method: 'PUT',
+          path: "/repos/#{repo_name}/pulls/#{pr_number}/update-branch",
+          body: {},
+          api_token: api_token,
+          error_handlers: {
+            422 => proc { |r| UI.user_error!("Cannot update PR ##{pr_number} branch (may have conflicts or unexpected HEAD SHA): #{r[:body]}") },
+            '*' => proc { |r| UI.user_error!("Failed to update branch for PR ##{pr_number}: GitHub responded with #{r[:status]}: #{r[:body]}") }
+          }
+        )
+        UI.success("Branch updated for PR ##{pr_number}")
+      end
+
       # Sends a Slack notification when auto-merge fails
       # @param repo_name [String] Repository name (without owner)
       # @param pr_title [String] Pull request title

--- a/spec/actions/update_pr_branch_action_spec.rb
+++ b/spec/actions/update_pr_branch_action_spec.rb
@@ -1,0 +1,143 @@
+describe Fastlane::Actions::UpdatePrBranchAction do
+  let(:github_token) { 'mock-github-token' }
+  let(:repo_name) { 'purchases-ios' }
+  let(:full_repo_name) { 'RevenueCat/purchases-ios' }
+  let(:branch) { 'release/5.60.0' }
+  let(:pr_number) { 42 }
+
+  describe '#run' do
+    it 'finds the PR and updates the branch with defaults' do
+      expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
+        .with(
+          repo_name: full_repo_name,
+          branch: branch,
+          base_branch: 'main',
+          api_token: github_token
+        )
+        .and_return(pr_number)
+
+      expect(Fastlane::Helper::GitHubHelper).to receive(:update_pr_branch)
+        .with(
+          repo_name: full_repo_name,
+          pr_number: pr_number,
+          api_token: github_token
+        )
+
+      Fastlane::Actions::UpdatePrBranchAction.run(
+        github_token: github_token,
+        repo_name: repo_name,
+        branch: branch
+      )
+    end
+
+    it 'uses the current git branch when branch is not provided' do
+      allow(Fastlane::Actions).to receive(:sh)
+        .with("git rev-parse --abbrev-ref HEAD")
+        .and_return("feature/my-branch\n")
+
+      expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
+        .with(
+          repo_name: full_repo_name,
+          branch: 'feature/my-branch',
+          base_branch: 'main',
+          api_token: github_token
+        )
+        .and_return(pr_number)
+
+      expect(Fastlane::Helper::GitHubHelper).to receive(:update_pr_branch)
+
+      Fastlane::Actions::UpdatePrBranchAction.run(
+        github_token: github_token,
+        repo_name: repo_name
+      )
+    end
+
+    it 'supports a custom base branch' do
+      expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
+        .with(
+          repo_name: full_repo_name,
+          branch: branch,
+          base_branch: 'develop',
+          api_token: github_token
+        )
+        .and_return(pr_number)
+
+      expect(Fastlane::Helper::GitHubHelper).to receive(:update_pr_branch)
+
+      Fastlane::Actions::UpdatePrBranchAction.run(
+        github_token: github_token,
+        repo_name: repo_name,
+        branch: branch,
+        base_branch: 'develop'
+      )
+    end
+
+    it 'propagates errors from find_open_pr_number' do
+      expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
+        .and_raise(FastlaneCore::Interface::FastlaneError.new)
+
+      expect(Fastlane::Helper::GitHubHelper).not_to receive(:update_pr_branch)
+
+      expect do
+        Fastlane::Actions::UpdatePrBranchAction.run(
+          github_token: github_token,
+          repo_name: repo_name,
+          branch: branch
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError)
+    end
+
+    it 'propagates errors from update_pr_branch' do
+      allow(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number).and_return(pr_number)
+
+      expect(Fastlane::Helper::GitHubHelper).to receive(:update_pr_branch)
+        .and_raise(StandardError.new("Failed to update branch"))
+
+      expect do
+        Fastlane::Actions::UpdatePrBranchAction.run(
+          github_token: github_token,
+          repo_name: repo_name,
+          branch: branch
+        )
+      end.to raise_error(StandardError, /Failed to update branch/)
+    end
+  end
+
+  describe '#available_options' do
+    it 'has correct number of options' do
+      expect(Fastlane::Actions::UpdatePrBranchAction.available_options.size).to eq(4)
+    end
+
+    it 'has github_token option with GITHUB_TOKEN env_name' do
+      option = Fastlane::Actions::UpdatePrBranchAction.available_options.find { |o| o.key == :github_token }
+      expect(option.env_name).to eq("GITHUB_TOKEN")
+      expect(option.optional).to be false
+    end
+
+    it 'has branch option that is optional' do
+      option = Fastlane::Actions::UpdatePrBranchAction.available_options.find { |o| o.key == :branch }
+      expect(option.optional).to be true
+    end
+
+    it 'has base_branch option defaulting to main' do
+      option = Fastlane::Actions::UpdatePrBranchAction.available_options.find { |o| o.key == :base_branch }
+      expect(option.default_value).to eq("main")
+      expect(option.optional).to be true
+    end
+  end
+
+  describe 'action metadata' do
+    it 'has a description' do
+      expect(Fastlane::Actions::UpdatePrBranchAction.description).not_to be_empty
+    end
+
+    it 'has nil return value' do
+      expect(Fastlane::Actions::UpdatePrBranchAction.return_value).to be_nil
+    end
+
+    it 'supports all platforms' do
+      expect(Fastlane::Actions::UpdatePrBranchAction.is_supported?(:ios)).to be true
+      expect(Fastlane::Actions::UpdatePrBranchAction.is_supported?(:android)).to be true
+    end
+  end
+end

--- a/spec/actions/update_pr_branch_action_spec.rb
+++ b/spec/actions/update_pr_branch_action_spec.rb
@@ -6,12 +6,11 @@ describe Fastlane::Actions::UpdatePrBranchAction do
   let(:pr_number) { 42 }
 
   describe '#run' do
-    it 'finds the PR and updates the branch with defaults' do
-      expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
+    it 'finds the PR without base_branch and updates the branch' do
+      expect(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number)
         .with(
           repo_name: full_repo_name,
           branch: branch,
-          base_branch: 'main',
           api_token: github_token
         )
         .and_return(pr_number)
@@ -35,11 +34,10 @@ describe Fastlane::Actions::UpdatePrBranchAction do
         .with("git rev-parse --abbrev-ref HEAD")
         .and_return("feature/my-branch\n")
 
-      expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
+      expect(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number)
         .with(
           repo_name: full_repo_name,
           branch: 'feature/my-branch',
-          base_branch: 'main',
           api_token: github_token
         )
         .and_return(pr_number)
@@ -52,8 +50,8 @@ describe Fastlane::Actions::UpdatePrBranchAction do
       )
     end
 
-    it 'supports a custom base branch' do
-      expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
+    it 'passes base_branch to find_unique_open_pr_number when provided' do
+      expect(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number)
         .with(
           repo_name: full_repo_name,
           branch: branch,
@@ -72,8 +70,8 @@ describe Fastlane::Actions::UpdatePrBranchAction do
       )
     end
 
-    it 'propagates errors from find_open_pr_number' do
-      expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
+    it 'propagates errors from find_unique_open_pr_number' do
+      expect(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number)
         .and_raise(FastlaneCore::Interface::FastlaneError.new)
 
       expect(Fastlane::Helper::GitHubHelper).not_to receive(:update_pr_branch)
@@ -88,7 +86,7 @@ describe Fastlane::Actions::UpdatePrBranchAction do
     end
 
     it 'propagates errors from update_pr_branch' do
-      allow(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number).and_return(pr_number)
+      allow(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number).and_return(pr_number)
 
       expect(Fastlane::Helper::GitHubHelper).to receive(:update_pr_branch)
         .and_raise(StandardError.new("Failed to update branch"))
@@ -119,9 +117,9 @@ describe Fastlane::Actions::UpdatePrBranchAction do
       expect(option.optional).to be true
     end
 
-    it 'has base_branch option defaulting to main' do
+    it 'has base_branch option that is optional with no default' do
       option = Fastlane::Actions::UpdatePrBranchAction.available_options.find { |o| o.key == :base_branch }
-      expect(option.default_value).to eq("main")
+      expect(option.default_value).to be_nil
       expect(option.optional).to be true
     end
   end

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -940,4 +940,58 @@ describe Fastlane::Helper::GitHubHelper do
       expect { call_merge_pr }.to raise_error(StandardError, /Connection refused/)
     end
   end
+
+  describe '.update_pr_branch' do
+    let(:repo_name) { 'RevenueCat/mock-repo-name' }
+    let(:pr_number) { 42 }
+    let(:api_token) { 'mock-github-token' }
+    let(:captured_handlers) { {} }
+
+    before do
+      allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry) do |**kwargs|
+        captured_handlers.merge!(kwargs[:error_handlers] || {})
+        { status: 202, body: '{"message": "Updating pull request branch."}' }
+      end
+    end
+
+    def call_update_pr_branch
+      Fastlane::Helper::GitHubHelper.update_pr_branch(
+        repo_name: repo_name,
+        pr_number: pr_number,
+        api_token: api_token
+      )
+    end
+
+    it 'calls the update-branch endpoint with PUT' do
+      expect(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+        .with(hash_including(
+                http_method: 'PUT',
+                path: "/repos/#{repo_name}/pulls/#{pr_number}/update-branch",
+                body: {}
+              ))
+
+      call_update_pr_branch
+    end
+
+    it 'error handler for 422 raises with conflict message' do
+      call_update_pr_branch
+
+      expect { captured_handlers[422].call(body: 'validation failed') }
+        .to raise_error(FastlaneCore::Interface::FastlaneError, /Cannot update.*conflicts or unexpected HEAD SHA/)
+    end
+
+    it 'error handler for unexpected status raises with status and body' do
+      call_update_pr_branch
+
+      expect { captured_handlers['*'].call(status: 500, body: 'Internal Server Error') }
+        .to raise_error(FastlaneCore::Interface::FastlaneError, /500.*Internal Server Error/)
+    end
+
+    it 'propagates network errors' do
+      allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+        .and_raise(StandardError.new("Connection refused"))
+
+      expect { call_update_pr_branch }.to raise_error(StandardError, /Connection refused/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds a new `update_pr_branch` method to `GitHubHelper` that calls `PUT /repos/{owner}/{repo}/pulls/{pr_number}/update-branch` to merge the base branch into the PR head branch (equivalent to clicking "Update branch" in the GitHub UI).
- Adds a new `UpdatePrBranchAction` Fastlane action wrapping the helper, following the same parameter pattern as `EnableAutoMergeForPrAction`.

This is used by the [sdks-circleci-orb companion PR](https://github.com/RevenueCat/sdks-circleci-orb/pull/48) as a fallback when direct merge of a release PR fails because the branch is not up-to-date with the base branch.

## Test plan

- [x] All 449 existing + new specs pass (0 failures)
- [x] Added specs for `UpdatePrBranchAction` (12 examples) and `GitHubHelper.update_pr_branch` (4 examples)
- [ ] Integration test: verify the action updates a PR branch on a test repo