### PR TITLE
Optionally include purchases-js in VERSIONS.md files in hybrids

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -30,6 +30,7 @@ module Fastlane
         dry_run = params[:dry_run]
         filter_labels = params[:filter_labels]
         exclude_labels = params[:exclude_labels]
+        include_purchases_js = params[:include_purchases_js]
 
         # See if we got any conflicting arguments.
         Helper::VersioningHelper.validate_input_if_appending_phc_version?(
@@ -79,7 +80,7 @@ module Fastlane
           UI.important("No github_token provided.")
         end
 
-        generated_contents = Helper::VersioningHelper.auto_generate_changelog(repo_name, github_token, rate_limit_sleep, include_prereleases, hybrid_common_version, versions_file_path, new_version_number, filter_labels: filter_labels, exclude_labels: exclude_labels)
+        generated_contents = Helper::VersioningHelper.auto_generate_changelog(repo_name, github_token, rate_limit_sleep, include_prereleases, hybrid_common_version, versions_file_path, new_version_number, filter_labels: filter_labels, exclude_labels: exclude_labels, include_purchases_js: include_purchases_js)
 
         if UI.interactive?
           Helper::RevenuecatInternalHelper.edit_changelog(generated_contents, changelog_latest_path, editor)
@@ -240,6 +241,11 @@ module Fastlane
                                        description: "Exclude PRs with any of these labels from the changelog",
                                        optional: true,
                                        type: Array),
