### PR TITLE
Add run_maestro_e2e_tests action for shared Maestro retry logic

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/run_maestro_e2e_tests_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/run_maestro_e2e_tests_action.rb
@@ -1,0 +1,97 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require 'fileutils'
+require_relative '../helper/revenuecat_internal_helper'
+
+module Fastlane
+  module Actions
+    class RunMaestroE2eTestsAction < Action
+      def self.run(params)
+        flow_dir = params[:flow_dir]
+        output_dir = params[:output_dir]
+        max_retries = params[:max_retries]
+        environment_name = params[:environment_name]
+
+        UI.user_error!("Flow directory not found: #{flow_dir}") unless File.directory?(flow_dir)
+
+        FileUtils.mkdir_p(output_dir)
+
+        success = false
+        attempt = 0
+
+        while attempt <= max_retries && !success
+          attempt_output_dir = "#{output_dir}/attempt_#{attempt}"
+          FileUtils.mkdir_p(attempt_output_dir)
+
+          begin
+            Actions.sh("maestro", "test", "--format", "junit", "--output", "#{attempt_output_dir}/report.xml", "--test-output-dir", attempt_output_dir, flow_dir)
+            success = true
+            postprocess_junit_report(attempt_output_dir, environment_name) if environment_name
+            FileUtils.cp("#{attempt_output_dir}/report.xml", "#{output_dir}/report.xml")
+          rescue StandardError => e
+            UI.error("Maestro test attempt #{attempt} failed: #{e.message}")
+            postprocess_junit_report(attempt_output_dir, environment_name) if environment_name
+            raise e if attempt >= max_retries
+
+            attempt += 1
+            UI.message("Retrying... #{attempt}/#{max_retries}")
+          end
+        end
+
+        success
+      end
+
+      def self.postprocess_junit_report(output_dir, environment_name)
+        junit_file = "#{output_dir}/report.xml"
+        return unless File.exist?(junit_file)
+
+        UI.message("Adding environment name (#{environment_name}) to test names in JUnit report...")
+        content = File.read(junit_file)
+        modified_content = content.gsub(/<testcase([^>]*)name="([^"]+)"/) do |_match|
+          prefix = Regexp.last_match(1)
+          test_name = Regexp.last_match(2)
+          "<testcase#{prefix}name=\"#{test_name} (#{environment_name})\""
+        end
+        File.write(junit_file, modified_content)
+      end
+
+      def self.description
+        "Runs Maestro E2E tests with automatic retries to handle flaky failures"
+      end
+
+      def self.authors
+        ["Andrés Pallares"]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :flow_dir,
+                                       description: "Path to the Maestro flow directory",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :output_dir,
+                                       description: "Path to store test output and JUnit reports",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :max_retries,
+                                       description: "Maximum number of retry attempts after initial failure",
+                                       optional: true,
+                                       default_value: 5,
+                                       type: Integer),
+          FastlaneCore::ConfigItem.new(key: :environment_name,
+                                       description: "Optional environment name to prefix in JUnit test case names (used by purchases-ios for multi-environment runs)",
+                                       optional: true,
+                                       type: String)
+        ]
+      end
+
+      def self.return_value
+        "Returns true if tests passed (possibly after retries), raises on final failure"
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/run_maestro_e2e_tests_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/run_maestro_e2e_tests_action.rb
@@ -7,8 +7,12 @@ module Fastlane
   module Actions
     class RunMaestroE2eTestsAction < Action
       def self.run(params)
-        flow_dir = params[:flow_dir]
-        output_dir = params[:output_dir]
+        # Fastlane's sh() resolves relative paths from the fastlane/ directory,
+        # but Ruby File operations resolve from the process cwd (project root).
+        # Resolve all paths relative to the fastlane/ directory for consistency.
+        fastlane_dir = FastlaneCore::FastlaneFolder.path
+        flow_dir = File.expand_path(params[:flow_dir], fastlane_dir)
+        output_dir = File.expand_path(params[:output_dir], fastlane_dir)
         max_retries = params[:max_retries]
         environment_name = params[:environment_name]
 

