### PR TITLE
feat: Allow falling back to direct PR lookup when GitHub search index is degraded

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -248,7 +248,7 @@ module Fastlane
                                        is_string: false,
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :fallback_pr_lookup,
-                                       description: "When the GitHub search API can't find a PR for a commit SHA, fall back to extracting the PR number from the commit message and fetching it directly via the REST API",
+                                       description: "When the GitHub search API can't find a PR for a commit SHA, fall back to extracting the PR number from the commit subject '(#N)' pattern and fetching it directly via the REST API. Assumes squash-merge workflows — a no-op on rebase-and-merge or true-merge workflows whose commit subjects don't include '(#N)'",
                                        optional: true,
                                        is_string: false,
                                        default_value: false),

--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_version_update_changelog_create_pr_action.rb
@@ -31,6 +31,7 @@ module Fastlane
         filter_labels = params[:filter_labels]
         exclude_labels = params[:exclude_labels]
         include_purchases_js = params[:include_purchases_js]
+        fallback_pr_lookup = params[:fallback_pr_lookup]
 
         # See if we got any conflicting arguments.
         Helper::VersioningHelper.validate_input_if_appending_phc_version?(
@@ -80,7 +81,7 @@ module Fastlane
           UI.important("No github_token provided.")
         end
 
-        generated_contents = Helper::VersioningHelper.auto_generate_changelog(repo_name, github_token, rate_limit_sleep, include_prereleases, hybrid_common_version, versions_file_path, new_version_number, filter_labels: filter_labels, exclude_labels: exclude_labels, include_purchases_js: include_purchases_js)
+        generated_contents = Helper::VersioningHelper.auto_generate_changelog(repo_name, github_token, rate_limit_sleep, include_prereleases, hybrid_common_version, versions_file_path, new_version_number, filter_labels: filter_labels, exclude_labels: exclude_labels, include_purchases_js: include_purchases_js, fallback_pr_lookup: fallback_pr_lookup)
 
         if UI.interactive?
           Helper::RevenuecatInternalHelper.edit_changelog(generated_contents, changelog_latest_path, editor)
@@ -243,6 +244,11 @@ module Fastlane
                                        type: Array),
           FastlaneCore::ConfigItem.new(key: :include_purchases_js,
                                        description: "Whether to include purchases-js version bumps in the changelog (for hybrids with web support, e.g. Flutter, React Native)",
+                                       optional: true,
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :fallback_pr_lookup,
+                                       description: "When the GitHub search API can't find a PR for a commit SHA, fall back to extracting the PR number from the commit message and fetching it directly via the REST API",
                                        optional: true,
                                        is_string: false,
                                        default_value: false),

--- a/lib/fastlane/plugin/revenuecat_internal/actions/determine_next_version_using_labels_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/determine_next_version_using_labels_action.rb
@@ -12,8 +12,9 @@ module Fastlane
         rate_limit_sleep = params[:github_rate_limit]
         include_prereleases = false
         current_version = params[:current_version]
+        fallback_pr_lookup = params[:fallback_pr_lookup]
 
-        Helper::VersioningHelper.determine_next_version_using_labels(repo_name, github_token, rate_limit_sleep, include_prereleases, current_version)
+        Helper::VersioningHelper.determine_next_version_using_labels(repo_name, github_token, rate_limit_sleep, include_prereleases, current_version, fallback_pr_lookup: fallback_pr_lookup)
       end
 
       def self.description
@@ -45,7 +46,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :current_version,
                                        description: "Current version of the SDK",
                                        optional: true,
-                                       type: String)
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :fallback_pr_lookup,
+                                       description: "When the GitHub search API can't find a PR for a commit SHA, fall back to extracting the PR number from the commit message and fetching it directly via the REST API",
+                                       optional: true,
+                                       is_string: false,
+                                       default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/revenuecat_internal/actions/determine_next_version_using_labels_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/determine_next_version_using_labels_action.rb
@@ -48,7 +48,7 @@ module Fastlane
                                        optional: true,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :fallback_pr_lookup,
-                                       description: "When the GitHub search API can't find a PR for a commit SHA, fall back to extracting the PR number from the commit message and fetching it directly via the REST API",
+                                       description: "When the GitHub search API can't find a PR for a commit SHA, fall back to extracting the PR number from the commit subject '(#N)' pattern and fetching it directly via the REST API. Assumes squash-merge workflows — a no-op on rebase-and-merge or true-merge workflows whose commit subjects don't include '(#N)'",
                                        optional: true,
                                        is_string: false,
                                        default_value: false)

--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -77,7 +77,7 @@ module Fastlane
         fetch_pr_by_number(pr_number, github_token, repo_name, expected_base: base_branch, expected_sha: sha)
       end
 
-      def self.extract_pr_number_from_commit_message(commit_message)
+      private_class_method def self.extract_pr_number_from_commit_message(commit_message)
         return nil if commit_message.nil?
 
         first_line = commit_message.split("\n").first
@@ -87,7 +87,7 @@ module Fastlane
         matches.last.first.to_i
       end
 
-      def self.fetch_pr_by_number(pr_number, github_token, repo_name, expected_base: nil, expected_sha: nil)
+      private_class_method def self.fetch_pr_by_number(pr_number, github_token, repo_name, expected_base: nil, expected_sha: nil)
         pr_resp = github_api_call_with_retry(server_url: 'https://api.github.com',
                                              path: "/repos/RevenueCat/#{repo_name}/pulls/#{pr_number}",
                                              http_method: 'GET',

--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -36,7 +36,11 @@ module Fastlane
         end
       end
 
-      def self.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch, commit_message: nil)
+      # When +fallback_commit_message+ is nil, the search API result is returned as-is.
+      # When it is a non-nil string, and the search API returns no items, the helper
+      # attempts a fallback lookup by extracting the PR number from the commit message
+      # and fetching the PR directly via the REST API. Pass nil to disable the fallback.
+      def self.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch, fallback_commit_message: nil)
         if github_token.nil? || github_token.empty?
           UI.important("No GitHub token provided, skipping PR lookup for SHA: #{sha}")
           return []
@@ -55,7 +59,7 @@ module Fastlane
                                              api_token: github_token)
         body = JSON.parse(pr_resp[:body])
         items = body["items"]
-        return items unless items.empty? && commit_message
+        return items unless items.empty? && fallback_commit_message
 
         # Fallback: extract PR number from commit message and fetch directly.
         # Squash-merge commits contain the PR number as "(#1234)" in the first line.
@@ -66,7 +70,7 @@ module Fastlane
         # commits don't get "(#N)" appended, so the regex no-ops before reaching the
         # REST call. For true merge commits, the merge commit does contain "(#N)" and
         # its SHA matches merge_commit_sha, so the fallback works there too.
-        pr_number = extract_pr_number_from_commit_message(commit_message)
+        pr_number = extract_pr_number_from_commit_message(fallback_commit_message)
         return [] unless pr_number
 
         if rate_limit_sleep > 0
@@ -87,7 +91,7 @@ module Fastlane
         matches.last.first.to_i
       end
 