+          FastlaneCore::ConfigItem.new(key: :include_purchases_js,
+                                       description: "Whether to include purchases-js version bumps in the changelog (for hybrids with web support, e.g. Flutter, React Native)",
+                                       optional: true,
+                                       is_string: false,
+                                       default_value: false),
           FastlaneCore::ConfigItem.new(key: :dry_run,
                                        description: "Whether to run the action in dry run mode",
                                        optional: true,

--- a/lib/fastlane/plugin/revenuecat_internal/actions/update_hybrids_versions_file_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/update_hybrids_versions_file_action.rb
@@ -6,11 +6,15 @@ require_relative '../helper/update_hybrids_versions_file_helper'
 module Fastlane
   module Actions
     class UpdateHybridsVersionsFileAction < Action
+      WEB_SDK_COLUMN_HEADER = 'Web SDK version'.freeze
+
+      # rubocop:disable Metrics/PerceivedComplexity
       def self.run(params)
         versions_file_path = params[:versions_file_path]
         new_sdk_version = params[:new_sdk_version]
         hybrid_common_version = params[:hybrid_common_version]
         github_token = params[:github_token]
+        include_purchases_js = params[:include_purchases_js]
 
         UI.user_error!("VERSIONS.md file not found") unless File.exist?(versions_file_path)
 
@@ -22,6 +26,11 @@ module Fastlane
 
         billing_client_version = Helper::UpdateHybridsVersionsFileHelper.get_android_billing_client_version(android_version, github_token)
         UI.message("Obtained android billing client version #{billing_client_version} for PHC version #{hybrid_common_version}")
+
+        if include_purchases_js
+          js_version = Helper::UpdateHybridsVersionsFileHelper.get_js_version_for_hybrid_common_version(hybrid_common_version, github_token)
+          UI.message("Obtained purchases-js version #{js_version} for PHC version #{hybrid_common_version}")
+        end
 
         File.open(versions_file_path, 'r+') do |file|
           lines = file.each_line.to_a
@@ -39,17 +48,53 @@ module Fastlane
             end
           end
 
-          new_line = [
+          # Insert the Web SDK column just before Play Billing when opting in,
+          # backfilling previous rows with a blank cell.
+          if include_purchases_js && !lines[0].include?(WEB_SDK_COLUMN_HEADER)
+            lines[0] = insert_cell_before_last_cell(lines[0], " #{WEB_SDK_COLUMN_HEADER} ")
+            lines[1] = insert_cell_before_last_cell(lines[1], '-----------------')
+            lines.each_with_index do |line, index|
+              next if index < 2
+
+              lines[index] = insert_cell_before_last_cell(line, ' ')
+            end
+          end
+
+          cells = [
             new_sdk_version,
             "[#{ios_version}](https://github.com/RevenueCat/purchases-ios/releases/tag/#{ios_version})",
             "[#{android_version}](https://github.com/RevenueCat/purchases-android/releases/tag/#{android_version})",
-            "[#{hybrid_common_version}](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/#{hybrid_common_version})",
-            "[#{billing_client_version}](https://developer.android.com/google/play/billing/release-notes)"
-          ].join(' | ')
+            "[#{hybrid_common_version}](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/#{hybrid_common_version})"
+          ]
+          if lines[0].include?(WEB_SDK_COLUMN_HEADER)
+            cells << (include_purchases_js ? "[#{js_version}](https://github.com/RevenueCat/purchases-js/releases/tag/#{js_version})" : '')
+          end
+          cells << "[#{billing_client_version}](https://developer.android.com/google/play/billing/release-notes)"
+
+          new_line = cells.join(' | ')
           lines.insert(2, "| #{new_line} |\n")
           file.rewind
           file.write(lines.join)
         end
+      end
+      # rubocop:enable Metrics/PerceivedComplexity
+
+      # Inserts a new cell into a pipe-delimited markdown row right before the
+      # last data cell. Leaves any trailing newline intact. Passes the line
+      # through unchanged if it isn't a proper pipe-delimited row (e.g. a
+      # markdown separator without leading/trailing pipes).
+      private_class_method def self.insert_cell_before_last_cell(line, cell_content)
+        had_newline = line.end_with?("\n")
+        # Limit -1 preserves the trailing empty string from a closing `|`, so
+        # a proper row "| a | b | c |" splits into ["", " a ", " b ", " c ", ""].
+        parts = line.chomp.split('|', -1)
+        # Need at least [leading_empty, last_data_cell, trailing_empty] to have a
+        # cell to insert before.
+        return line if parts.length < 3
+
+        parts.insert(parts.length - 2, cell_content)
+        result = parts.join('|')
+        had_newline ? "#{result}\n" : result
       end
 
       def self.description
@@ -79,7 +124,13 @@ module Fastlane
                                        description: "GitHub token for API authentication",
                                        optional: true,
                                        type: String,
-                                       sensitive: true)
+                                       sensitive: true),
+          FastlaneCore::ConfigItem.new(key: :include_purchases_js,
+                                       description: "Whether to include a purchases-js (Web SDK) version column (for hybrids with web support, e.g. Flutter, React Native); " \
+                                                    "adds a 'Web SDK version' column if missing and backfills previous rows with a blank cell",
+                                       optional: true,
+                                       is_string: false,
+                                       default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/revenuecat_internal/constants.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/constants.rb
@@ -2,6 +2,7 @@
 
 REPO_NAME_IOS = 'purchases-ios'
 REPO_NAME_ANDROID = 'purchases-android'
+REPO_NAME_JS = 'purchases-js'
 # Taken from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 PATTERN_BUILD_METADATA = "[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*"
 PATTERN_BUILD_METADATA_ANCHORED = /^#{PATTERN_BUILD_METADATA}$/.freeze

--- a/lib/fastlane/plugin/revenuecat_internal/helper/update_hybrids_versions_file_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/update_hybrids_versions_file_helper.rb
@@ -1,4 +1,5 @@
 require 'base64'
+require 'json'
 require 'fastlane_core/ui/ui'
 require 'fastlane/action'
 require 'fastlane/actions/github_api'
@@ -24,6 +25,16 @@ module Fastlane
         matches = contents.match("s.dependency 'RevenueCat', '(.*)'").captures
         UI.user_error!("Could not find ios version in #{repo_name} in file '#{path}'") if matches.length != 1
         matches[0]
+      end
+
+      def self.get_js_version_for_hybrid_common_version(hybrid_common_version, github_token)
+        path = 'purchases-js-hybrid-mappings/package.json'
+        repo_name = 'purchases-hybrid-common'
+        contents = get_contents_file_github(path, repo_name, hybrid_common_version, github_token)
+        package_json = JSON.parse(contents)
+        version = package_json.dig('dependencies', '@revenuecat/purchases-js')
+        UI.user_error!("Could not find purchases-js version in #{repo_name} in file '#{path}'") if version.nil? || version.empty?
+        version
       end
 
       def self.get_android_billing_client_version(android_version, github_token)

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -487,26 +487,26 @@ module Fastlane
         native_dependency_changelogs += platform_changelogs(ios_releases, 'iOS')
         if include_purchases_js
           previous_phc_version = extract_semver_from_versions_file(versions_latest_release[PHC_VERSION_COLUMN])
-          native_dependency_changelogs += js_releases_links(github_token, phc_version, previous_phc_version)
+          native_dependency_changelogs += js_releases_links(github_token, previous_phc_version, phc_version)
         end
         native_dependency_changelogs.join("\n")
       end
 
-      private_class_method def self.js_releases_links(github_token, phc_version, previous_phc_version)
+      private_class_method def self.js_releases_links(github_token, previous_phc_version, new_phc_version)
         unless Gem::Version.correct?(previous_phc_version)
-          UI.error("Malformed previous PHC version #{previous_phc_version} for version #{phc_version} of purchases-hybrid-common. Skipping purchases-js changelog.")
+          UI.error("Malformed previous PHC version #{previous_phc_version} for version #{new_phc_version} of purchases-hybrid-common. Skipping purchases-js changelog.")
           return []
         end
 
         previous_js_version = Helper::UpdateHybridsVersionsFileHelper.get_js_version_for_hybrid_common_version(previous_phc_version, github_token)
         UI.message("Obtained purchases-js version #{previous_js_version} for previous PHC version #{previous_phc_version}")
-        new_js_version = Helper::UpdateHybridsVersionsFileHelper.get_js_version_for_hybrid_common_version(phc_version, github_token)
-        UI.message("Obtained purchases-js version #{new_js_version} for PHC version #{phc_version}")
+        new_js_version = Helper::UpdateHybridsVersionsFileHelper.get_js_version_for_hybrid_common_version(new_phc_version, github_token)
+        UI.message("Obtained purchases-js version #{new_js_version} for PHC version #{new_phc_version}")
 
         js_releases = Helper::GitHubHelper.get_releases_between_tags(github_token, previous_js_version, new_js_version, REPO_NAME_JS)
         platform_changelogs(js_releases, 'Web')
       rescue StandardError => e
-        UI.error("Could not resolve purchases-js versions for PHC #{previous_phc_version} -> #{phc_version}: #{e.message}. Skipping purchases-js changelog.")
+        UI.error("Could not resolve purchases-js versions for PHC #{previous_phc_version} -> #{new_phc_version}: #{e.message}. Skipping purchases-js changelog.")
         []
       end
 

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -53,7 +53,7 @@ module Fastlane
       end
 
       # rubocop:disable Metrics/PerceivedComplexity
-      def self.auto_generate_changelog(repo_name, github_token, rate_limit_sleep, include_prereleases, hybrid_common_version, versions_file_path, target_tag = nil, filter_labels: nil, exclude_labels: nil, cross_repo_pr_reference: '')
+      def self.auto_generate_changelog(repo_name, github_token, rate_limit_sleep, include_prereleases, hybrid_common_version, versions_file_path, target_tag = nil, filter_labels: nil, exclude_labels: nil, cross_repo_pr_reference: '', include_purchases_js: false)
         filter_labels = nil if filter_labels&.empty?
         exclude_labels = nil if exclude_labels&.empty?
         cross_repo_pr_reference = cross_repo_pr_reference.to_s.strip
@@ -136,7 +136,7 @@ module Fastlane
         end
 
         if last_phc_dep_line && hybrid_common_version && versions_file_path
-          last_phc_dep_line << native_releases_links(github_token, hybrid_common_version, versions_file_path)
+          last_phc_dep_line << native_releases_links(github_token, hybrid_common_version, versions_file_path, include_purchases_js: include_purchases_js)
         end
 
         build_changelog_sections(changelog_sections)
@@ -449,7 +449,7 @@ module Fastlane
         end
       end
 
-      private_class_method def self.native_releases_links(github_token, phc_version, versions_file_path)
+      private_class_method def self.native_releases_links(github_token, phc_version, versions_file_path, include_purchases_js: false)
         latest_release_row = File.readlines(versions_file_path)[2]
         if latest_release_row.nil?
           UI.error("Can't detect iOS and Android version for version #{phc_version} of purchases-hybrid-common. Empty VERSIONS.md")
@@ -485,7 +485,29 @@ module Fastlane
         native_dependency_changelogs = [""]
         native_dependency_changelogs += platform_changelogs(android_releases, 'Android')
         native_dependency_changelogs += platform_changelogs(ios_releases, 'iOS')
+        if include_purchases_js
+          previous_phc_version = extract_semver_from_versions_file(versions_latest_release[PHC_VERSION_COLUMN])
+          native_dependency_changelogs += js_releases_links(github_token, phc_version, previous_phc_version)
+        end
         native_dependency_changelogs.join("\n")
+      end
+
+      private_class_method def self.js_releases_links(github_token, phc_version, previous_phc_version)
+        unless Gem::Version.correct?(previous_phc_version)
+          UI.error("Malformed previous PHC version #{previous_phc_version} for version #{phc_version} of purchases-hybrid-common. Skipping purchases-js changelog.")
+          return []
+        end
+
+        previous_js_version = Helper::UpdateHybridsVersionsFileHelper.get_js_version_for_hybrid_common_version(previous_phc_version, github_token)
+        UI.message("Obtained purchases-js version #{previous_js_version} for previous PHC version #{previous_phc_version}")
+        new_js_version = Helper::UpdateHybridsVersionsFileHelper.get_js_version_for_hybrid_common_version(phc_version, github_token)
+        UI.message("Obtained purchases-js version #{new_js_version} for PHC version #{phc_version}")
+
+        js_releases = Helper::GitHubHelper.get_releases_between_tags(github_token, previous_js_version, new_js_version, REPO_NAME_JS)
+        platform_changelogs(js_releases, 'Web')
+      rescue StandardError => e
+        UI.error("Could not resolve purchases-js versions for PHC #{previous_phc_version} -> #{phc_version}: #{e.message}. Skipping purchases-js changelog.")
+        []
       end
 
       private_class_method def self.extract_semver_from_versions_file(version_string)

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -494,8 +494,7 @@ module Fastlane
 
       private_class_method def self.js_releases_links(github_token, previous_phc_version, new_phc_version)
         unless Gem::Version.correct?(previous_phc_version)
-          UI.error("Malformed previous PHC version #{previous_phc_version} for version #{new_phc_version} of purchases-hybrid-common. Skipping purchases-js changelog.")
-          return []
+          UI.user_error!("Malformed previous PHC version #{previous_phc_version} for version #{new_phc_version} of purchases-hybrid-common.")
         end
 
         previous_js_version = Helper::UpdateHybridsVersionsFileHelper.get_js_version_for_hybrid_common_version(previous_phc_version, github_token)
@@ -505,9 +504,6 @@ module Fastlane
 
         js_releases = Helper::GitHubHelper.get_releases_between_tags(github_token, previous_js_version, new_js_version, REPO_NAME_JS)
         platform_changelogs(js_releases, 'Web')
-      rescue StandardError => e
-        UI.error("Could not resolve purchases-js versions for PHC #{previous_phc_version} -> #{new_phc_version}: #{e.message}. Skipping purchases-js changelog.")
-        []
       end
 
       private_class_method def self.extract_semver_from_versions_file(version_string)

--- a/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
+++ b/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
@@ -52,7 +52,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         .with(mock_github_token)
         .and_return({ authenticated: true, rate_limit_remaining: 5000 })
       expect(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
-        .with(mock_repo_name, mock_github_token, 3, false, nil, nil, new_version, filter_labels: nil, exclude_labels: nil)
+        .with(mock_repo_name, mock_github_token, 3, false, nil, nil, new_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil)
         .and_return(auto_generated_changelog)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:edit_changelog)
@@ -107,7 +107,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         .with('release/1.13.0', mock_github_pr_token)
         .once
       expect(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
-        .with(mock_repo_name, mock_github_token, 3, false, nil, nil, new_version, filter_labels: nil, exclude_labels: nil)
+        .with(mock_repo_name, mock_github_token, 3, false, nil, nil, new_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil)
         .and_return(auto_generated_changelog)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:edit_changelog)
@@ -147,7 +147,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
     it 'generates changelog with appropriate parameters when bumping a hybrid SDK' do
       setup_stubs
       expect(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
-        .with(mock_repo_name, mock_github_token, 3, false, hybrid_common_version, versions_file_path, new_version, filter_labels: nil, exclude_labels: nil)
+        .with(mock_repo_name, mock_github_token, 3, false, hybrid_common_version, versions_file_path, new_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil)
         .and_return(auto_generated_changelog)
         .once
 
@@ -616,7 +616,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
       allow(FastlaneCore::UI).to receive(:confirm).with(anything).and_return(true)
       allow(File).to receive(:read).with(mock_changelog_latest_path).and_return(edited_changelog)
       allow(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
-        .with(mock_repo_name, mock_github_token, 3, false, hybrid_common_version, nil, new_version, filter_labels: nil, exclude_labels: nil)
+        .with(mock_repo_name, mock_github_token, 3, false, hybrid_common_version, nil, new_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil)
         .and_return(auto_generated_changelog)
         .once
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:edit_changelog)
@@ -672,7 +672,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
       allow(FastlaneCore::UI).to receive(:important).with(anything)
       allow(File).to receive(:read).with(mock_changelog_latest_path).and_return(edited_changelog)
       allow(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
-        .with(mock_repo_name, mock_github_token, 3, is_prerelease, hybrid_common_version, nil, expected_version, filter_labels: nil, exclude_labels: nil)
+        .with(mock_repo_name, mock_github_token, 3, is_prerelease, hybrid_common_version, nil, expected_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil)
         .and_return(auto_generated_changelog)
         .once
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:write_changelog)
@@ -766,7 +766,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         .with(mock_github_token)
         .and_return({ authenticated: true, rate_limit_remaining: 5000 })
       allow(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
-        .with(mock_repo_name, mock_github_token, 3, false, nil, nil, new_version, filter_labels: nil, exclude_labels: nil)
+        .with(mock_repo_name, mock_github_token, 3, false, nil, nil, new_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil)
         .and_return(auto_generated_changelog)
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:write_changelog)
         .with(auto_generated_changelog, mock_changelog_latest_path)
@@ -788,7 +788,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
 
   describe '#available_options' do
     it 'has correct number of options' do
-      expect(Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction.available_options.size).to eq(22)
+      expect(Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction.available_options.size).to eq(23)
     end
   end
 end

--- a/spec/actions/update_hybrids_versions_file_action_spec.rb
+++ b/spec/actions/update_hybrids_versions_file_action_spec.rb
@@ -99,11 +99,128 @@ describe Fastlane::Actions::UpdateHybridsVersionsFileAction do
                          "| 1.5.1 | [1.4.1](https://github.com/RevenueCat/purchases-ios/releases/tag/1.4.1) | [2.1.2](https://github.com/RevenueCat/purchases-android/releases/tag/2.1.2) | [1.1.0](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/1.1.0) | [6.2.1](https://developer.android.com/google/play/billing/release-notes) |\n"
       expect(updated_versions_content).to eq(expected_content)
     end
+
+    context 'when include_purchases_js is true' do
+      it 'inserts the Web SDK column before Play Billing when missing, backfills previous rows and preserves existing Play Billing values' do
+        initial_value = "| Version | iOS version | Android version | common version | Play Billing Library version |\n" \
+                        "|---------|-------------|-----------------|----------------|------------------------------|\n" \
+                        "| 1.5.0 | 1.3.5 | 2.1.1 | 1.0.8 | 6.2.0 |\n" \
+                        "| 1.0.0 | 1.3.4 | 2.0.1 | 1.0.5 | 6.1.0 |\n"
+        File.write(versions_path, initial_value)
+        expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
+          .with(hybrid_common_version, 'mock-github-token').and_return('2.1.2').once
+        expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
+          .with(hybrid_common_version, 'mock-github-token').and_return('1.4.1').once
+        expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_billing_client_version)
+          .with('2.1.2', 'mock-github-token').and_return('6.2.1').once
+        expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_js_version_for_hybrid_common_version)
+          .with(hybrid_common_version, 'mock-github-token').and_return('1.34.0').once
+        Fastlane::Actions::UpdateHybridsVersionsFileAction.run(
+          versions_file_path: versions_path,
+          new_sdk_version: '1.5.1',
+          hybrid_common_version: hybrid_common_version,
+          github_token: 'mock-github-token',
+          include_purchases_js: true
+        )
+        updated_versions_content = File.read(versions_path)
+        expected_content = "| Version | iOS version | Android version | common version | Web SDK version | Play Billing Library version |\n" \
+                           "|---------|-------------|-----------------|----------------|-----------------|------------------------------|\n" \
+                           "| 1.5.1 | [1.4.1](https://github.com/RevenueCat/purchases-ios/releases/tag/1.4.1) | [2.1.2](https://github.com/RevenueCat/purchases-android/releases/tag/2.1.2) | [1.1.0](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/1.1.0) " \
+                           "| [1.34.0](https://github.com/RevenueCat/purchases-js/releases/tag/1.34.0) | [6.2.1](https://developer.android.com/google/play/billing/release-notes) |\n" \
+                           "| 1.5.0 | 1.3.5 | 2.1.1 | 1.0.8 | | 6.2.0 |\n" \
+                           "| 1.0.0 | 1.3.4 | 2.0.1 | 1.0.5 | | 6.1.0 |\n"
+        expect(updated_versions_content).to eq(expected_content)
+      end
+
+      it 'reuses the existing Web SDK column when already present' do
+        initial_value = "| Version | iOS version | Android version | common version | Web SDK version | Play Billing Library version |\n" \
+                        "|---------|-------------|-----------------|----------------|-----------------|------------------------------|\n" \
+                        "| 1.5.0 | 1.3.5 | 2.1.1 | 1.0.8 | 1.33.0 | 6.2.0 |\n"
+        File.write(versions_path, initial_value)
+        expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
+          .with(hybrid_common_version, 'mock-github-token').and_return('2.1.2').once
+        expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
+          .with(hybrid_common_version, 'mock-github-token').and_return('1.4.1').once
+        expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_billing_client_version)
+          .with('2.1.2', 'mock-github-token').and_return('6.2.1').once
+        expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_js_version_for_hybrid_common_version)
+          .with(hybrid_common_version, 'mock-github-token').and_return('1.34.0').once
+        Fastlane::Actions::UpdateHybridsVersionsFileAction.run(
+          versions_file_path: versions_path,
+          new_sdk_version: '1.5.1',
+          hybrid_common_version: hybrid_common_version,
+          github_token: 'mock-github-token',
+          include_purchases_js: true
+        )
+        updated_versions_content = File.read(versions_path)
+        expected_content = "| Version | iOS version | Android version | common version | Web SDK version | Play Billing Library version |\n" \
+                           "|---------|-------------|-----------------|----------------|-----------------|------------------------------|\n" \
+                           "| 1.5.1 | [1.4.1](https://github.com/RevenueCat/purchases-ios/releases/tag/1.4.1) | [2.1.2](https://github.com/RevenueCat/purchases-android/releases/tag/2.1.2) | [1.1.0](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/1.1.0) " \
+                           "| [1.34.0](https://github.com/RevenueCat/purchases-js/releases/tag/1.34.0) | [6.2.1](https://developer.android.com/google/play/billing/release-notes) |\n" \
+                           "| 1.5.0 | 1.3.5 | 2.1.1 | 1.0.8 | 1.33.0 | 6.2.0 |\n"
+        expect(updated_versions_content).to eq(expected_content)
+      end
+
+      it 'also extends missing Play Billing column and adds Web SDK column in one pass' do
+        initial_value = "| Version | iOS version | Android version | common version |\n" \
+                        "|---------|-------------|-----------------|----------------|\n" \
+                        "| 1.5.0 | 1.3.5 | 2.1.1 | 1.0.8 |\n"
+        File.write(versions_path, initial_value)
+        expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
+          .with(hybrid_common_version, 'mock-github-token').and_return('2.1.2').once
+        expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
+          .with(hybrid_common_version, 'mock-github-token').and_return('1.4.1').once
+        expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_billing_client_version)
+          .with('2.1.2', 'mock-github-token').and_return('6.2.1').once
+        expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_js_version_for_hybrid_common_version)
+          .with(hybrid_common_version, 'mock-github-token').and_return('1.34.0').once
+        Fastlane::Actions::UpdateHybridsVersionsFileAction.run(
+          versions_file_path: versions_path,
+          new_sdk_version: '1.5.1',
+          hybrid_common_version: hybrid_common_version,
+          github_token: 'mock-github-token',
+          include_purchases_js: true
+        )
+        updated_versions_content = File.read(versions_path)
+        expected_content = "| Version | iOS version | Android version | common version | Web SDK version | Play Billing Library version |\n" \
+                           "|---------|-------------|-----------------|----------------|-----------------|------------------------------|\n" \
+                           "| 1.5.1 | [1.4.1](https://github.com/RevenueCat/purchases-ios/releases/tag/1.4.1) | [2.1.2](https://github.com/RevenueCat/purchases-android/releases/tag/2.1.2) | [1.1.0](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/1.1.0) " \
+                           "| [1.34.0](https://github.com/RevenueCat/purchases-js/releases/tag/1.34.0) | [6.2.1](https://developer.android.com/google/play/billing/release-notes) |\n" \
+                           "| 1.5.0 | 1.3.5 | 2.1.1 | 1.0.8 | | |\n"
+        expect(updated_versions_content).to eq(expected_content)
+      end
+
+      it 'does not touch the file when include_purchases_js is false (default)' do
+        initial_value = "| Version | iOS version | Android version | common version | Play Billing Library version |\n" \
+                        "|---------|-------------|-----------------|----------------|------------------------------|\n" \
+                        "| 1.5.0 | 1.3.5 | 2.1.1 | 1.0.8 | 6.2.0 |\n"
+        File.write(versions_path, initial_value)
+        expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
+          .with(hybrid_common_version, 'mock-github-token').and_return('2.1.2').once
+        expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
+          .with(hybrid_common_version, 'mock-github-token').and_return('1.4.1').once
+        expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_billing_client_version)
+          .with('2.1.2', 'mock-github-token').and_return('6.2.1').once
+        expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).not_to receive(:get_js_version_for_hybrid_common_version)
+        Fastlane::Actions::UpdateHybridsVersionsFileAction.run(
+          versions_file_path: versions_path,
+          new_sdk_version: '1.5.1',
+          hybrid_common_version: hybrid_common_version,
+          github_token: 'mock-github-token'
+        )
+        updated_versions_content = File.read(versions_path)
+        expected_content = "| Version | iOS version | Android version | common version | Play Billing Library version |\n" \
+                           "|---------|-------------|-----------------|----------------|------------------------------|\n" \
+                           "| 1.5.1 | [1.4.1](https://github.com/RevenueCat/purchases-ios/releases/tag/1.4.1) | [2.1.2](https://github.com/RevenueCat/purchases-android/releases/tag/2.1.2) | [1.1.0](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/1.1.0) | [6.2.1](https://developer.android.com/google/play/billing/release-notes) |\n" \
+                           "| 1.5.0 | 1.3.5 | 2.1.1 | 1.0.8 | 6.2.0 |\n"
+        expect(updated_versions_content).to eq(expected_content)
+      end
+    end
   end
 
   describe '#available_options' do
     it 'has correct number of options' do