--- a/lib/fastlane/plugin/revenuecat_internal/actions/run_maestro_e2e_tests_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/run_maestro_e2e_tests_action.rb
@@ -41,6 +41,11 @@ module Fastlane
         success
       end
 
+      # Appends the environment name to each <testcase> name attribute in the JUnit XML report.
+      # This is needed because purchases-ios runs Maestro tests against multiple backend
+      # environments (e.g. production, sandbox) in the same CI job. Without this, CircleCI
+      # merges identically-named test cases from different environments into a single entry,
+      # making it impossible to tell which environment a failure came from.
       def self.postprocess_junit_report(output_dir, environment_name)
         junit_file = "#{output_dir}/report.xml"
         return unless File.exist?(junit_file)

--- a/lib/fastlane/plugin/revenuecat_internal/actions/run_maestro_e2e_tests_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/run_maestro_e2e_tests_action.rb
@@ -65,7 +65,7 @@ module Fastlane
       end
 
       def self.authors
-        ["Andrés Pallares"]
+        ["Antonio Pallares"]
       end
 
       def self.available_options

--- a/spec/actions/run_maestro_e2e_tests_action_spec.rb
+++ b/spec/actions/run_maestro_e2e_tests_action_spec.rb
@@ -1,9 +1,11 @@
 describe Fastlane::Actions::RunMaestroE2eTestsAction do
   describe '#run' do
+    let(:fastlane_dir) { '/project/fastlane/' }
     let(:flow_dir) { '/tmp/maestro_test_flows' }
     let(:output_dir) { '/tmp/maestro_test_output' }
 
     before do
+      allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(fastlane_dir)
       allow(File).to receive(:directory?).and_call_original
       allow(File).to receive(:directory?).with(flow_dir).and_return(true)
       allow(FileUtils).to receive(:mkdir_p)
@@ -21,6 +23,23 @@ describe Fastlane::Actions::RunMaestroE2eTestsAction do
           output_dir: output_dir,
           max_retries: 5
         )
+      end
+    end
+
+    context 'when using relative paths' do
+      it 'resolves paths relative to the fastlane directory' do
+        resolved_flow = File.expand_path("../e2e-tests/maestro/", fastlane_dir)
+        allow(File).to receive(:directory?).with(resolved_flow).and_return(true)
+        allow(Fastlane::Actions).to receive(:sh)
+
+        Fastlane::Actions::RunMaestroE2eTestsAction.run(
+          flow_dir: '../e2e-tests/maestro/',
+          output_dir: 'test_output',
+          max_retries: 5
+        )
+
+        resolved_output = File.expand_path("test_output", fastlane_dir)
+        expect(FileUtils).to have_received(:mkdir_p).with(resolved_output)
       end
     end
 

