### PR TITLE
Make base_branch optional in merge_pr and enable_auto_merge_for_pr

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/enable_auto_merge_for_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/enable_auto_merge_for_pr_action.rb
@@ -9,17 +9,19 @@ module Fastlane
         github_token = params[:github_token]
         repo_name = params[:repo_name]
         branch = params[:branch] || Actions.sh("git rev-parse --abbrev-ref HEAD").strip
-        base_branch = params[:base_branch] || 'main'
+        base_branch = params[:base_branch]
         merge_method = params[:merge_method] || 'SQUASH'
 
         full_repo_name = "RevenueCat/#{repo_name}"
 
-        pr_number = Helper::GitHubHelper.find_open_pr_number(
+        find_pr_params = {
           repo_name: full_repo_name,
           branch: branch,
-          base_branch: base_branch,
           api_token: github_token
-        )
+        }
+        find_pr_params[:base_branch] = base_branch if base_branch
+
+        pr_number = Helper::GitHubHelper.find_open_pr_number(**find_pr_params)
 
         Helper::GitHubHelper.enable_auto_merge(
           repo_name: full_repo_name,
@@ -63,9 +65,9 @@ module Fastlane
                                        optional: true,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :base_branch,
-                                       description: "Base branch the PR targets. Defaults to 'main'",
+                                       description: "Base branch the PR targets. When omitted the action auto-detects the PR, " \
+                                                    "failing if multiple open PRs exist for the same head branch",
                                        optional: true,
-                                       default_value: "main",
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :merge_method,
                                        description: "Merge method: 'SQUASH', 'MERGE', or 'REBASE'",

--- a/lib/fastlane/plugin/revenuecat_internal/actions/enable_auto_merge_for_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/enable_auto_merge_for_pr_action.rb
@@ -21,7 +21,7 @@ module Fastlane
         }
         find_pr_params[:base_branch] = base_branch if base_branch
 
-        pr_number = Helper::GitHubHelper.find_open_pr_number(**find_pr_params)
+        pr_number = Helper::GitHubHelper.find_unique_open_pr_number(**find_pr_params)
 
         Helper::GitHubHelper.enable_auto_merge(
           repo_name: full_repo_name,

--- a/lib/fastlane/plugin/revenuecat_internal/actions/merge_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/merge_pr_action.rb
@@ -22,7 +22,7 @@ module Fastlane
         }
         find_pr_params[:base_branch] = base_branch if base_branch
 