-      expect(Fastlane::Actions::UpdateHybridsVersionsFileAction.available_options.size).to eq(4)
+      expect(Fastlane::Actions::UpdateHybridsVersionsFileAction.available_options.size).to eq(5)
     end
   end
 end

--- a/spec/helper/update_hybrids_versions_file_helper_spec.rb
+++ b/spec/helper/update_hybrids_versions_file_helper_spec.rb
@@ -34,4 +34,50 @@ describe Fastlane::Helper::UpdateHybridsVersionsFileHelper do
       expect(version).to eq('4.9.0')
     end
   end
+
+  describe '.get_js_version_for_hybrid_common_version' do
+    let(:get_contents_js_hybrid_mappings_response) do
+      { json: JSON.parse(File.read("#{File.dirname(__FILE__)}/../test_files/get_contents_phc_js_hybrid_mappings.json")) }
+    end
+
+    def build_contents_response(body_hash)
+      { json: { 'content' => Base64.encode64(body_hash.to_json) } }
+    end
+
+    it 'obtains correct purchases-js version from github' do
+      expect(Fastlane::Actions::GithubApiAction).to receive(:run).with(
+        server_url: "https://api.github.com",
+        http_method: 'GET',
+        path: "/repos/revenuecat/purchases-hybrid-common/contents/purchases-js-hybrid-mappings/package.json?ref=18.0.0",
+        body: {},
+        api_token: 'mock-github-token'
+      ).and_return(get_contents_js_hybrid_mappings_response).once
+      version = Fastlane::Helper::UpdateHybridsVersionsFileHelper.get_js_version_for_hybrid_common_version('18.0.0', 'mock-github-token')
+      expect(version).to eq('1.34.0')
+    end
+
+    it 'raises a user error when the purchases-js dependency is missing' do
+      allow(Fastlane::Actions::GithubApiAction).to receive(:run)
+        .and_return(build_contents_response({ 'name' => '@revenuecat/purchases-js-hybrid-mappings', 'dependencies' => {} }))
+      expect do
+        Fastlane::Helper::UpdateHybridsVersionsFileHelper.get_js_version_for_hybrid_common_version('18.0.0', 'mock-github-token')
+      end.to raise_exception(FastlaneCore::Interface::FastlaneError, /Could not find purchases-js version/)
+    end
+
+    it 'raises a user error when the purchases-js dependency version is empty' do
+      allow(Fastlane::Actions::GithubApiAction).to receive(:run)
+        .and_return(build_contents_response({ 'dependencies' => { '@revenuecat/purchases-js' => '' } }))
+      expect do
+        Fastlane::Helper::UpdateHybridsVersionsFileHelper.get_js_version_for_hybrid_common_version('18.0.0', 'mock-github-token')
+      end.to raise_exception(FastlaneCore::Interface::FastlaneError, /Could not find purchases-js version/)
+    end
+
+    it 'raises when the package.json has no dependencies key at all' do
+      allow(Fastlane::Actions::GithubApiAction).to receive(:run)
+        .and_return(build_contents_response({ 'name' => '@revenuecat/purchases-js-hybrid-mappings' }))
+      expect do
+        Fastlane::Helper::UpdateHybridsVersionsFileHelper.get_js_version_for_hybrid_common_version('18.0.0', 'mock-github-token')
+      end.to raise_exception(FastlaneCore::Interface::FastlaneError, /Could not find purchases-js version/)
+    end
+  end
 end

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -381,6 +381,103 @@ describe Fastlane::Helper::VersioningHelper do
                               "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.2 (#550) via RevenueCat Git Bot (@RCGitBot)")
     end
 