--- a/spec/actions/run_maestro_e2e_tests_action_spec.rb
+++ b/spec/actions/run_maestro_e2e_tests_action_spec.rb
@@ -1,0 +1,239 @@
+describe Fastlane::Actions::RunMaestroE2eTestsAction do
+  describe '#run' do
+    let(:flow_dir) { '/tmp/maestro_test_flows' }
+    let(:output_dir) { '/tmp/maestro_test_output' }
+
+    before do
+      allow(File).to receive(:directory?).and_call_original
+      allow(File).to receive(:directory?).with(flow_dir).and_return(true)
+      allow(FileUtils).to receive(:mkdir_p)
+      allow(FileUtils).to receive(:cp)
+    end
+
+    context 'when flow directory does not exist' do
+      it 'raises a user error' do
+        allow(File).to receive(:directory?).with('/nonexistent').and_return(false)
+
+        expect(Fastlane::UI).to receive(:user_error!).with("Flow directory not found: /nonexistent")
+
+        Fastlane::Actions::RunMaestroE2eTestsAction.run(
+          flow_dir: '/nonexistent',
+          output_dir: output_dir,
+          max_retries: 5
+        )
+      end
+    end
+
+    context 'when maestro succeeds on first attempt' do
+      it 'returns true without retrying' do
+        expect(Fastlane::Actions).to receive(:sh).once
+
+        result = Fastlane::Actions::RunMaestroE2eTestsAction.run(
+          flow_dir: flow_dir,
+          output_dir: output_dir,
+          max_retries: 5
+        )
+
+        expect(result).to be true
+      end
+
+      it 'copies the report to the main output directory' do
+        allow(Fastlane::Actions).to receive(:sh)
+        expect(FileUtils).to receive(:cp).with("#{output_dir}/attempt_0/report.xml", "#{output_dir}/report.xml")
+
+        Fastlane::Actions::RunMaestroE2eTestsAction.run(
+          flow_dir: flow_dir,
+          output_dir: output_dir,
+          max_retries: 5
+        )
+      end
+    end
+
+    context 'when maestro fails then succeeds on retry' do
+      it 'retries and returns true' do
+        call_count = 0
+        allow(Fastlane::Actions).to receive(:sh) do
+          call_count += 1
+          raise StandardError, "Maestro failed" if call_count == 1
+        end
+        allow(Fastlane::UI).to receive(:error)
+        allow(Fastlane::UI).to receive(:message)
+
+        result = Fastlane::Actions::RunMaestroE2eTestsAction.run(
+          flow_dir: flow_dir,
+          output_dir: output_dir,
+          max_retries: 5
+        )
+
+        expect(result).to be true
+        expect(call_count).to eq(2)
+      end
+
+      it 'logs the failure and retry messages' do
+        first_call = true
+        allow(Fastlane::Actions).to receive(:sh) do
+          if first_call
+            first_call = false
+            raise StandardError, "Maestro failed"
+          end
+        end
+
+        expect(Fastlane::UI).to receive(:error).with("Maestro test attempt 0 failed: Maestro failed")
+        expect(Fastlane::UI).to receive(:message).with("Retrying... 1/5")
+
+        Fastlane::Actions::RunMaestroE2eTestsAction.run(
+          flow_dir: flow_dir,
+          output_dir: output_dir,
+          max_retries: 5
+        )
+      end
+    end
+
+    context 'when maestro fails all retries' do
+      it 'raises the last error after exhausting retries' do
+        allow(Fastlane::Actions).to receive(:sh).and_raise(StandardError, "Maestro failed")
+        allow(Fastlane::UI).to receive(:error)
+        allow(Fastlane::UI).to receive(:message)
+
+        expect do
+          Fastlane::Actions::RunMaestroE2eTestsAction.run(
+            flow_dir: flow_dir,
+            output_dir: output_dir,
+            max_retries: 2
+          )
+        end.to raise_error(StandardError, "Maestro failed")
+      end
+
+      it 'attempts exactly max_retries + 1 times' do
+        call_count = 0
+        allow(Fastlane::Actions).to receive(:sh) do
+          call_count += 1
+          raise StandardError, "Maestro failed"
+        end
+        allow(Fastlane::UI).to receive(:error)
+        allow(Fastlane::UI).to receive(:message)
+
+        begin
+          Fastlane::Actions::RunMaestroE2eTestsAction.run(
+            flow_dir: flow_dir,
+            output_dir: output_dir,
+            max_retries: 2
+          )
+        rescue StandardError
+          nil
+        end
+
+        expect(call_count).to eq(3)
+      end
+    end
+
+    context 'with environment_name parameter' do
+      it 'does not call postprocess when environment_name is nil' do
+        allow(Fastlane::Actions).to receive(:sh)
+        expect(Fastlane::Actions::RunMaestroE2eTestsAction).not_to receive(:postprocess_junit_report)
+
+        Fastlane::Actions::RunMaestroE2eTestsAction.run(
+          flow_dir: flow_dir,
+          output_dir: output_dir,
+          max_retries: 5
+        )
+      end
+
+      it 'calls postprocess on success when environment_name is set' do
+        allow(Fastlane::Actions).to receive(:sh)
+        expect(Fastlane::Actions::RunMaestroE2eTestsAction).to receive(:postprocess_junit_report)
+          .with("#{output_dir}/attempt_0", "sandbox")
+
+        Fastlane::Actions::RunMaestroE2eTestsAction.run(
+          flow_dir: flow_dir,
+          output_dir: output_dir,
+          max_retries: 5,
+          environment_name: "sandbox"
+        )
+      end
+
+      it 'calls postprocess on failure when environment_name is set' do
+        allow(Fastlane::Actions).to receive(:sh).and_raise(StandardError, "fail")
+        allow(Fastlane::UI).to receive(:error)
+        expect(Fastlane::Actions::RunMaestroE2eTestsAction).to receive(:postprocess_junit_report)
+          .with("#{output_dir}/attempt_0", "sandbox")
+
+        begin
+          Fastlane::Actions::RunMaestroE2eTestsAction.run(
+            flow_dir: flow_dir,
+            output_dir: output_dir,
+            max_retries: 0,
+            environment_name: "sandbox"
+          )
+        rescue StandardError
+          nil
+        end
+      end
+    end
+  end
+
+  describe '.postprocess_junit_report' do
+    let(:output_dir) { Dir.mktmpdir }
+    let(:junit_file) { "#{output_dir}/report.xml" }
+
+    after { FileUtils.rm_rf(output_dir) }
+
+    it 'appends environment name to testcase names' do
+      File.write(junit_file, <<~XML)
+        <testsuite>
+          <testcase classname="e2e" name="purchase_through_paywall" time="10.5"/>
+          <testcase classname="e2e" name="restore_purchases" time="5.2"/>
+        </testsuite>
+      XML
+
+      Fastlane::Actions::RunMaestroE2eTestsAction.postprocess_junit_report(output_dir, "sandbox")
+
+      content = File.read(junit_file)
+      expect(content).to include('name="purchase_through_paywall (sandbox)"')
+      expect(content).to include('name="restore_purchases (sandbox)"')
+    end
+
+    it 'does nothing when the report file does not exist' do
+      expect { Fastlane::Actions::RunMaestroE2eTestsAction.postprocess_junit_report(output_dir, "sandbox") }
+        .not_to raise_error
+    end
+  end
+
+  describe '#available_options' do
+    it 'has correct number of options' do
+      expect(Fastlane::Actions::RunMaestroE2eTestsAction.available_options.size).to eq(4)
+    end
+
+    it 'has required flow_dir option' do
+      option = Fastlane::Actions::RunMaestroE2eTestsAction.available_options.find { |o| o.key == :flow_dir }
+      expect(option.optional).to be false
+    end
+
+    it 'has required output_dir option' do
+      option = Fastlane::Actions::RunMaestroE2eTestsAction.available_options.find { |o| o.key == :output_dir }
+      expect(option.optional).to be false
+    end
+
+    it 'has optional max_retries with default of 5' do
+      option = Fastlane::Actions::RunMaestroE2eTestsAction.available_options.find { |o| o.key == :max_retries }
+      expect(option.optional).to be true
+      expect(option.default_value).to eq(5)
+    end
+
+    it 'has optional environment_name' do
+      option = Fastlane::Actions::RunMaestroE2eTestsAction.available_options.find { |o| o.key == :environment_name }
+      expect(option.optional).to be true
+    end
+  end
+
+  describe 'action metadata' do
+    it 'has a description' do
+      expect(Fastlane::Actions::RunMaestroE2eTestsAction.description).not_to be_empty
+    end
+
+    it 'supports all platforms' do
+      expect(Fastlane::Actions::RunMaestroE2eTestsAction.is_supported?(:ios)).to be true
+      expect(Fastlane::Actions::RunMaestroE2eTestsAction.is_supported?(:android)).to be true
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a new `run_maestro_e2e_tests` action that runs Maestro E2E tests with automatic retries (up to 5 by default) to handle flaky test failures
- Supports an optional `environment_name` parameter for JUnit report postprocessing (used by purchases-ios for multi-environment runs)
- Each retry attempt stores its output in a separate subdirectory for debugging

## Test plan
- [ ] Verify CI passes in the SDK repos that consume this action (react-native, flutter, cordova, capacitor, kmp, unity, iOS)

Made with [Cursor](https://cursor.com)