-      private_class_method def self.fetch_pr_by_number(pr_number, github_token, repo_name, expected_base: nil, expected_sha: nil)
+      private_class_method def self.fetch_pr_by_number(pr_number, github_token, repo_name, expected_base:, expected_sha:)
         pr_resp = github_api_call_with_retry(server_url: 'https://api.github.com',
                                              path: "/repos/RevenueCat/#{repo_name}/pulls/#{pr_number}",
                                              http_method: 'GET',
@@ -100,7 +104,7 @@ module Fastlane
           return []
         end
 
-        if expected_base && pr.dig("base", "ref") != expected_base
+        if pr.dig("base", "ref") != expected_base
           UI.important("PR ##{pr_number} targets #{pr.dig('base', 'ref')}, not #{expected_base}. Skipping.")
           return []
         end
@@ -110,7 +114,7 @@ module Fastlane
         # the last one, but those commits won't have "(#N)" in their message so the
         # regex already returns nil above. If a future repo uses a non-squash workflow
         # and hits this path, this is the line to revisit.
-        if expected_sha && pr["merge_commit_sha"] != expected_sha
+        if pr["merge_commit_sha"] != expected_sha
           UI.important("PR ##{pr_number} merge SHA #{pr['merge_commit_sha']} does not match commit #{expected_sha}. Skipping.")
           return []
         end

--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -65,7 +65,7 @@ module Fastlane
         return [] unless pr_number
 
         UI.message("Search API returned no results for #{sha}. Falling back to direct PR ##{pr_number} lookup.")
-        fetch_pr_by_number(pr_number, github_token, repo_name)
+        fetch_pr_by_number(pr_number, github_token, repo_name, expected_base: base_branch, expected_sha: sha)
       end
 
       def self.extract_pr_number_from_commit_message(commit_message)
@@ -78,13 +78,29 @@ module Fastlane
         matches.last.first.to_i
       end
 
-      def self.fetch_pr_by_number(pr_number, github_token, repo_name)
+      def self.fetch_pr_by_number(pr_number, github_token, repo_name, expected_base: nil, expected_sha: nil)
         pr_resp = github_api_call_with_retry(server_url: 'https://api.github.com',
                                              path: "/repos/RevenueCat/#{repo_name}/pulls/#{pr_number}",
                                              http_method: 'GET',
                                              body: {},
                                              api_token: github_token)
         pr = JSON.parse(pr_resp[:body])
+
+        unless pr["merged_at"]
+          UI.important("PR ##{pr_number} was never merged, skipping.")
+          return []
+        end
+
+        if expected_base && pr.dig("base", "ref") != expected_base
+          UI.important("PR ##{pr_number} targets #{pr.dig('base', 'ref')}, not #{expected_base}. Skipping.")
+          return []
+        end
+
+        if expected_sha && pr["merge_commit_sha"] != expected_sha
+          UI.important("PR ##{pr_number} merge SHA #{pr['merge_commit_sha']} does not match commit #{expected_sha}. Skipping.")
+          return []
+        end
+
         [pr]
       rescue StandardError => e
         UI.important("Failed to fetch PR ##{pr_number} directly: #{e.message}")

--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -61,8 +61,17 @@ module Fastlane
         # Squash-merge commits contain the PR number as "(#1234)" in the first line.
         # External contributor PRs have two: "...original (#111) by @user (#222)" —
         # the last one is the merged PR.
+        #
+        # This fallback assumes squash-merge workflows. For rebase-and-merge, individual
+        # commits don't get "(#N)" appended, so the regex no-ops before reaching the
+        # REST call. For true merge commits, the merge commit does contain "(#N)" and
+        # its SHA matches merge_commit_sha, so the fallback works there too.
         pr_number = extract_pr_number_from_commit_message(commit_message)
         return [] unless pr_number
+
+        if rate_limit_sleep > 0
+          sleep(rate_limit_sleep)
+        end
 
         UI.message("Search API returned no results for #{sha}. Falling back to direct PR ##{pr_number} lookup.")
         fetch_pr_by_number(pr_number, github_token, repo_name, expected_base: base_branch, expected_sha: sha)
@@ -96,6 +105,11 @@ module Fastlane
           return []
         end
 
+        # This check assumes squash merges where the commit on the base branch IS the
+        # merge_commit_sha. For rebase-and-merge this would reject every commit except
+        # the last one, but those commits won't have "(#N)" in their message so the
+        # regex already returns nil above. If a future repo uses a non-squash workflow
+        # and hits this path, this is the line to revisit.
         if expected_sha && pr["merge_commit_sha"] != expected_sha
           UI.important("PR ##{pr_number} merge SHA #{pr['merge_commit_sha']} does not match commit #{expected_sha}. Skipping.")
           return []

--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -36,7 +36,7 @@ module Fastlane
         end
       end
 
-      def self.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch)
+      def self.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch, commit_message: nil)
         if github_token.nil? || github_token.empty?
           UI.important("No GitHub token provided, skipping PR lookup for SHA: #{sha}")
           return []
@@ -47,7 +47,7 @@ module Fastlane
           sleep(rate_limit_sleep)
         end
 
-        # Get pull request associate with commit message
+        # Get pull request associated with commit via search API
         pr_resp = github_api_call_with_retry(server_url: 'https://api.github.com',
                                              path: "/search/issues?q=repo:RevenueCat/#{repo_name}+is:pr+base:#{base_branch}+SHA:#{sha}",
                                              http_method: 'GET',
@@ -55,7 +55,40 @@ module Fastlane
                                              api_token: github_token)
         body = JSON.parse(pr_resp[:body])
         items = body["items"]
-        return items
+        return items unless items.empty? && commit_message
+
+        # Fallback: extract PR number from commit message and fetch directly.
+        # Squash-merge commits contain the PR number as "(#1234)" in the first line.
+        # External contributor PRs have two: "...original (#111) by @user (#222)" —
+        # the last one is the merged PR.
+        pr_number = extract_pr_number_from_commit_message(commit_message)
+        return [] unless pr_number
+
+        UI.message("Search API returned no results for #{sha}. Falling back to direct PR ##{pr_number} lookup.")
+        fetch_pr_by_number(pr_number, github_token, repo_name)
+      end
+
+      def self.extract_pr_number_from_commit_message(commit_message)
+        return nil if commit_message.nil?
+
+        first_line = commit_message.split("\n").first
+        matches = first_line&.scan(/\(#(\d+)\)/)
+        return nil if matches.nil? || matches.empty?
+
+        matches.last.first.to_i
+      end
+
+      def self.fetch_pr_by_number(pr_number, github_token, repo_name)
+        pr_resp = github_api_call_with_retry(server_url: 'https://api.github.com',
+                                             path: "/repos/RevenueCat/#{repo_name}/pulls/#{pr_number}",
+                                             http_method: 'GET',
+                                             body: {},
+                                             api_token: github_token)
+        pr = JSON.parse(pr_resp[:body])
+        [pr]
+      rescue StandardError => e
+        UI.important("Failed to fetch PR ##{pr_number} directly: #{e.message}")
+        []
       end
 
       def self.check_authentication_and_rate_limits(github_token)

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -88,8 +88,8 @@ module Fastlane
           name = commit["commit"]["author"]["name"]
 
           sha = commit["sha"]
-          commit_message = fallback_pr_lookup ? commit["commit"]["message"] : nil
-          items = Helper::GitHubHelper.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch, commit_message: commit_message)
+          fallback_commit_message = fallback_pr_lookup ? commit["commit"]["message"] : nil
+          items = Helper::GitHubHelper.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch, fallback_commit_message: fallback_commit_message)
 
           case items.size
           when 1