+    it 'includes purchases-js release links when include_purchases_js is true' do
+      stub_native_and_js_releases(
+        js_releases: [
+          { 'name' => '1.34.0', 'html_url' => 'https://github.com/RevenueCat/purchases-js/releases/tag/1.34.0' }
+        ]
+      )
+      setup_commit_search_stubs(hashes_to_responses_hybrid, get_commits_response_hybrid, "9237147947bcbce00f36ae3ab51acccc54690782")
+      expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_js_version_for_hybrid_common_version)
+        .with('4.5.2', 'mock-github-token').and_return('1.33.0').once
+      expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_js_version_for_hybrid_common_version)
+        .with(hybrid_common_version, 'mock-github-token').and_return('1.34.0').once
+      expect_any_instance_of(Object).not_to receive(:sleep)
+      changelog = Fastlane::Helper::VersioningHelper.auto_generate_changelog(
+        'mock-repo-name',
+        'mock-github-token',
+        0,
+        false,
+        hybrid_common_version,
+        versions_path,
+        nil,
+        include_purchases_js: true
+      )
+      expect(changelog).to eq("## RevenueCat SDK\n" \
+                              "### 📦 Dependency Updates\n" \
+                              "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.3 (#553) via RevenueCat Git Bot (@RCGitBot)\n" \
+                              "\s\s* [Android 5.6.6](https://github.com/RevenueCat/purchases-android/releases/tag/5.6.6)\n" \
+                              "\s\s* [iOS 4.15.4](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.4)\n" \
+                              "\s\s* [iOS 4.15.3](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.3)\n" \
+                              "\s\s* [Web 1.34.0](https://github.com/RevenueCat/purchases-js/releases/tag/1.34.0)")
+    end
+
+    it 'does not fetch purchases-js data when include_purchases_js is false (default)' do
+      mock_native_releases
+      setup_commit_search_stubs(hashes_to_responses_hybrid, get_commits_response_hybrid, "9237147947bcbce00f36ae3ab51acccc54690782")
+      expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
+        .with(hybrid_common_version, 'mock-github-token').and_return('5.6.6').once
+      expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
+        .with(hybrid_common_version, 'mock-github-token').and_return('4.15.4').once
+      expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).not_to receive(:get_js_version_for_hybrid_common_version)
+      changelog = Fastlane::Helper::VersioningHelper.auto_generate_changelog(
+        'mock-repo-name',
+        'mock-github-token',
+        0,
+        false,
+        hybrid_common_version,
+        versions_path
+      )
+      expect(changelog).not_to include('Web ')
+    end
+
+    it 'skips purchases-js section gracefully when the previous PHC lacks the hybrid mappings file' do
+      stub_native_and_js_releases(js_releases: [])
+      setup_commit_search_stubs(hashes_to_responses_hybrid, get_commits_response_hybrid, "9237147947bcbce00f36ae3ab51acccc54690782")
+      expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_js_version_for_hybrid_common_version)
+        .with('4.5.2', 'mock-github-token').and_raise(StandardError.new('404 Not Found'))
+      expect(FastlaneCore::UI).to receive(:error)
+        .with(/Could not resolve purchases-js versions for PHC 4.5.2 -> 4.5.3.*404 Not Found.*Skipping purchases-js changelog\./).once
+      changelog = Fastlane::Helper::VersioningHelper.auto_generate_changelog(
+        'mock-repo-name',
+        'mock-github-token',
+        0,
+        false,
+        hybrid_common_version,
+        versions_path,
+        nil,
+        include_purchases_js: true
+      )
+      expect(changelog).to eq("## RevenueCat SDK\n" \
+                              "### 📦 Dependency Updates\n" \
+                              "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.3 (#553) via RevenueCat Git Bot (@RCGitBot)\n" \
+                              "\s\s* [Android 5.6.6](https://github.com/RevenueCat/purchases-android/releases/tag/5.6.6)\n" \
+                              "\s\s* [iOS 4.15.4](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.4)\n" \
+                              "\s\s* [iOS 4.15.3](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.3)")
+    end
+
+    it 'does not append purchases-js links when the JS version did not change' do
+      stub_native_and_js_releases(js_releases: [])
+      setup_commit_search_stubs(hashes_to_responses_hybrid, get_commits_response_hybrid, "9237147947bcbce00f36ae3ab51acccc54690782")
+      expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_js_version_for_hybrid_common_version)
+        .with('4.5.2', 'mock-github-token').and_return('1.34.0').once
+      expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_js_version_for_hybrid_common_version)
+        .with(hybrid_common_version, 'mock-github-token').and_return('1.34.0').once
+      changelog = Fastlane::Helper::VersioningHelper.auto_generate_changelog(
+        'mock-repo-name',
+        'mock-github-token',
+        0,
+        false,
+        hybrid_common_version,
+        versions_path,
+        nil,
+        include_purchases_js: true
+      )
+      expect(changelog).not_to include('Web ')
+      expect(changelog).to include('[Android 5.6.6]')
+      expect(changelog).to include('[iOS 4.15.4]')
+    end
+
     it 'sleeps between getting commits info if passing rate limit sleep' do
       setup_commit_search_stubs(hashes_to_responses)
       expect_any_instance_of(Object).to receive(:sleep).with(3).exactly(5).times