-        pr_number = Helper::GitHubHelper.find_open_pr_number(**find_pr_params)
+        pr_number = Helper::GitHubHelper.find_unique_open_pr_number(**find_pr_params)
 
         if use_merge_queue
           Helper::GitHubHelper.enqueue_pr(

--- a/lib/fastlane/plugin/revenuecat_internal/actions/merge_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/merge_pr_action.rb
@@ -9,18 +9,20 @@ module Fastlane
         github_token = params[:github_token]
         repo_name = params[:repo_name]
         branch = params[:branch] || Actions.sh("git rev-parse --abbrev-ref HEAD").strip
-        base_branch = params[:base_branch] || 'main'
+        base_branch = params[:base_branch]
         merge_method = params[:merge_method] || 'SQUASH'
         use_merge_queue = params[:use_merge_queue] || false
 
         full_repo_name = "RevenueCat/#{repo_name}"
 
-        pr_number = Helper::GitHubHelper.find_open_pr_number(
+        find_pr_params = {
           repo_name: full_repo_name,
           branch: branch,
-          base_branch: base_branch,
           api_token: github_token
-        )
+        }
+        find_pr_params[:base_branch] = base_branch if base_branch
+
+        pr_number = Helper::GitHubHelper.find_open_pr_number(**find_pr_params)
 
         if use_merge_queue
           Helper::GitHubHelper.enqueue_pr(
@@ -75,9 +77,9 @@ module Fastlane
                                        optional: true,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :base_branch,
-                                       description: "Base branch the PR targets. Defaults to 'main'",
+                                       description: "Base branch the PR targets. When omitted the action auto-detects the PR, " \
+                                                    "failing if multiple open PRs exist for the same head branch",
                                        optional: true,
-                                       default_value: "main",
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :merge_method,
                                        description: "Merge method: 'SQUASH', 'MERGE', or 'REBASE'",

--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -294,20 +294,26 @@ module Fastlane
       #
       # @param repo_name [String] Full repo name with owner, e.g. "RevenueCat/purchases-ios"
       # @param branch [String] Head branch of the PR
-      # @param base_branch [String, nil] Base branch the PR targets (optional)
       # @param api_token [String] GitHub API token with repo permissions
+      # @param base_branch [String, nil] Base branch the PR targets (optional)
       # @return [Integer] The PR number
-      def self.find_unique_open_pr_number(repo_name:, branch:, base_branch: nil, api_token:)
+      def self.find_unique_open_pr_number(repo_name:, branch:, api_token:, base_branch: nil)
+        prs = fetch_open_prs(repo_name: repo_name, branch: branch, base_branch: base_branch, api_token: api_token)
+        validate_pr_results!(prs, branch: branch, base_branch: base_branch)
+
+        pr = prs.first
+        UI.message("Found PR ##{pr['number']}: #{pr['title']}")
+        pr["number"]
+      end
+
+      private_class_method def self.fetch_open_prs(repo_name:, branch:, base_branch:, api_token:)
         owner = repo_name.split('/').first
         query_params = { head: "#{owner}:#{branch}", state: "open" }
         query_params[:base] = base_branch if base_branch
         query = URI.encode_www_form(query_params)
 
-        if base_branch
-          UI.message("Looking for open PR from #{branch} into #{base_branch}...")
-        else
-          UI.message("Looking for open PR from #{branch}...")
-        end
+        target_msg = base_branch ? " into #{base_branch}" : ""
+        UI.message("Looking for open PR from #{branch}#{target_msg}...")
 
         response = github_api_call_with_retry(
           server_url: "https://api.github.com",
@@ -316,28 +322,24 @@ module Fastlane
           api_token: api_token
         )
 
-        prs = JSON.parse(response[:body])
+        JSON.parse(response[:body])
+      end
 
-        if prs.empty?
-          target = base_branch ? " into #{base_branch}" : ""
-          UI.user_error!("No open PR found from #{branch}#{target}")
+      private_class_method def self.validate_pr_results!(prs, branch:, base_branch:)
+        target = base_branch ? " into #{base_branch}" : ""
+        UI.user_error!("No open PR found from #{branch}#{target}") if prs.empty?
+
+        return unless prs.size > 1
+
+        if base_branch
+          UI.important("Found #{prs.size} open PRs from #{branch} into #{base_branch}, using the most recent one")
+        else
+          targets = prs.map { |pr| pr.dig('base', 'ref') }.compact.join(', ')
+          UI.user_error!(
+            "Found #{prs.size} open PRs from #{branch} (targeting: #{targets}). " \
+            "Specify base_branch to disambiguate."
+          )
         end
-
-        if prs.size > 1
-          if base_branch
-            UI.important("Found #{prs.size} open PRs from #{branch} into #{base_branch}, using the most recent one")
-          else
-            targets = prs.map { |pr| pr.dig('base', 'ref') }.compact.join(', ')
-            UI.user_error!(
-              "Found #{prs.size} open PRs from #{branch} (targeting: #{targets}). " \
-              "Specify base_branch to disambiguate."
-            )
-          end
-        end
-
-        pr = prs.first
-        UI.message("Found PR ##{pr['number']}: #{pr['title']}")
-        pr["number"]
       end
 
       # Enables GitHub's "auto-merge" (merge when ready) on an existing pull request

--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -284,19 +284,26 @@ module Fastlane
         end
       end
 
-      # Finds an open pull request from the given head branch into the given base branch.
-      # Returns the PR number of the most recent match.
+      # Finds an open pull request from the given head branch.
+      # When +base_branch+ is provided the search is scoped to PRs targeting
+      # that base; otherwise all open PRs from +branch+ are returned.
       #
       # @param repo_name [String] Full repo name with owner, e.g. "RevenueCat/purchases-ios"
       # @param branch [String] Head branch of the PR
-      # @param base_branch [String] Base branch the PR targets
+      # @param base_branch [String, nil] Base branch the PR targets (optional)
       # @param api_token [String] GitHub API token with repo permissions
       # @return [Integer] The PR number
-      def self.find_open_pr_number(repo_name:, branch:, base_branch:, api_token:)
+      def self.find_open_pr_number(repo_name:, branch:, base_branch: nil, api_token:)
         owner = repo_name.split('/').first
-        query = URI.encode_www_form(head: "#{owner}:#{branch}", base: base_branch, state: "open")
+        query_params = { head: "#{owner}:#{branch}", state: "open" }
+        query_params[:base] = base_branch if base_branch
+        query = URI.encode_www_form(query_params)
 
-        UI.message("Looking for open PR from #{branch} into #{base_branch}...")
+        if base_branch
+          UI.message("Looking for open PR from #{branch} into #{base_branch}...")
+        else
+          UI.message("Looking for open PR from #{branch}...")
+        end
 
         response = github_api_call_with_retry(
           server_url: "https://api.github.com",
@@ -306,10 +313,22 @@ module Fastlane
         )
 
         prs = JSON.parse(response[:body])
-        UI.user_error!("No open PR found from #{branch} into #{base_branch}") if prs.empty?
+
+        if prs.empty?
+          target = base_branch ? " into #{base_branch}" : ""
+          UI.user_error!("No open PR found from #{branch}#{target}")
+        end
 
         if prs.size > 1
-          UI.important("Found #{prs.size} open PRs from #{branch} into #{base_branch}, using the most recent one")
+          if base_branch
+            UI.important("Found #{prs.size} open PRs from #{branch} into #{base_branch}, using the most recent one")
+          else
+            targets = prs.map { |pr| pr.dig('base', 'ref') }.compact.join(', ')
+            UI.user_error!(
+              "Found #{prs.size} open PRs from #{branch} (targeting: #{targets}). " \
+              "Specify base_branch to disambiguate."
+            )
+          end
         end
 
         pr = prs.first

--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -284,16 +284,20 @@ module Fastlane
         end
       end
 
-      # Finds an open pull request from the given head branch.
+      # Finds the unique open pull request from the given head branch.
+      #
       # When +base_branch+ is provided the search is scoped to PRs targeting
-      # that base; otherwise all open PRs from +branch+ are returned.
+      # that base. When omitted, all open PRs from +branch+ are considered.
+      #
+      # @raise [FastlaneError] if no open PR is found, or if multiple open PRs
+      #   exist from +branch+ and +base_branch+ was not specified.
       #
       # @param repo_name [String] Full repo name with owner, e.g. "RevenueCat/purchases-ios"
       # @param branch [String] Head branch of the PR
       # @param base_branch [String, nil] Base branch the PR targets (optional)
       # @param api_token [String] GitHub API token with repo permissions
       # @return [Integer] The PR number
-      def self.find_open_pr_number(repo_name:, branch:, base_branch: nil, api_token:)
+      def self.find_unique_open_pr_number(repo_name:, branch:, base_branch: nil, api_token:)
         owner = repo_name.split('/').first
         query_params = { head: "#{owner}:#{branch}", state: "open" }
         query_params[:base] = base_branch if base_branch

--- a/spec/actions/enable_auto_merge_for_pr_action_spec.rb
+++ b/spec/actions/enable_auto_merge_for_pr_action_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane::Actions::EnableAutoMergeForPrAction do
 
   describe '#run' do
     it 'finds the PR without base_branch and enables auto-merge with defaults' do
-      expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
+      expect(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number)
         .with(
           repo_name: full_repo_name,
           branch: branch,
@@ -35,7 +35,7 @@ describe Fastlane::Actions::EnableAutoMergeForPrAction do
         .with("git rev-parse --abbrev-ref HEAD")
         .and_return("feature/my-branch\n")
 
-      expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
+      expect(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number)
         .with(
           repo_name: full_repo_name,
           branch: 'feature/my-branch',
@@ -51,8 +51,8 @@ describe Fastlane::Actions::EnableAutoMergeForPrAction do
       )
     end
 
-    it 'passes base_branch to find_open_pr_number when provided' do
-      expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
+    it 'passes base_branch to find_unique_open_pr_number when provided' do
+      expect(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number)
         .with(
           repo_name: full_repo_name,
           branch: branch,
@@ -72,7 +72,7 @@ describe Fastlane::Actions::EnableAutoMergeForPrAction do
     end
 
     it 'passes custom merge_method to enable_auto_merge' do
-      allow(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number).and_return(pr_number)
+      allow(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number).and_return(pr_number)
 
       expect(Fastlane::Helper::GitHubHelper).to receive(:enable_auto_merge)
         .with(
@@ -90,8 +90,8 @@ describe Fastlane::Actions::EnableAutoMergeForPrAction do
       )
     end
 
-    it 'propagates errors from find_open_pr_number' do
-      expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
+    it 'propagates errors from find_unique_open_pr_number' do
+      expect(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number)
         .and_raise(FastlaneCore::Interface::FastlaneError.new)
 
       expect(Fastlane::Helper::GitHubHelper).not_to receive(:enable_auto_merge)
@@ -106,7 +106,7 @@ describe Fastlane::Actions::EnableAutoMergeForPrAction do
     end
 
     it 'propagates errors from enable_auto_merge' do
-      allow(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number).and_return(pr_number)
+      allow(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number).and_return(pr_number)
 
       expect(Fastlane::Helper::GitHubHelper).to receive(:enable_auto_merge)
         .and_raise(StandardError.new("Failed to enable auto-merge"))

--- a/spec/actions/enable_auto_merge_for_pr_action_spec.rb
+++ b/spec/actions/enable_auto_merge_for_pr_action_spec.rb
@@ -6,12 +6,11 @@ describe Fastlane::Actions::EnableAutoMergeForPrAction do
   let(:pr_number) { 42 }
 
   describe '#run' do
-    it 'finds the PR and enables auto-merge with defaults' do
+    it 'finds the PR without base_branch and enables auto-merge with defaults' do
       expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
         .with(
           repo_name: full_repo_name,
           branch: branch,
-          base_branch: 'main',
           api_token: github_token
         )
         .and_return(pr_number)
@@ -40,7 +39,6 @@ describe Fastlane::Actions::EnableAutoMergeForPrAction do
         .with(
           repo_name: full_repo_name,
           branch: 'feature/my-branch',
-          base_branch: 'main',
           api_token: github_token
         )
         .and_return(pr_number)
@@ -53,7 +51,7 @@ describe Fastlane::Actions::EnableAutoMergeForPrAction do
       )
     end
 
-    it 'supports a custom base branch' do
+    it 'passes base_branch to find_open_pr_number when provided' do
       expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
         .with(
           repo_name: full_repo_name,
@@ -139,9 +137,9 @@ describe Fastlane::Actions::EnableAutoMergeForPrAction do
       expect(option.optional).to be true
     end
 
-    it 'has base_branch option defaulting to main' do
+    it 'has base_branch option that is optional with no default' do
       option = Fastlane::Actions::EnableAutoMergeForPrAction.available_options.find { |o| o.key == :base_branch }
-      expect(option.default_value).to eq("main")
+      expect(option.default_value).to be_nil
       expect(option.optional).to be true
     end
 

--- a/spec/actions/merge_pr_action_spec.rb
+++ b/spec/actions/merge_pr_action_spec.rb
@@ -6,12 +6,11 @@ describe Fastlane::Actions::MergePrAction do
   let(:pr_number) { 42 }
 
   describe '#run' do
-    it 'finds the PR, merges with defaults, and returns the PR number' do
+    it 'finds the PR without base_branch, merges with defaults, and returns the PR number' do
       expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
         .with(
           repo_name: full_repo_name,
           branch: branch,
-          base_branch: 'main',
           api_token: github_token
         )
         .and_return(pr_number)
@@ -42,7 +41,6 @@ describe Fastlane::Actions::MergePrAction do
         .with(
           repo_name: full_repo_name,
           branch: 'feature/my-branch',
-          base_branch: 'main',
           api_token: github_token
         )
         .and_return(pr_number)
@@ -55,7 +53,7 @@ describe Fastlane::Actions::MergePrAction do
       )
     end
 
-    it 'supports a custom base branch' do
+    it 'passes base_branch to find_open_pr_number when provided' do
       expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
         .with(
           repo_name: full_repo_name,
@@ -129,7 +127,6 @@ describe Fastlane::Actions::MergePrAction do
         .with(
           repo_name: full_repo_name,
           branch: branch,
-          base_branch: 'main',
           api_token: github_token
         )
         .and_return(pr_number)
@@ -200,9 +197,9 @@ describe Fastlane::Actions::MergePrAction do
       expect(option.optional).to be true
     end
 
-    it 'has base_branch option defaulting to main' do
+    it 'has base_branch option that is optional with no default' do
       option = Fastlane::Actions::MergePrAction.available_options.find { |o| o.key == :base_branch }
-      expect(option.default_value).to eq("main")
+      expect(option.default_value).to be_nil
       expect(option.optional).to be true
     end
 

--- a/spec/actions/merge_pr_action_spec.rb
+++ b/spec/actions/merge_pr_action_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane::Actions::MergePrAction do
 
   describe '#run' do
     it 'finds the PR without base_branch, merges with defaults, and returns the PR number' do
-      expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
+      expect(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number)
         .with(
           repo_name: full_repo_name,
           branch: branch,
@@ -37,7 +37,7 @@ describe Fastlane::Actions::MergePrAction do
         .with("git rev-parse --abbrev-ref HEAD")
         .and_return("feature/my-branch\n")
 
-      expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
+      expect(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number)
         .with(
           repo_name: full_repo_name,
           branch: 'feature/my-branch',
@@ -53,8 +53,8 @@ describe Fastlane::Actions::MergePrAction do
       )
     end
 
-    it 'passes base_branch to find_open_pr_number when provided' do
-      expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
+    it 'passes base_branch to find_unique_open_pr_number when provided' do
+      expect(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number)
         .with(
           repo_name: full_repo_name,
           branch: branch,
@@ -74,7 +74,7 @@ describe Fastlane::Actions::MergePrAction do
     end
 
     it 'passes custom merge_method to merge_pr' do
-      allow(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number).and_return(pr_number)
+      allow(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number).and_return(pr_number)
 
       expect(Fastlane::Helper::GitHubHelper).to receive(:merge_pr)
         .with(
@@ -92,8 +92,8 @@ describe Fastlane::Actions::MergePrAction do
       )
     end
 
-    it 'propagates errors from find_open_pr_number' do
-      expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
+    it 'propagates errors from find_unique_open_pr_number' do
+      expect(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number)
         .and_raise(FastlaneCore::Interface::FastlaneError.new)
 
       expect(Fastlane::Helper::GitHubHelper).not_to receive(:merge_pr)
@@ -108,7 +108,7 @@ describe Fastlane::Actions::MergePrAction do
     end
 
     it 'propagates errors from merge_pr' do
-      allow(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number).and_return(pr_number)
+      allow(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number).and_return(pr_number)
 
       expect(Fastlane::Helper::GitHubHelper).to receive(:merge_pr)
         .and_raise(StandardError.new("Failed to merge PR"))
@@ -123,7 +123,7 @@ describe Fastlane::Actions::MergePrAction do
     end
 
     it 'uses enqueue_pr when use_merge_queue is true' do
-      expect(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number)
+      expect(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number)
         .with(
           repo_name: full_repo_name,
           branch: branch,
@@ -151,7 +151,7 @@ describe Fastlane::Actions::MergePrAction do
     end
 
     it 'does not use enqueue_pr when use_merge_queue is false' do
-      allow(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number).and_return(pr_number)
+      allow(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number).and_return(pr_number)
 
       expect(Fastlane::Helper::GitHubHelper).to receive(:merge_pr)
       expect(Fastlane::Helper::GitHubHelper).not_to receive(:enqueue_pr)
@@ -165,7 +165,7 @@ describe Fastlane::Actions::MergePrAction do
     end
 
     it 'propagates errors from enqueue_pr' do
-      allow(Fastlane::Helper::GitHubHelper).to receive(:find_open_pr_number).and_return(pr_number)
+      allow(Fastlane::Helper::GitHubHelper).to receive(:find_unique_open_pr_number).and_return(pr_number)
 
       expect(Fastlane::Helper::GitHubHelper).to receive(:enqueue_pr)
         .and_raise(StandardError.new("Failed to enqueue PR"))

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -470,91 +470,153 @@ describe Fastlane::Helper::GitHubHelper do
     let(:branch) { 'release/5.60.0' }
     let(:base_branch) { 'main' }
 
-    def expected_path(head_branch, target_base = base_branch)
-      query = URI.encode_www_form(head: "RevenueCat:#{head_branch}", base: target_base, state: "open")
+    def expected_path_with_base(head_branch, target_base)
+      query = URI.encode_www_form(head: "RevenueCat:#{head_branch}", state: "open", base: target_base)
       "/repos/#{repo_name}/pulls?#{query}"
     end
 
-    it 'returns the PR number for a single matching PR' do
-      pr_response = { body: [{ "number" => 42, "title" => "Release PR" }].to_json }
-
-      expect(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
-        .with(
-          server_url: 'https://api.github.com',
-          http_method: 'GET',
-          path: expected_path(branch),
-          api_token: api_token
-        )
-        .and_return(pr_response)
-
-      result = Fastlane::Helper::GitHubHelper.find_open_pr_number(
-        repo_name: repo_name,
-        branch: branch,
-        base_branch: base_branch,
-        api_token: api_token
-      )
-
-      expect(result).to eq(42)
+    def expected_path_without_base(head_branch)
+      query = URI.encode_www_form(head: "RevenueCat:#{head_branch}", state: "open")
+      "/repos/#{repo_name}/pulls?#{query}"
     end
 
-    it 'raises error when no open PR is found' do
-      empty_response = { body: [].to_json }
+    context 'with base_branch specified' do
+      it 'returns the PR number for a single matching PR' do
+        pr_response = { body: [{ "number" => 42, "title" => "Release PR" }].to_json }
 
-      expect(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
-        .and_return(empty_response)
+        expect(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(
+            server_url: 'https://api.github.com',
+            http_method: 'GET',
+            path: expected_path_with_base(branch, base_branch),
+            api_token: api_token
+          )
+          .and_return(pr_response)
 
-      expect do
-        Fastlane::Helper::GitHubHelper.find_open_pr_number(
+        result = Fastlane::Helper::GitHubHelper.find_open_pr_number(
           repo_name: repo_name,
           branch: branch,
           base_branch: base_branch,
           api_token: api_token
         )
-      end.to raise_error(FastlaneCore::Interface::FastlaneError, /No open PR found from #{Regexp.escape(branch)} into #{base_branch}/)
-    end
 
-    it 'picks the first (most recent) PR and warns when multiple match' do
-      newer_pr = { "number" => 42, "title" => "New PR" }
-      older_pr = { "number" => 10, "title" => "Old PR" }
-      multi_response = { body: [newer_pr, older_pr].to_json }
+        expect(result).to eq(42)
+      end
 
-      expect(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
-        .and_return(multi_response)
+      it 'raises error when no open PR is found' do
+        empty_response = { body: [].to_json }
 
-      expect(FastlaneCore::UI).to receive(:important)
-        .with("Found 2 open PRs from #{branch} into #{base_branch}, using the most recent one")
+        expect(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .and_return(empty_response)
 
-      result = Fastlane::Helper::GitHubHelper.find_open_pr_number(
-        repo_name: repo_name,
-        branch: branch,
-        base_branch: base_branch,
-        api_token: api_token
-      )
+        expect do
+          Fastlane::Helper::GitHubHelper.find_open_pr_number(
+            repo_name: repo_name,
+            branch: branch,
+            base_branch: base_branch,
+            api_token: api_token
+          )
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, /No open PR found from #{Regexp.escape(branch)} into #{base_branch}/)
+      end
 
-      expect(result).to eq(42)
-    end
+      it 'picks the first (most recent) PR and warns when multiple match' do
+        newer_pr = { "number" => 42, "title" => "New PR" }
+        older_pr = { "number" => 10, "title" => "Old PR" }
+        multi_response = { body: [newer_pr, older_pr].to_json }
 
-    it 'URL-encodes branch names with special characters' do
-      special_branch = 'feature/foo&bar#1'
-      pr_response = { body: [{ "number" => 7, "title" => "Special" }].to_json }
+        expect(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .and_return(multi_response)
 
-      expect(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
-        .with(
-          server_url: 'https://api.github.com',
-          http_method: 'GET',
-          path: expected_path(special_branch),
+        expect(FastlaneCore::UI).to receive(:important)
+          .with("Found 2 open PRs from #{branch} into #{base_branch}, using the most recent one")
+
+        result = Fastlane::Helper::GitHubHelper.find_open_pr_number(
+          repo_name: repo_name,
+          branch: branch,
+          base_branch: base_branch,
           api_token: api_token
         )
-        .and_return(pr_response)
 
-      result = Fastlane::Helper::GitHubHelper.find_open_pr_number(
-        repo_name: repo_name,
-        branch: special_branch,
-        base_branch: base_branch,
-        api_token: api_token
-      )
+        expect(result).to eq(42)
+      end
 
-      expect(result).to eq(7)
+      it 'URL-encodes branch names with special characters' do
+        special_branch = 'feature/foo&bar#1'
+        pr_response = { body: [{ "number" => 7, "title" => "Special" }].to_json }
+
+        expect(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(
+            server_url: 'https://api.github.com',
+            http_method: 'GET',
+            path: expected_path_with_base(special_branch, base_branch),
+            api_token: api_token
+          )
+          .and_return(pr_response)
+
+        result = Fastlane::Helper::GitHubHelper.find_open_pr_number(
+          repo_name: repo_name,
+          branch: special_branch,
+          base_branch: base_branch,
+          api_token: api_token
+        )
+
+        expect(result).to eq(7)
+      end
+    end
+
+    context 'without base_branch' do
+      it 'returns the PR number when exactly one open PR exists' do
+        pr_response = { body: [{ "number" => 99, "title" => "Release PR" }].to_json }
+
+        expect(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(
+            server_url: 'https://api.github.com',
+            http_method: 'GET',
+            path: expected_path_without_base(branch),
+            api_token: api_token
+          )
+          .and_return(pr_response)
+
+        result = Fastlane::Helper::GitHubHelper.find_open_pr_number(
+          repo_name: repo_name,
+          branch: branch,
+          api_token: api_token
+        )
+
+        expect(result).to eq(99)
+      end
+
+      it 'raises error when no open PR is found' do
+        empty_response = { body: [].to_json }
+
+        expect(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .and_return(empty_response)
+
+        expect do
+          Fastlane::Helper::GitHubHelper.find_open_pr_number(
+            repo_name: repo_name,
+            branch: branch,
+            api_token: api_token
+          )
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, /No open PR found from #{Regexp.escape(branch)}/)
+      end
+
+      it 'raises error when multiple open PRs exist' do
+        pr1 = { "number" => 42, "title" => "PR to main", "base" => { "ref" => "main" } }
+        pr2 = { "number" => 10, "title" => "PR to develop", "base" => { "ref" => "develop" } }
+        multi_response = { body: [pr1, pr2].to_json }
+
+        expect(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .and_return(multi_response)
+
+        expect do
+          Fastlane::Helper::GitHubHelper.find_open_pr_number(
+            repo_name: repo_name,
+            branch: branch,
+            api_token: api_token
+          )
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, /Found 2 open PRs.*Specify base_branch to disambiguate/)
+      end
     end
 
     it 'propagates network errors' do

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -464,7 +464,7 @@ describe Fastlane::Helper::GitHubHelper do
     end
   end
 
-  describe '.find_open_pr_number' do
+  describe '.find_unique_open_pr_number' do
     let(:repo_name) { 'RevenueCat/mock-repo-name' }
     let(:api_token) { 'mock-github-token' }
     let(:branch) { 'release/5.60.0' }
@@ -493,7 +493,7 @@ describe Fastlane::Helper::GitHubHelper do
           )
           .and_return(pr_response)
 
-        result = Fastlane::Helper::GitHubHelper.find_open_pr_number(
+        result = Fastlane::Helper::GitHubHelper.find_unique_open_pr_number(
           repo_name: repo_name,
           branch: branch,
           base_branch: base_branch,
@@ -510,7 +510,7 @@ describe Fastlane::Helper::GitHubHelper do
           .and_return(empty_response)
 
         expect do
-          Fastlane::Helper::GitHubHelper.find_open_pr_number(
+          Fastlane::Helper::GitHubHelper.find_unique_open_pr_number(
             repo_name: repo_name,
             branch: branch,
             base_branch: base_branch,
@@ -530,7 +530,7 @@ describe Fastlane::Helper::GitHubHelper do
         expect(FastlaneCore::UI).to receive(:important)
           .with("Found 2 open PRs from #{branch} into #{base_branch}, using the most recent one")
 
-        result = Fastlane::Helper::GitHubHelper.find_open_pr_number(
+        result = Fastlane::Helper::GitHubHelper.find_unique_open_pr_number(
           repo_name: repo_name,
           branch: branch,
           base_branch: base_branch,
@@ -553,7 +553,7 @@ describe Fastlane::Helper::GitHubHelper do
           )
           .and_return(pr_response)
 
-        result = Fastlane::Helper::GitHubHelper.find_open_pr_number(
+        result = Fastlane::Helper::GitHubHelper.find_unique_open_pr_number(
           repo_name: repo_name,
           branch: special_branch,
           base_branch: base_branch,
@@ -577,7 +577,7 @@ describe Fastlane::Helper::GitHubHelper do
           )
           .and_return(pr_response)
 
-        result = Fastlane::Helper::GitHubHelper.find_open_pr_number(
+        result = Fastlane::Helper::GitHubHelper.find_unique_open_pr_number(
           repo_name: repo_name,
           branch: branch,
           api_token: api_token
@@ -593,7 +593,7 @@ describe Fastlane::Helper::GitHubHelper do
           .and_return(empty_response)
 
         expect do
-          Fastlane::Helper::GitHubHelper.find_open_pr_number(
+          Fastlane::Helper::GitHubHelper.find_unique_open_pr_number(
             repo_name: repo_name,
             branch: branch,
             api_token: api_token
@@ -610,7 +610,7 @@ describe Fastlane::Helper::GitHubHelper do
           .and_return(multi_response)
 
         expect do
-          Fastlane::Helper::GitHubHelper.find_open_pr_number(
+          Fastlane::Helper::GitHubHelper.find_unique_open_pr_number(
             repo_name: repo_name,
             branch: branch,
             api_token: api_token
@@ -624,7 +624,7 @@ describe Fastlane::Helper::GitHubHelper do
         .and_raise(StandardError.new("Connection refused"))
 
       expect do
-        Fastlane::Helper::GitHubHelper.find_open_pr_number(
+        Fastlane::Helper::GitHubHelper.find_unique_open_pr_number(
           repo_name: repo_name,
           branch: branch,
           base_branch: base_branch,


### PR DESCRIPTION
## Description

The `base_branch` parameter in `merge_pr` and `enable_auto_merge_for_pr` actions previously defaulted to `main`, which caused failures when the release PR targets a different branch (e.g. pre-release PRs that don't go into `main`).

Since no caller (neither the SDKs nor the CircleCI orb) ever passes `base_branch` explicitly, the hard-coded default was always wrong for those cases.

## Changes

- Made `base_branch` optional (no default) in both `merge_pr` and `enable_auto_merge_for_pr` actions
- Renamed `find_open_pr_number` to `find_unique_open_pr_number` to clarify intent
- Updated `GitHubHelper.find_unique_open_pr_number` to support omitting `base_branch`:
  - When omitted, it searches for open PRs by head branch only
  - If exactly **one** PR is found, it is used automatically (covers the vast majority of cases)
  - If **multiple** PRs exist for the same head branch, the action fails with a clear error asking to specify `base_branch` to disambiguate
- `base_branch` can still be passed explicitly for the rare case where disambiguation is needed
- Updated all specs

- [x] A description about what and why you are contributing, even if it's trivial.
- [x] If applicable, unit tests.