@@ -426,8 +426,8 @@ module Fastlane
 
       private_class_method def self.get_type_of_bump_for_commit(commit, github_token, rate_limit_sleep, repo_name, base_branch, fallback_pr_lookup)
         sha = commit["sha"]
-        commit_message = fallback_pr_lookup ? commit["commit"]["message"] : nil
-        items = Helper::GitHubHelper.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch, commit_message: commit_message)
+        fallback_commit_message = fallback_pr_lookup ? commit["commit"]["message"] : nil
+        items = Helper::GitHubHelper.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch, fallback_commit_message: fallback_commit_message)
 
         if items.size == 0
           UI.important("There is no pull request associated with #{sha}")

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -31,13 +31,13 @@ module Fastlane
       ANDROID_VERSION_COLUMN = 3
       PHC_VERSION_COLUMN = 4
 
-      def self.determine_next_version_using_labels(repo_name, github_token, rate_limit_sleep, include_prereleases, current_version)
+      def self.determine_next_version_using_labels(repo_name, github_token, rate_limit_sleep, include_prereleases, current_version, fallback_pr_lookup: false)
         old_version = latest_version_number(include_prereleases: include_prereleases, current_version: current_version)
         UI.important("Determining next version after #{old_version}")
 
         commits = Helper::GitHubHelper.get_commits_since_old_version(github_token, old_version, repo_name)
 
-        type_of_bump = get_type_of_bump_from_commits(commits, github_token, rate_limit_sleep, repo_name)
+        type_of_bump = get_type_of_bump_from_commits(commits, github_token, rate_limit_sleep, repo_name, fallback_pr_lookup: fallback_pr_lookup)
 
         if type_of_bump == :major && current_version
           latest_major = latest_version_number(include_prereleases: include_prereleases).split('.').first
@@ -53,7 +53,7 @@ module Fastlane
       end
 
       # rubocop:disable Metrics/PerceivedComplexity
-      def self.auto_generate_changelog(repo_name, github_token, rate_limit_sleep, include_prereleases, hybrid_common_version, versions_file_path, target_tag = nil, filter_labels: nil, exclude_labels: nil, cross_repo_pr_reference: '', include_purchases_js: false)
+      def self.auto_generate_changelog(repo_name, github_token, rate_limit_sleep, include_prereleases, hybrid_common_version, versions_file_path, target_tag = nil, filter_labels: nil, exclude_labels: nil, cross_repo_pr_reference: '', include_purchases_js: false, fallback_pr_lookup: false)
         filter_labels = nil if filter_labels&.empty?
         exclude_labels = nil if exclude_labels&.empty?
         cross_repo_pr_reference = cross_repo_pr_reference.to_s.strip
@@ -88,7 +88,7 @@ module Fastlane
           name = commit["commit"]["author"]["name"]
 
           sha = commit["sha"]
-          commit_message = commit["commit"]["message"]
+          commit_message = fallback_pr_lookup ? commit["commit"]["message"] : nil
           items = Helper::GitHubHelper.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch, commit_message: commit_message)
 
           case items.size
@@ -409,7 +409,7 @@ module Fastlane
           .to_set
       end
 
-      private_class_method def self.get_type_of_bump_from_commits(commits, github_token, rate_limit_sleep, repo_name)
+      private_class_method def self.get_type_of_bump_from_commits(commits, github_token, rate_limit_sleep, repo_name, fallback_pr_lookup: false)
         base_branch = Actions.git_branch
 
         type_of_bump = :skip
@@ -417,7 +417,7 @@ module Fastlane
           break if type_of_bump == :major
 
           sha = commit["sha"]
-          commit_message = commit["commit"]["message"]
+          commit_message = fallback_pr_lookup ? commit["commit"]["message"] : nil
           items = Helper::GitHubHelper.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch, commit_message: commit_message)
 
           if items.size == 0

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -416,25 +416,30 @@ module Fastlane
         commits.each do |commit|
           break if type_of_bump == :major
 
-          sha = commit["sha"]
-          commit_message = fallback_pr_lookup ? commit["commit"]["message"] : nil
-          items = Helper::GitHubHelper.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch, commit_message: commit_message)
+          type_of_bump_for_commit = get_type_of_bump_for_commit(commit, github_token, rate_limit_sleep, repo_name, base_branch, fallback_pr_lookup)
+          next if type_of_bump_for_commit.nil?
 
-          if items.size == 0
-            UI.important("There is no pull request associated with #{sha}")
-            next
-          elsif items.size > 1
-            UI.user_error!("Cannot determine next version. Multiple commits found for #{sha}")
-          end
-
-          item = items.first
-          commit_supported_labels = get_type_of_change_from_pr_info(item)
-          # Filter out pr:changelog_ignore as it shouldn't affect version determination
-          labels_for_version = commit_supported_labels.reject { |label| label == "pr:changelog_ignore" }.to_set
-          type_of_bump_for_commit = get_type_of_bump_from_types_of_change(labels_for_version)
           type_of_bump = [type_of_bump, type_of_bump_for_commit].max_by { |t| BUMP_VALUES[t] }
         end
         type_of_bump
+      end
+
+      private_class_method def self.get_type_of_bump_for_commit(commit, github_token, rate_limit_sleep, repo_name, base_branch, fallback_pr_lookup)
+        sha = commit["sha"]
+        commit_message = fallback_pr_lookup ? commit["commit"]["message"] : nil
+        items = Helper::GitHubHelper.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch, commit_message: commit_message)
+
+        if items.size == 0
+          UI.important("There is no pull request associated with #{sha}")
+          return nil
+        elsif items.size > 1
+          UI.user_error!("Cannot determine next version. Multiple commits found for #{sha}")
+        end
+
+        commit_supported_labels = get_type_of_change_from_pr_info(items.first)
+        # Filter out pr:changelog_ignore as it shouldn't affect version determination
+        labels_for_version = commit_supported_labels.reject { |label| label == "pr:changelog_ignore" }.to_set
+        get_type_of_bump_from_types_of_change(labels_for_version)
       end
 
       private_class_method def self.get_type_of_bump_from_types_of_change(change_types)

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -88,7 +88,8 @@ module Fastlane
           name = commit["commit"]["author"]["name"]
 
           sha = commit["sha"]
-          items = Helper::GitHubHelper.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch)
+          commit_message = commit["commit"]["message"]
+          items = Helper::GitHubHelper.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch, commit_message: commit_message)
 
           case items.size
           when 1
@@ -416,11 +417,10 @@ module Fastlane
           break if type_of_bump == :major
 
           sha = commit["sha"]
-          items = Helper::GitHubHelper.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch)
+          commit_message = commit["commit"]["message"]
+          items = Helper::GitHubHelper.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch, commit_message: commit_message)
 
           if items.size == 0
-            # skip this commit to minimize risk. If there are more commits, we'll use the current type_of_bump
-            # if there are no more commits, we'll skip the version bump
             UI.important("There is no pull request associated with #{sha}")
             next
           elsif items.size > 1