@@ -738,6 +835,30 @@ describe Fastlane::Helper::VersioningHelper do
               error_handlers: anything,
               api_token: 'mock-github-token')
         .and_return(purchases_ios_releases)
+    end
+
+    # Stubs everything `native_releases_links` needs by directly mocking the
+    # release-fetch layer and the native/JS PHC version lookups. Lets tests
+    # control each platform's releases independently of the big JSON fixtures.
+    def stub_native_and_js_releases(js_releases:)
+      allow(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_android_version_for_hybrid_common_version)
+        .with(hybrid_common_version, 'mock-github-token').and_return('5.6.6')
+      allow(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_ios_version_for_hybrid_common_version)
+        .with(hybrid_common_version, 'mock-github-token').and_return('4.15.4')
+      allow(Fastlane::Helper::GitHubHelper).to receive(:get_releases_between_tags)
+        .with('mock-github-token', '5.6.5', '5.6.6', 'purchases-android')
+        .and_return([
+                      { 'name' => '5.6.6', 'html_url' => 'https://github.com/RevenueCat/purchases-android/releases/tag/5.6.6' }
+                    ])
+      allow(Fastlane::Helper::GitHubHelper).to receive(:get_releases_between_tags)
+        .with('mock-github-token', '4.15.2', '4.15.4', 'purchases-ios')
+        .and_return([
+                      { 'name' => '4.15.4', 'html_url' => 'https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.4' },
+                      { 'name' => '4.15.3', 'html_url' => 'https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.3' }
+                    ])
+      allow(Fastlane::Helper::GitHubHelper).to receive(:get_releases_between_tags)
+        .with('mock-github-token', anything, anything, 'purchases-js')
+        .and_return(js_releases)
     end
   end
 

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -431,29 +431,44 @@ describe Fastlane::Helper::VersioningHelper do
       expect(changelog).not_to include('Web ')
     end
 