--- a/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
+++ b/spec/actions/bump_version_update_changelog_create_pr_action_spec.rb
@@ -52,7 +52,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         .with(mock_github_token)
         .and_return({ authenticated: true, rate_limit_remaining: 5000 })
       expect(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
-        .with(mock_repo_name, mock_github_token, 3, false, nil, nil, new_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil)
+        .with(mock_repo_name, mock_github_token, 3, false, nil, nil, new_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil, fallback_pr_lookup: nil)
         .and_return(auto_generated_changelog)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:edit_changelog)
@@ -107,7 +107,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         .with('release/1.13.0', mock_github_pr_token)
         .once
       expect(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
-        .with(mock_repo_name, mock_github_token, 3, false, nil, nil, new_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil)
+        .with(mock_repo_name, mock_github_token, 3, false, nil, nil, new_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil, fallback_pr_lookup: nil)
         .and_return(auto_generated_changelog)
         .once
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:edit_changelog)
@@ -147,7 +147,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
     it 'generates changelog with appropriate parameters when bumping a hybrid SDK' do
       setup_stubs
       expect(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
-        .with(mock_repo_name, mock_github_token, 3, false, hybrid_common_version, versions_file_path, new_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil)
+        .with(mock_repo_name, mock_github_token, 3, false, hybrid_common_version, versions_file_path, new_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil, fallback_pr_lookup: nil)
         .and_return(auto_generated_changelog)
         .once
 
@@ -166,6 +166,30 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         hybrid_common_version: hybrid_common_version,
         versions_file_path: versions_file_path,
         is_prerelease: false
+      )
+    end
+
+    it 'forwards fallback_pr_lookup to auto_generate_changelog when enabled' do
+      setup_stubs
+      expect(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
+        .with(mock_repo_name, mock_github_token, 3, false, nil, nil, new_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil, fallback_pr_lookup: true)
+        .and_return(auto_generated_changelog)
+        .once
+
+      Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction.run(
+        current_version: current_version,
+        changelog_latest_path: mock_changelog_latest_path,
+        changelog_path: mock_changelog_path,
+        files_to_update: { "./test_file.sh" => ['{x}'], "./test_file2.rb" => ['{x}'] },
+        files_to_update_without_prerelease_modifiers: { "./test_file3.kt" => ['{x}'], "./test_file4.swift" => ['{x}'] },
+        files_to_update_on_latest_stable_releases: { "./test_file5.kt" => ['{x}'], "./test_file6.swift" => ['{x}'] },
+        repo_name: mock_repo_name,
+        github_pr_token: mock_github_pr_token,
+        github_token: mock_github_token,
+        github_rate_limit: 3,
+        editor: editor,
+        is_prerelease: false,
+        fallback_pr_lookup: true
       )
     end
 
@@ -616,7 +640,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
       allow(FastlaneCore::UI).to receive(:confirm).with(anything).and_return(true)
       allow(File).to receive(:read).with(mock_changelog_latest_path).and_return(edited_changelog)
       allow(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
-        .with(mock_repo_name, mock_github_token, 3, false, hybrid_common_version, nil, new_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil)
+        .with(mock_repo_name, mock_github_token, 3, false, hybrid_common_version, nil, new_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil, fallback_pr_lookup: nil)
         .and_return(auto_generated_changelog)
         .once
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:edit_changelog)
@@ -672,7 +696,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
       allow(FastlaneCore::UI).to receive(:important).with(anything)
       allow(File).to receive(:read).with(mock_changelog_latest_path).and_return(edited_changelog)
       allow(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
-        .with(mock_repo_name, mock_github_token, 3, is_prerelease, hybrid_common_version, nil, expected_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil)
+        .with(mock_repo_name, mock_github_token, 3, is_prerelease, hybrid_common_version, nil, expected_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil, fallback_pr_lookup: nil)
         .and_return(auto_generated_changelog)
         .once
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:write_changelog)
@@ -766,7 +790,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
         .with(mock_github_token)
         .and_return({ authenticated: true, rate_limit_remaining: 5000 })
       allow(Fastlane::Helper::VersioningHelper).to receive(:auto_generate_changelog)
-        .with(mock_repo_name, mock_github_token, 3, false, nil, nil, new_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil)
+        .with(mock_repo_name, mock_github_token, 3, false, nil, nil, new_version, filter_labels: nil, exclude_labels: nil, include_purchases_js: nil, fallback_pr_lookup: nil)
         .and_return(auto_generated_changelog)
       allow(Fastlane::Helper::RevenuecatInternalHelper).to receive(:write_changelog)
         .with(auto_generated_changelog, mock_changelog_latest_path)
@@ -788,7 +812,7 @@ describe Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction do
 
   describe '#available_options' do
     it 'has correct number of options' do
-      expect(Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction.available_options.size).to eq(23)
+      expect(Fastlane::Actions::BumpVersionUpdateChangelogCreatePrAction.available_options.size).to eq(24)
     end
   end
 end

--- a/spec/actions/determine_next_version_using_labels_action_spec.rb
+++ b/spec/actions/determine_next_version_using_labels_action_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane::Actions::DetermineNextVersionUsingLabelsAction do
 
     it 'calls all the appropriate methods with appropriate parameters' do
       expect(Fastlane::Helper::VersioningHelper).to receive(:determine_next_version_using_labels)
-        .with(mock_repo_name, mock_github_token, 3, false, current_version)
+        .with(mock_repo_name, mock_github_token, 3, false, current_version, fallback_pr_lookup: nil)
         .and_return(new_version)
         .once
 
@@ -19,11 +19,26 @@ describe Fastlane::Actions::DetermineNextVersionUsingLabelsAction do
       )
       expect(calculated_version).to eq(new_version)
     end
+
+    it 'forwards fallback_pr_lookup when enabled' do
+      expect(Fastlane::Helper::VersioningHelper).to receive(:determine_next_version_using_labels)
+        .with(mock_repo_name, mock_github_token, 3, false, current_version, fallback_pr_lookup: true)
+        .and_return(new_version)
+        .once
+
+      Fastlane::Actions::DetermineNextVersionUsingLabelsAction.run(
+        repo_name: mock_repo_name,
+        github_token: mock_github_token,
+        github_rate_limit: 3,
+        current_version: current_version,
+        fallback_pr_lookup: true
+      )
+    end
   end
 
   describe '#available_options' do
     it 'has correct number of options' do
-      expect(Fastlane::Actions::DetermineNextVersionUsingLabelsAction.available_options.size).to eq(4)
+      expect(Fastlane::Actions::DetermineNextVersionUsingLabelsAction.available_options.size).to eq(5)
     end
   end
 end

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -56,7 +56,7 @@ describe Fastlane::Helper::GitHubHelper do
       expect(items).not_to be_nil
     end
 
-    context 'when search returns empty and commit_message is provided' do
+    context 'when search returns empty and fallback_commit_message is provided' do
       let(:empty_search_response) { { body: '{"items": []}' } }
       let(:valid_pr_body) do
         {
@@ -81,7 +81,7 @@ describe Fastlane::Helper::GitHubHelper do
 
         items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
           hash, github_token, 0, 'mock-repo-name', 'main',
-          commit_message: "Fall back to getCustomerInfo (#6650)\n\n* individual commit 1\n* individual commit 2"
+          fallback_commit_message: "Fall back to getCustomerInfo (#6650)\n\n* individual commit 1\n* individual commit 2"
         )
 
         expect(items.length).to eq(1)
@@ -109,7 +109,7 @@ describe Fastlane::Helper::GitHubHelper do
 
         items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
           hash, github_token, 0, 'mock-repo-name', 'main',
-          commit_message: "[EXTERNAL] fix(google): guard showInAppMessages (#3367) by @matteinn (#3368)"
+          fallback_commit_message: "[EXTERNAL] fix(google): guard showInAppMessages (#3367) by @matteinn (#3368)"
         )
 
         expect(items.length).to eq(1)
@@ -123,7 +123,7 @@ describe Fastlane::Helper::GitHubHelper do
 
         items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
           hash, github_token, 0, 'mock-repo-name', 'main',
-          commit_message: "Some commit without a PR reference"
+          fallback_commit_message: "Some commit without a PR reference"
         )
 
         expect(items).to eq([])
@@ -139,7 +139,7 @@ describe Fastlane::Helper::GitHubHelper do
 
         items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
           hash, github_token, 0, 'mock-repo-name', 'main',
-          commit_message: "Some feature (#9999)"
+          fallback_commit_message: "Some feature (#9999)"
         )
 
         expect(items).to eq([])
@@ -156,7 +156,7 @@ describe Fastlane::Helper::GitHubHelper do
 
         items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
           hash, github_token, 0, 'mock-repo-name', 'main',
-          commit_message: "Some feature (#6650)"
+          fallback_commit_message: "Some feature (#6650)"
         )
 
         expect(items).to eq([])
@@ -173,7 +173,7 @@ describe Fastlane::Helper::GitHubHelper do
 
         items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
           hash, github_token, 0, 'mock-repo-name', 'main',
-          commit_message: "Some feature (#6650)"
+          fallback_commit_message: "Some feature (#6650)"
         )
 
         expect(items).to eq([])
@@ -190,14 +190,14 @@ describe Fastlane::Helper::GitHubHelper do
 
         items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
           hash, github_token, 0, 'mock-repo-name', 'main',
-          commit_message: "Some feature (#6650)"
+          fallback_commit_message: "Some feature (#6650)"
         )
 
         expect(items).to eq([])
       end
     end
 
-    context 'when search returns empty and no commit_message is provided' do
+    context 'when search returns empty and no fallback_commit_message is provided' do
       let(:empty_search_response) { { body: '{"items": []}' } }
 
       it 'returns empty without attempting fallback' do

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -73,7 +73,7 @@ describe Fastlane::Helper::GitHubHelper do
 
       it 'falls back to direct PR lookup from commit message' do
         allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
-          .with(hash_including(path: /search\/issues/))
+          .with(hash_including(path: %r{search/issues}))
           .and_return(empty_search_response)
         allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
           .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/pulls/6650"))
@@ -101,7 +101,7 @@ describe Fastlane::Helper::GitHubHelper do
         }
 
         allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
-          .with(hash_including(path: /search\/issues/))
+          .with(hash_including(path: %r{search/issues}))
           .and_return(empty_search_response)
         allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
           .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/pulls/3368"))
@@ -118,7 +118,7 @@ describe Fastlane::Helper::GitHubHelper do
 
       it 'returns empty when commit message has no PR number' do
         allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
-          .with(hash_including(path: /search\/issues/))
+          .with(hash_including(path: %r{search/issues}))
           .and_return(empty_search_response)
 
         items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
@@ -131,7 +131,7 @@ describe Fastlane::Helper::GitHubHelper do
 
       it 'returns empty when direct PR fetch fails' do
         allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
-          .with(hash_including(path: /search\/issues/))
+          .with(hash_including(path: %r{search/issues}))
           .and_return(empty_search_response)
         allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
           .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/pulls/9999"))
@@ -148,7 +148,7 @@ describe Fastlane::Helper::GitHubHelper do
       it 'rejects PR that was never merged' do
         unmerged_pr = valid_pr_body.merge('merged_at' => nil)
         allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
-          .with(hash_including(path: /search\/issues/))
+          .with(hash_including(path: %r{search/issues}))
           .and_return(empty_search_response)
         allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
           .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/pulls/6650"))
@@ -165,7 +165,7 @@ describe Fastlane::Helper::GitHubHelper do
       it 'rejects PR that targets a different base branch' do
         wrong_base_pr = valid_pr_body.merge('base' => { 'ref' => 'release/5.68.0' })
         allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
-          .with(hash_including(path: /search\/issues/))
+          .with(hash_including(path: %r{search/issues}))
           .and_return(empty_search_response)
         allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
           .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/pulls/6650"))
@@ -182,7 +182,7 @@ describe Fastlane::Helper::GitHubHelper do
       it 'rejects PR whose merge commit SHA does not match' do
         wrong_sha_pr = valid_pr_body.merge('merge_commit_sha' => 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef')
         allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
-          .with(hash_including(path: /search\/issues/))
+          .with(hash_including(path: %r{search/issues}))
           .and_return(empty_search_response)
         allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
           .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/pulls/6650"))
@@ -202,11 +202,11 @@ describe Fastlane::Helper::GitHubHelper do
 
       it 'returns empty without attempting fallback' do
         allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
-          .with(hash_including(path: /search\/issues/))
+          .with(hash_including(path: %r{search/issues}))
           .and_return(empty_search_response)
 
         expect(Fastlane::Helper::GitHubHelper).not_to receive(:github_api_call_with_retry)
-          .with(hash_including(path: /\/pulls\/\d+/))
+          .with(hash_including(path: %r{/pulls/\d+}))
 
         items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
           hash, github_token, 0, 'mock-repo-name', 'main'

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -58,9 +58,18 @@ describe Fastlane::Helper::GitHubHelper do
 
     context 'when search returns empty and commit_message is provided' do
       let(:empty_search_response) { { body: '{"items": []}' } }
-      let(:pr_response) do
-        { body: '{"number": 6650, "title": "Fall back to getCustomerInfo", "user": {"login": "rickvdl"}, "labels": [{"name": "pr:fix"}]}' }
+      let(:valid_pr_body) do
+        {
+          'number' => 6650,
+          'title' => 'Fall back to getCustomerInfo',
+          'user' => { 'login' => 'rickvdl' },
+          'labels' => [{ 'name' => 'pr:fix' }],
+          'merged_at' => '2026-04-22T08:12:37Z',
+          'merge_commit_sha' => hash,
+          'base' => { 'ref' => 'main' }
+        }
       end
+      let(:pr_response) { { body: valid_pr_body.to_json } }
 
       it 'falls back to direct PR lookup from commit message' do
         allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
@@ -81,12 +90,22 @@ describe Fastlane::Helper::GitHubHelper do
       end
 
       it 'extracts last PR number for external contributor PRs' do
+        external_pr_body = {
+          'number' => 3368,
+          'title' => 'Guard showInAppMessages',
+          'user' => { 'login' => 'MonikaMateska' },
+          'labels' => [{ 'name' => 'pr:fix' }],
+          'merged_at' => '2026-04-22T08:00:00Z',
+          'merge_commit_sha' => hash,
+          'base' => { 'ref' => 'main' }
+        }
+
         allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
           .with(hash_including(path: /search\/issues/))
           .and_return(empty_search_response)
         allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
           .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/pulls/3368"))
-          .and_return({ body: '{"number": 3368, "title": "Guard showInAppMessages", "user": {"login": "MonikaMateska"}, "labels": [{"name": "pr:fix"}]}' })
+          .and_return({ body: external_pr_body.to_json })
 
         items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
           hash, github_token, 0, 'mock-repo-name', 'main',
@@ -121,6 +140,57 @@ describe Fastlane::Helper::GitHubHelper do
         items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
           hash, github_token, 0, 'mock-repo-name', 'main',
           commit_message: "Some feature (#9999)"
+        )
+
+        expect(items).to eq([])
+      end
+
+      it 'rejects PR that was never merged' do
+        unmerged_pr = valid_pr_body.merge('merged_at' => nil)
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: /search\/issues/))
+          .and_return(empty_search_response)
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/pulls/6650"))
+          .and_return({ body: unmerged_pr.to_json })
+
+        items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 0, 'mock-repo-name', 'main',
+          commit_message: "Some feature (#6650)"
+        )
+
+        expect(items).to eq([])
+      end
+
+      it 'rejects PR that targets a different base branch' do
+        wrong_base_pr = valid_pr_body.merge('base' => { 'ref' => 'release/5.68.0' })
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: /search\/issues/))
+          .and_return(empty_search_response)
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/pulls/6650"))
+          .and_return({ body: wrong_base_pr.to_json })
+
+        items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 0, 'mock-repo-name', 'main',
+          commit_message: "Some feature (#6650)"
+        )
+
+        expect(items).to eq([])
+      end
+
+      it 'rejects PR whose merge commit SHA does not match' do
+        wrong_sha_pr = valid_pr_body.merge('merge_commit_sha' => 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef')
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: /search\/issues/))
+          .and_return(empty_search_response)
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/pulls/6650"))
+          .and_return({ body: wrong_sha_pr.to_json })
+
+        items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 0, 'mock-repo-name', 'main',
+          commit_message: "Some feature (#6650)"
         )
 
         expect(items).to eq([])

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -55,6 +55,131 @@ describe Fastlane::Helper::GitHubHelper do
       )
       expect(items).not_to be_nil
     end