-    it 'skips purchases-js section gracefully when the previous PHC lacks the hybrid mappings file' do
+    it 'propagates the error when the purchases-js version lookup fails (e.g. old PHC without the hybrid mappings file)' do
       stub_native_and_js_releases(js_releases: [])
       setup_commit_search_stubs(hashes_to_responses_hybrid, get_commits_response_hybrid, "9237147947bcbce00f36ae3ab51acccc54690782")
       expect(Fastlane::Helper::UpdateHybridsVersionsFileHelper).to receive(:get_js_version_for_hybrid_common_version)
         .with('4.5.2', 'mock-github-token').and_raise(StandardError.new('404 Not Found'))
-      expect(FastlaneCore::UI).to receive(:error)
-        .with(/Could not resolve purchases-js versions for PHC 4.5.2 -> 4.5.3.*404 Not Found.*Skipping purchases-js changelog\./).once
-      changelog = Fastlane::Helper::VersioningHelper.auto_generate_changelog(
-        'mock-repo-name',
-        'mock-github-token',
-        0,
-        false,
-        hybrid_common_version,
-        versions_path,
-        nil,
-        include_purchases_js: true
-      )
-      expect(changelog).to eq("## RevenueCat SDK\n" \
-                              "### 📦 Dependency Updates\n" \
-                              "* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 4.5.3 (#553) via RevenueCat Git Bot (@RCGitBot)\n" \
-                              "\s\s* [Android 5.6.6](https://github.com/RevenueCat/purchases-android/releases/tag/5.6.6)\n" \
-                              "\s\s* [iOS 4.15.4](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.4)\n" \
-                              "\s\s* [iOS 4.15.3](https://github.com/RevenueCat/purchases-ios/releases/tag/4.15.3)")
+      expect do
+        Fastlane::Helper::VersioningHelper.auto_generate_changelog(
+          'mock-repo-name',
+          'mock-github-token',
+          0,
+          false,
+          hybrid_common_version,
+          versions_path,
+          nil,
+          include_purchases_js: true
+        )
+      end.to raise_exception(StandardError, '404 Not Found')
+    end
+
+    it 'raises a user error when the previous PHC version in VERSIONS.md is malformed and include_purchases_js is on' do
+      stub_native_and_js_releases(js_releases: [])
+      setup_commit_search_stubs(hashes_to_responses_hybrid, get_commits_response_hybrid, "9237147947bcbce00f36ae3ab51acccc54690782")
+      expect(File).to receive(:readlines).with(versions_path)
+                                         .and_return(["| Version | iOS version | Android version | Common files version |\n",
+                                                      "|---------|-------------|-----------------|----------------------|\n",
+                                                      "| 4.5.3   | 4.15.2      | 5.6.5           | not-a-version        |"])
+      expect do
+        Fastlane::Helper::VersioningHelper.auto_generate_changelog(
+          'mock-repo-name',
+          'mock-github-token',
+          0,
+          false,
+          hybrid_common_version,
+          versions_path,
+          nil,
+          include_purchases_js: true
+        )
+      end.to raise_exception(FastlaneCore::Interface::FastlaneError, /Malformed previous PHC version not-a-version/)
     end
 
     it 'does not append purchases-js links when the JS version did not change' do