+
+    context 'when search returns empty and commit_message is provided' do
+      let(:empty_search_response) { { body: '{"items": []}' } }
+      let(:pr_response) do
+        { body: '{"number": 6650, "title": "Fall back to getCustomerInfo", "user": {"login": "rickvdl"}, "labels": [{"name": "pr:fix"}]}' }
+      end
+
+      it 'falls back to direct PR lookup from commit message' do
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: /search\/issues/))
+          .and_return(empty_search_response)
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/pulls/6650"))
+          .and_return(pr_response)
+
+        items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 0, 'mock-repo-name', 'main',
+          commit_message: "Fall back to getCustomerInfo (#6650)\n\n* individual commit 1\n* individual commit 2"
+        )
+
+        expect(items.length).to eq(1)
+        expect(items.first['number']).to eq(6650)
+        expect(items.first['title']).to eq('Fall back to getCustomerInfo')
+      end
+
+      it 'extracts last PR number for external contributor PRs' do
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: /search\/issues/))
+          .and_return(empty_search_response)
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/pulls/3368"))
+          .and_return({ body: '{"number": 3368, "title": "Guard showInAppMessages", "user": {"login": "MonikaMateska"}, "labels": [{"name": "pr:fix"}]}' })
+
+        items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 0, 'mock-repo-name', 'main',
+          commit_message: "[EXTERNAL] fix(google): guard showInAppMessages (#3367) by @matteinn (#3368)"
+        )
+
+        expect(items.length).to eq(1)
+        expect(items.first['number']).to eq(3368)
+      end
+
+      it 'returns empty when commit message has no PR number' do
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: /search\/issues/))
+          .and_return(empty_search_response)
+
+        items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 0, 'mock-repo-name', 'main',
+          commit_message: "Some commit without a PR reference"
+        )
+
+        expect(items).to eq([])
+      end
+
+      it 'returns empty when direct PR fetch fails' do
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: /search\/issues/))
+          .and_return(empty_search_response)
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/pulls/9999"))
+          .and_raise(StandardError.new("404 Not Found"))
+
+        items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 0, 'mock-repo-name', 'main',
+          commit_message: "Some feature (#9999)"
+        )
+
+        expect(items).to eq([])
+      end
+    end
+
+    context 'when search returns empty and no commit_message is provided' do
+      let(:empty_search_response) { { body: '{"items": []}' } }
+
+      it 'returns empty without attempting fallback' do
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: /search\/issues/))
+          .and_return(empty_search_response)
+
+        expect(Fastlane::Helper::GitHubHelper).not_to receive(:github_api_call_with_retry)
+          .with(hash_including(path: /\/pulls\/\d+/))
+
+        items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 0, 'mock-repo-name', 'main'
+        )
+
+        expect(items).to eq([])
+      end
+    end
+  end
+
+  describe '.extract_pr_number_from_commit_message' do
+    it 'extracts PR number from standard squash merge message' do
+      result = Fastlane::Helper::GitHubHelper.extract_pr_number_from_commit_message(
+        "Add some feature (#1234)\n\n* commit 1\n* commit 2"
+      )
+      expect(result).to eq(1234)
+    end
+
+    it 'extracts last PR number from external contributor message' do
+      result = Fastlane::Helper::GitHubHelper.extract_pr_number_from_commit_message(
+        "[EXTERNAL] fix: guard something (#3367) by @matteinn (#3368)"
+      )
+      expect(result).to eq(3368)
+    end
+
+    it 'returns nil when no PR number present' do
+      result = Fastlane::Helper::GitHubHelper.extract_pr_number_from_commit_message(
+        "Some commit without PR reference"
+      )
+      expect(result).to be_nil
+    end
+
+    it 'only considers the first line' do
+      result = Fastlane::Helper::GitHubHelper.extract_pr_number_from_commit_message(
+        "Main title (#100)\n\nBody mentions (#999)"
+      )
+      expect(result).to eq(100)
+    end
+
+    it 'returns nil for nil input' do
+      result = Fastlane::Helper::GitHubHelper.extract_pr_number_from_commit_message(nil)
+      expect(result).to be_nil
+    end
   end
 
   describe '.get_commits_since_old_version' do

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -219,35 +219,39 @@ describe Fastlane::Helper::GitHubHelper do
 
   describe '.extract_pr_number_from_commit_message' do
     it 'extracts PR number from standard squash merge message' do