--- a/spec/test_files/get_contents_phc_js_hybrid_mappings.json
+++ b/spec/test_files/get_contents_phc_js_hybrid_mappings.json
@@ -1,0 +1,16 @@
+{
+    "name": "package.json",
+    "path": "purchases-js-hybrid-mappings/package.json",
+    "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "size": 512,
+    "url": "https://api.github.com/repos/RevenueCat/purchases-hybrid-common/contents/purchases-js-hybrid-mappings/package.json?ref=18.0.0",
+    "html_url": "https://github.com/RevenueCat/purchases-hybrid-common/blob/18.0.0/purchases-js-hybrid-mappings/package.json",
+    "git_url": "https://api.github.com/repos/RevenueCat/purchases-hybrid-common/git/blobs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "download_url": "https://raw.githubusercontent.com/RevenueCat/purchases-hybrid-common/18.0.0/purchases-js-hybrid-mappings/package.json",
+    "type": "file",
+    "content": "ewogICJuYW1lIjogIkByZXZlbnVlY2F0L3B1cmNoYXNlcy1qcy1oeWJyaWQtbWFwcGluZ3MiLAogICJ2ZXJzaW9uIjogIjE4LjAuMCIsCiAgImRlc2NyaXB0aW9uIjogIlJldmVudWVDYXQncyBKYXZhU2NyaXB0IGh5YnJpZCBtYXBwaW5ncyBmb3IgcHVyY2hhc2VzLWpzIiwKICAiZGVwZW5kZW5jaWVzIjogewogICAgIkByZXZlbnVlY2F0L3B1cmNoYXNlcy1qcyI6ICIxLjM0LjAiCiAgfQp9Cg==\n",
+    "encoding": "base64",
+    "_links": {
+        "self": "https://api.github.com/repos/RevenueCat/purchases-hybrid-common/contents/purchases-js-hybrid-mappings/package.json?ref=18.0.0"
+    }
+}


### PR DESCRIPTION
This adds an option that will include the purchases-js version in the VERSIONS.md file in each hybrid. It will add the new column if it doesn't exist, and also process the existing file so it's correctly formatted with the addition of the new column