-      result = Fastlane::Helper::GitHubHelper.extract_pr_number_from_commit_message(
+      result = Fastlane::Helper::GitHubHelper.send(
+        :extract_pr_number_from_commit_message,
         "Add some feature (#1234)\n\n* commit 1\n* commit 2"
       )
       expect(result).to eq(1234)
     end
 
     it 'extracts last PR number from external contributor message' do
-      result = Fastlane::Helper::GitHubHelper.extract_pr_number_from_commit_message(
+      result = Fastlane::Helper::GitHubHelper.send(
+        :extract_pr_number_from_commit_message,
         "[EXTERNAL] fix: guard something (#3367) by @matteinn (#3368)"
       )
       expect(result).to eq(3368)
     end
 
     it 'returns nil when no PR number present' do
-      result = Fastlane::Helper::GitHubHelper.extract_pr_number_from_commit_message(
+      result = Fastlane::Helper::GitHubHelper.send(
+        :extract_pr_number_from_commit_message,
         "Some commit without PR reference"
       )
       expect(result).to be_nil
     end
 
     it 'only considers the first line' do
-      result = Fastlane::Helper::GitHubHelper.extract_pr_number_from_commit_message(
+      result = Fastlane::Helper::GitHubHelper.send(
+        :extract_pr_number_from_commit_message,
         "Main title (#100)\n\nBody mentions (#999)"
       )
       expect(result).to eq(100)
     end
 
     it 'returns nil for nil input' do
-      result = Fastlane::Helper::GitHubHelper.extract_pr_number_from_commit_message(nil)
+      result = Fastlane::Helper::GitHubHelper.send(:extract_pr_number_from_commit_message, nil)
       expect(result).to be_nil
     end
   end

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -835,6 +835,114 @@ describe Fastlane::Helper::VersioningHelper do
                               "* Updating great support link via Miguel José Carranza Guisado")
     end
 
+    context 'with fallback_pr_lookup opt-in' do
+      let(:fake_sha) { 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' }
+      let(:empty_search_response) { { body: JSON.generate('items' => []) } }
+      let(:commits_with_pr_ref_response) do
+        {
+          body: JSON.generate(
+            'commits' => [
+              {
+                'sha' => fake_sha,
+                'commit' => {
+                  'author' => { 'name' => 'Antonio Pallares' },
+                  'message' => "Fix flaky race condition (#42)\n\n* inner commit details"
+                }
+              }
+            ]
+          )
+        }
+      end
+      let(:valid_pr_response) do
+        {
+          body: JSON.generate(
+            'number' => 42,
+            'title' => 'Fix flaky race condition',
+            'user' => { 'login' => 'pallares' },
+            'labels' => [{ 'name' => 'pr:fix' }],
+            'merged_at' => '2026-04-22T12:00:00Z',
+            'merge_commit_sha' => fake_sha,
+            'base' => { 'ref' => 'main' }
+          )
+        }
+      end
+
+      before do
+        setup_tag_stubs
+        mock_commits_since_last_release(fake_sha, commits_with_pr_ref_response)
+        allow(Fastlane::Actions::GithubApiAction).to receive(:run)
+          .with(server_url: server_url,
+                path: "/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:main+SHA:#{fake_sha}",
+                http_method: http_method,
+                body: {},
+                api_token: 'mock-github-token')
+          .and_return(empty_search_response)
+      end
+
+      it 'falls back to direct PR lookup and uses PR metadata when enabled' do
+        expect(Fastlane::Actions::GithubApiAction).to receive(:run)
+          .with(server_url: server_url,
+                path: "/repos/RevenueCat/mock-repo-name/pulls/42",
+                http_method: http_method,
+                body: {},
+                api_token: 'mock-github-token')
+          .and_return(valid_pr_response)
+          .once
+
+        changelog = Fastlane::Helper::VersioningHelper.auto_generate_changelog(
+          'mock-repo-name', 'mock-github-token', 0, false, nil, nil, nil,
+          fallback_pr_lookup: true
+        )
+        expect(changelog).to eq("## RevenueCat SDK\n" \
+                                "### 🐞 Bugfixes\n" \
+                                "* Fix flaky race condition (#42) via Antonio Pallares (@pallares)")
+      end
+
+      it 'does not hit the direct PR endpoint when disabled and classifies commit as Other' do
+        expect(Fastlane::Actions::GithubApiAction).not_to receive(:run)
+          .with(hash_including(path: %r{/pulls/\d+\z}))
+
+        changelog = Fastlane::Helper::VersioningHelper.auto_generate_changelog(
+          'mock-repo-name', 'mock-github-token', 0, false, nil, nil, nil
+        )
+        expect(changelog).to eq("### 🔄 Other Changes\n" \
+                                "* Fix flaky race condition (#42)\n\n* inner commit details via Antonio Pallares")
+      end
+
+      it 'does not hit the direct PR endpoint when enabled but commit subject has no PR reference' do
+        commits_no_pr_ref_response = {
+          body: JSON.generate(
+            'commits' => [
+              {
+                'sha' => fake_sha,
+                'commit' => {
+                  'author' => { 'name' => 'Antonio Pallares' },
+                  'message' => "Direct push without PR reference"
+                }
+              }
+            ]
+          )
+        }
+        allow(Fastlane::Actions::GithubApiAction).to receive(:run)
+          .with(server_url: server_url,
+                path: "/repos/RevenueCat/mock-repo-name/compare/1.11.0...#{fake_sha}",
+                http_method: http_method,
+                body: {},
+                api_token: 'mock-github-token')
+          .and_return(commits_no_pr_ref_response)
+
+        expect(Fastlane::Actions::GithubApiAction).not_to receive(:run)
+          .with(hash_including(path: %r{/pulls/\d+\z}))
+
+        changelog = Fastlane::Helper::VersioningHelper.auto_generate_changelog(
+          'mock-repo-name', 'mock-github-token', 0, false, nil, nil, nil,
+          fallback_pr_lookup: true
+        )
+        expect(changelog).to eq("### 🔄 Other Changes\n" \
+                                "* Direct push without PR reference via Antonio Pallares")
+      end
+    end
+
     def mock_native_releases
       allow(Fastlane::Actions::GithubApiAction).to receive(:run)
         .with(server_url: server_url,
@@ -1344,6 +1452,80 @@ describe Fastlane::Helper::VersioningHelper do
       )
       expect(next_version).to eq("2.0.0")
       expect(type_of_bump).to eq(:major)
+    end
+
+    context 'with fallback_pr_lookup opt-in' do
+      let(:fake_sha) { 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' }
+      let(:empty_search_response) { { body: JSON.generate('items' => []) } }
+      let(:commits_with_pr_ref_response) do
+        {
+          body: JSON.generate(
+            'commits' => [
+              {
+                'sha' => fake_sha,
+                'commit' => {
+                  'author' => { 'name' => 'Antonio Pallares' },
+                  'message' => "Fix flaky race condition (#42)"
+                }
+              }
+            ]
+          )
+        }
+      end
+      let(:patch_pr_response) do
+        {
+          body: JSON.generate(
+            'number' => 42,
+            'title' => 'Fix flaky race condition',
+            'user' => { 'login' => 'pallares' },
+            'labels' => [{ 'name' => 'pr:fix' }],
+            'merged_at' => '2026-04-22T12:00:00Z',
+            'merge_commit_sha' => fake_sha,
+            'base' => { 'ref' => 'main' }
+          )
+        }
+      end
+
+      before do
+        setup_tag_stubs
+        mock_commits_since_last_release(fake_sha, commits_with_pr_ref_response)
+        allow(Fastlane::Actions::GithubApiAction).to receive(:run)
+          .with(server_url: server_url,
+                path: "/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:main+SHA:#{fake_sha}",
+                http_method: http_method,
+                body: {},
+                api_token: 'mock-github-token')
+          .and_return(empty_search_response)
+      end
+
+      it 'falls back to direct PR lookup and uses PR labels to determine the bump when enabled' do
+        expect(Fastlane::Actions::GithubApiAction).to receive(:run)
+          .with(server_url: server_url,
+                path: "/repos/RevenueCat/mock-repo-name/pulls/42",
+                http_method: http_method,
+                body: {},
+                api_token: 'mock-github-token')
+          .and_return(patch_pr_response)
+          .once
+
+        next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
+          'mock-repo-name', 'mock-github-token', 0, false, nil,
+          fallback_pr_lookup: true
+        )
+        expect(type_of_bump).to eq(:patch)
+        expect(next_version).to eq("1.11.1")
+      end
+
+      it 'does not hit the direct PR endpoint when disabled and stays at :skip' do
+        expect(Fastlane::Actions::GithubApiAction).not_to receive(:run)
+          .with(hash_including(path: %r{/pulls/\d+\z}))
+
+        next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
+          'mock-repo-name', 'mock-github-token', 0, false, nil
+        )
+        expect(type_of_bump).to eq(:skip)
+        expect(next_version).to eq("1.11.0")
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Adds a new `fallback_pr_lookup` flag (default `false`) to `BumpVersionUpdateChangelogCreatePrAction` and `DetermineNextVersionUsingLabelsAction` that opts into a fallback path when GitHub's search API can't find the PR for a commit SHA: the helper extracts the PR number from the commit subject (`(#1234)` squash-merge pattern) and fetches it directly via `GET /repos/.../pulls/{number}`. When the flag is off, behavior is bit-identical to `main`.

To avoid contaminating the changelog when the subject accidentally references an unrelated PR (reverts, cherry-picks, non-squash workflows), the fetched PR is only accepted if **all three** hold: `merged_at` is set, `base.ref` matches the base branch, and `merge_commit_sha` equals the commit SHA. Otherwise the fallback logs and returns empty — same behavior as "no PR associated with this commit".

## Test plan

- Unit tests in `spec/helper/github_helper_spec.rb` cover: fallback on empty search, extraction regex (standard subject, external-contributor subject with two `(#N)`, first-line-only, nil, no match), REST failures, and each of the three rejection guards.
- Plumbing tests in `spec/actions/` verify `fallback_pr_lookup: true` is forwarded end-to-end from both actions.
- HTTP-level integration tests in `spec/helper/versioning_helper_spec.rb` verify the opt-in is respected (no-op when off or when the subject has no `(#N)`) and drives correct changelog sections when on.

<details>
<summary><strong>Local validation against <code>purchases-ios</code> v5.68.1</strong></summary>

Reproduced end-to-end against the real repo with the search index still degraded. With the flag off, the output matched the broken changelog in [purchases-ios#6666](https://github.com/RevenueCat/purchases-ios/pull/6666) (34 `Cannot find pull request associated to …` warnings, every PR dumped into "Other Changes" with the raw squash-merge body). With the flag on, 27 commits were recovered via the direct-PR fallback, all three safety guards accepted cleanly, and the changelog rendered correctly:

```markdown
## RevenueCat SDK
### ✨ New Features
* Add workflows network layer for multipage paywalls (#6557) via Cesar de la Vega (@vegaro)
### 🐞 Bugfixes
* Resolve the issue around tab control context identity (PWENG-31) (#6634) via Alexander Repty (@alexrepty)
* Fall back to getCustomerInfo when posting unfinished receipt fails (#6650) via Rick (@rickvdl)
* fix(RevenueCatUI): legacy paywall `component_name` parity with Android (#6662) via Monika Mateska (@MonikaMateska)
* Clip carousel pages to card width to fix transient overlay artifact (#6657) via Monika Mateska (@MonikaMateska)
* Fix SPM 'unhandled file' warning for RevenueCatUIDev.xctestplan (#6625) via Rick (@rickvdl)

## RevenueCatUI SDK
### 🐞 Bugfixes
* Defer paywall dismissal after purchase callbacks (#6621) via Jacob Rakidzich (@JZDesign)
### Paywallsv2
#### 🐞 Bugfixes
* Replace fatalError with assertionFailure + throw for fallbackHeader (#6636) via Facundo Menzella (@facumenzella)

### 🔄 Other Changes
* AdMob SSV: add `@_spi(Internal)` poll endpoint on `Purchases` (#6641) via Pol Miro (@polmiro)
* Skip CI on auto-generated snapshot branches (#6633) via Rick (@rickvdl)
* Add TUIST_LAUNCH_ARGUMENTS env var for injecting launch arguments at generation time (#6664) via Facundo Menzella (@facumenzella)
* Add workflow to re-run Danger on PR label change (#6660) via Rick (@rickvdl)
* Fix rcgitbot_please_test token permissions for PR comments (#6655) via Antonio Pallares (@ajpallares)
* Add pr:other label to auto-generated snapshot PRs (#6631) via Rick (@rickvdl)
* Add TUIST_SWIFT_CONDITIONS for injecting compiler flags at project generation time (#6661) via Facundo Menzella (@facumenzella)
* Skip SPM Release Build steps during snapshot-generation pipelines (#6659) via Antonio Pallares (@ajpallares)
* Fix iOS 15 snapshot-generation job hanging indefinitely (#6658) via Antonio Pallares (@ajpallares)
* Bump fastlane-plugin-revenuecat_internal from `e348913` to `b822f01` (#6651) via dependabot[bot] (@dependabot[bot])
* Use env-var interpolation in rcgitbot_please_test workflow (#6649) via Antonio Pallares (@ajpallares)
* Expose `apiKey` on `Purchases` via `@_spi(Internal)` (#6635) via Pol Miro (@polmiro)
* Bump fastlane from 2.232.2 to 2.233.0 (#6639) via dependabot[bot] (@dependabot[bot])
* Bump fastlane-plugin-revenuecat_internal from `a1eed48` to `e348913` (#6638) via dependabot[bot] (@dependabot[bot])
* Add @RCGitBot please test <job-name> on-demand job trigger (#6607) via Antonio Pallares (@ajpallares)
* Migrate CircleCI to dynamic configuration (#6605) via Antonio Pallares (@ajpallares)
* Bump fastlane from 2.229.1 to 2.232.2 and fix Mac Catalyst archive export (#6370) via dependabot[bot] (@dependabot[bot])
* Add automated GitHub releases for purchases-ios-admob (#6537) via Pol Miro (@polmiro)
* Add missing source files to RevenueCat.xcodeproj (#6624) via Rick (@rickvdl)
* UI events for paywall component interactions (#6523) via Monika Mateska (@MonikaMateska)
* Run paywalls V1 snapshot recording on main and release branches (#6620) via Rick (@rickvdl)
* fix(ads): remove mistake masking behavior (#6613) via Peter Porfy (@peterporfy)
* Use shared run_maestro_e2e_tests action from fastlane plugin (#6616) via Antonio Pallares (@ajpallares)
* Bump fastlane-plugin-revenuecat_internal from `20911d1` to `a1eed48` (#6618) via dependabot[bot] (@dependabot[bot])
```

</details>
