### PR TITLE
Disambiguate multi-PR search results by merge_commit_sha

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -40,6 +40,13 @@ module Fastlane
       # When it is a non-nil string, and the search API returns no items, the helper
       # attempts a fallback lookup by extracting the PR number from the commit message
       # and fetching the PR directly via the REST API. Pass nil to disable the fallback.
+      #
+      # When the search API returns more than one PR for the same SHA (e.g. because a
+      # stacked PR brought commits from the base branch into its head), this helper
+      # disambiguates by fetching each candidate's `merge_commit_sha` and keeping only
+      # the PR whose merge SHA equals the queried commit. If exactly one candidate
+      # survives, only that PR is returned; otherwise the original list is returned
+      # so the caller can apply its own policy.
       def self.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch, fallback_commit_message: nil)
         if github_token.nil? || github_token.empty?
           UI.important("No GitHub token provided, skipping PR lookup for SHA: #{sha}")
@@ -51,6 +58,10 @@ module Fastlane
           sleep(rate_limit_sleep)
         end
 
+        if base_branch.to_s.strip.empty?
+          UI.important("No base branch provided for PR search of SHA #{sha}; relying on the `SHA:` qualifier alone, which may match stacked PRs that contain the commit.")
+        end
+
         # Get pull request associated with commit via search API
         pr_resp = github_api_call_with_retry(server_url: 'https://api.github.com',
                                              path: "/search/issues?q=repo:RevenueCat/#{repo_name}+is:pr+base:#{base_branch}+SHA:#{sha}",
@@ -59,17 +70,25 @@ module Fastlane
                                              api_token: github_token)
         body = JSON.parse(pr_resp[:body])
         items = body["items"]
-        return items unless items.empty? && fallback_commit_message
 
-        # Fallback: extract PR number from commit message and fetch directly.
-        # Squash-merge commits contain the PR number as "(#1234)" in the first line.
-        # External contributor PRs have two: "...original (#111) by @user (#222)" —
-        # the last one is the merged PR.
-        #
-        # This fallback assumes squash-merge workflows. For rebase-and-merge, individual
-        # commits don't get "(#N)" appended, so the regex no-ops before reaching the
-        # REST call. For true merge commits, the merge commit does contain "(#N)" and
-        # its SHA matches merge_commit_sha, so the fallback works there too.
+        return items if items.size == 1
+        return disambiguate_pr_items_by_merge_commit_sha(items, sha, github_token, rate_limit_sleep, repo_name) if items.size > 1
+
+        attempt_pr_lookup_from_commit_message(sha, fallback_commit_message, github_token, rate_limit_sleep, repo_name, base_branch)
+      end
+
+      # Fallback: extract PR number from commit message and fetch directly.
+      # Squash-merge commits contain the PR number as "(#1234)" in the first line.
+      # External contributor PRs have two: "...original (#111) by @user (#222)" —
+      # the last one is the merged PR.
+      #
+      # This fallback assumes squash-merge workflows. For rebase-and-merge, individual
+      # commits don't get "(#N)" appended, so the regex no-ops before reaching the
+      # REST call. For true merge commits, the merge commit does contain "(#N)" and
+      # its SHA matches merge_commit_sha, so the fallback works there too.
+      private_class_method def self.attempt_pr_lookup_from_commit_message(sha, fallback_commit_message, github_token, rate_limit_sleep, repo_name, base_branch)
+        return [] unless fallback_commit_message
+
         pr_number = extract_pr_number_from_commit_message(fallback_commit_message)
         return [] unless pr_number
 
@@ -79,6 +98,53 @@ module Fastlane
 
         UI.message("Search API returned no results for #{sha}. Falling back to direct PR ##{pr_number} lookup.")
         fetch_pr_by_number(pr_number, github_token, repo_name, expected_base: base_branch, expected_sha: sha)
+      end
+
+      # GitHub's `SHA:<sha>` PR-search qualifier matches any PR whose branch contains
+      # the commit, not just the PR that introduced it. Stacked PRs that brought the
+      # base branch into their head therefore appear as spurious matches.
+      #
+      # When the search returns multiple PRs for the same SHA, we disambiguate by
+      # fetching each candidate's `merge_commit_sha`, which is the commit GitHub
+      # leaves on the base branch when the PR merges:
+      #   - squash merge → the squashed commit pushed to the base ref
+      #   - merge commit → the merge commit itself
+      #   - rebase merge → the tip commit after the rebase
+      # In all three cases, the originating PR's `merge_commit_sha` equals the SHA
+      # that ends up in `git log <prev_tag>..<new_tag>` on the base branch, so it is
+      # the unambiguous attribution signal.
+      #
+      # If exactly one candidate matches, only that PR is returned. If zero or more
+      # than one match, the original list is returned unchanged so the caller can
+      # decide how to handle the ambiguity (typically: error out).
+      private_class_method def self.disambiguate_pr_items_by_merge_commit_sha(items, sha, github_token, rate_limit_sleep, repo_name)
+        pr_numbers = items.map { |item| "##{item['number']}" }.join(', ')
+        UI.message("Search API returned #{items.size} PRs (#{pr_numbers}) for #{sha}; disambiguating by merge_commit_sha.")
+
+        matches = items.select do |item|
+          pr_number = item["number"]
+          if rate_limit_sleep > 0
+            sleep(rate_limit_sleep)
+          end
+
+          begin
+            detail_resp = github_api_call_with_retry(server_url: 'https://api.github.com',
+                                                     path: "/repos/RevenueCat/#{repo_name}/pulls/#{pr_number}",
+                                                     http_method: 'GET',
+                                                     body: {},
+                                                     api_token: github_token)
+            detail = JSON.parse(detail_resp[:body])
+            detail["merge_commit_sha"] == sha
+          rescue StandardError => e
+            UI.important("Failed to fetch PR ##{pr_number} for disambiguation: #{e.message}")
+            false
+          end
+        end
+
+        return matches if matches.size == 1
+
+        UI.important("Could not disambiguate #{items.size} PRs for #{sha} via merge_commit_sha (#{matches.size} candidate(s) matched).")
+        items
       end
 
       private_class_method def self.extract_pr_number_from_commit_message(commit_message)

--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -40,13 +40,6 @@ module Fastlane
       # When it is a non-nil string, and the search API returns no items, the helper
       # attempts a fallback lookup by extracting the PR number from the commit message
       # and fetching the PR directly via the REST API. Pass nil to disable the fallback.
-      #
-      # When the search API returns more than one PR for the same SHA (e.g. because a
-      # stacked PR brought commits from the base branch into its head), this helper
-      # disambiguates by fetching each candidate's `merge_commit_sha` and keeping only
-      # the PR whose merge SHA equals the queried commit. If exactly one candidate
-      # survives, only that PR is returned; otherwise the original list is returned
-      # so the caller can apply its own policy.
       def self.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch, fallback_commit_message: nil)
         if github_token.nil? || github_token.empty?
           UI.important("No GitHub token provided, skipping PR lookup for SHA: #{sha}")

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -132,7 +132,8 @@ module Fastlane
               changelog_sections[:other].push(line)
             end
           else
-            UI.user_error!("Cannot generate changelog. Multiple commits found for #{sha}")
+            pr_numbers = items.map { |multi_item| "##{multi_item['number']}" }.join(', ')
+            UI.user_error!("Cannot generate changelog. Multiple PRs (#{pr_numbers}) match commit #{sha} and disambiguation by merge_commit_sha did not yield a single match.")
           end
         end
 
@@ -433,7 +434,8 @@ module Fastlane
           UI.important("There is no pull request associated with #{sha}")
           return nil
         elsif items.size > 1
-          UI.user_error!("Cannot determine next version. Multiple commits found for #{sha}")
+          pr_numbers = items.map { |item| "##{item['number']}" }.join(', ')
+          UI.user_error!("Cannot determine next version. Multiple PRs (#{pr_numbers}) match commit #{sha} and disambiguation by merge_commit_sha did not yield a single match.")
         end
 
         commit_supported_labels = get_type_of_change_from_pr_info(items.first)

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -215,6 +215,143 @@ describe Fastlane::Helper::GitHubHelper do
         expect(items).to eq([])
       end
     end
+
+    context 'when search returns multiple PRs for the same SHA' do
+      # GitHub's `SHA:<sha>` qualifier matches any PR whose branch contains the
+      # commit, not just the PR that introduced it. When a stacked PR brings
+      # the base branch into its head, the search returns spurious extra
+      # candidates. Disambiguate by `merge_commit_sha` against the queried SHA.
+      let(:multi_search_response) do
+        {
+          body: {
+            'items' => [
+              { 'number' => 6693, 'title' => 'Add workflowTrigger to ButtonComponent.Action' },
+              { 'number' => 6697, 'title' => 'Cache decoded images by file URL in `FileImageLoader`' }
+            ]
+          }.to_json
+        }
+      end
+
+      it 'returns the single PR whose merge_commit_sha matches the queried SHA' do
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: %r{search/issues}))
+          .and_return(multi_search_response)
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: '/repos/RevenueCat/mock-repo-name/pulls/6693'))
+          .and_return({ body: { 'merge_commit_sha' => hash }.to_json })
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: '/repos/RevenueCat/mock-repo-name/pulls/6697'))
+          .and_return({ body: { 'merge_commit_sha' => 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' }.to_json })
+
+        items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 0, 'mock-repo-name', 'main'
+        )
+
+        expect(items.length).to eq(1)
+        expect(items.first['number']).to eq(6693)
+      end
+
+      it 'returns the original list when no candidate matches by merge_commit_sha' do
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: %r{search/issues}))
+          .and_return(multi_search_response)
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: %r{/pulls/\d+}))
+          .and_return({ body: { 'merge_commit_sha' => 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' }.to_json })
+
+        items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 0, 'mock-repo-name', 'main'
+        )
+
+        expect(items.length).to eq(2)
+      end
+
+      it 'returns the original list when more than one candidate matches by merge_commit_sha' do
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: %r{search/issues}))
+          .and_return(multi_search_response)
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: %r{/pulls/\d+}))
+          .and_return({ body: { 'merge_commit_sha' => hash }.to_json })
+
+        items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 0, 'mock-repo-name', 'main'
+        )
+
+        expect(items.length).to eq(2)
+      end
+
+      it 'treats failures while fetching candidate PR details as non-matches' do
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: %r{search/issues}))
+          .and_return(multi_search_response)
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: '/repos/RevenueCat/mock-repo-name/pulls/6693'))
+          .and_return({ body: { 'merge_commit_sha' => hash }.to_json })
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: '/repos/RevenueCat/mock-repo-name/pulls/6697'))
+          .and_raise(StandardError.new('502 Bad Gateway'))
+
+        items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 0, 'mock-repo-name', 'main'
+        )
+
+        expect(items.length).to eq(1)
+        expect(items.first['number']).to eq(6693)
+      end
+
+      it 'sleeps between candidate detail fetches when rate limit sleep is set' do
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: %r{search/issues}))
+          .and_return(multi_search_response)
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: %r{/pulls/\d+}))
+          .and_return({ body: { 'merge_commit_sha' => 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' }.to_json })
+
+        # Once for the initial wait before the search, once per candidate before
+        # its detail fetch (2 candidates).
+        expect_any_instance_of(Object).to receive(:sleep).with(2).exactly(3).times
+
+        Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 2, 'mock-repo-name', 'main'
+        )
+      end
+    end
+
+    context 'when base_branch is empty' do
+      let(:multi_search_response) do
+        {
+          body: {
+            'items' => [
+              { 'number' => 6693, 'title' => 'Originating PR' },
+              { 'number' => 6697, 'title' => 'Stacked PR that brought main commits into its head' }
+            ]
+          }.to_json
+        }
+      end
+
+      it 'still searches and disambiguates without a base filter' do
+        # When base_branch is empty (e.g. detached-HEAD CI on a tag), the search
+        # collapses to the SHA filter alone. Disambiguation by merge_commit_sha
+        # must still produce a single attribution.
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: "/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:+SHA:#{hash}"))
+          .and_return(multi_search_response)
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: '/repos/RevenueCat/mock-repo-name/pulls/6693'))
+          .and_return({ body: { 'merge_commit_sha' => hash }.to_json })
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: '/repos/RevenueCat/mock-repo-name/pulls/6697'))
+          .and_return({ body: { 'merge_commit_sha' => 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' }.to_json })
+
+        items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 0, 'mock-repo-name', ''
+        )
+
+        expect(items.length).to eq(1)
+        expect(items.first['number']).to eq(6693)
+      end
+    end
   end
 
   describe '.extract_pr_number_from_commit_message' do

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -729,7 +729,7 @@ describe Fastlane::Helper::VersioningHelper do
       end
     end
 
-    it 'fails if it finds multiple commits with same sha' do
+    it 'fails if it finds multiple commits with same sha and disambiguation does not narrow it down' do
       setup_commit_search_stubs(hashes_to_responses)
       allow(Fastlane::Actions::GithubApiAction).to receive(:run)
         .with(server_url: server_url,
@@ -738,6 +738,18 @@ describe Fastlane::Helper::VersioningHelper do
               body: {},
               api_token: 'mock-github-token')
         .and_return(duplicate_items_get_commit_2_response)
+      # When disambiguation can't narrow the candidates (here both items return a
+      # `merge_commit_sha` that does not match the queried SHA), the helper falls
+      # back to the original list and the caller errors out with the actionable
+      # message that includes the matching PR numbers.
+      allow(Fastlane::Actions::GithubApiAction).to receive(:run)
+        .with(server_url: server_url,
+              path: '/repos/RevenueCat/mock-repo-name/pulls/1751',
+              http_method: http_method,
+              body: {},
+              api_token: 'mock-github-token')
+        .and_return({ body: { 'merge_commit_sha' => 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' }.to_json })
+
       expect do
         Fastlane::Helper::VersioningHelper.auto_generate_changelog(
           'mock-repo-name',
@@ -747,7 +759,7 @@ describe Fastlane::Helper::VersioningHelper do
           nil,
           nil
         )
-      end.to raise_exception(StandardError)
+      end.to raise_exception(StandardError, /Multiple PRs \(#1751, #1751\) match commit 0e67cdb1c7582ce3e2fd00367acc24db6242c6d6/)
     end
 
     it 'breaking fix is added to breaking changes section' do
@@ -1395,7 +1407,7 @@ describe Fastlane::Helper::VersioningHelper do
       expect(type_of_bump).to eq(:minor)
     end
 
-    it 'fails if it finds multiple commits with same sha' do
+    it 'fails if it finds multiple commits with same sha and disambiguation does not narrow it down' do
       setup_commit_search_stubs(hashes_to_responses)
 
       allow(Fastlane::Actions::GithubApiAction).to receive(:run)
@@ -1405,6 +1417,16 @@ describe Fastlane::Helper::VersioningHelper do
               body: {},
               api_token: 'mock-github-token')
         .and_return(get_duplicate_items_fix_commit_response)
+      # See the analogous spec under `.auto_generate_changelog` for why the
+      # `merge_commit_sha` returned here intentionally does not match.
+      allow(Fastlane::Actions::GithubApiAction).to receive(:run)
+        .with(server_url: server_url,
+              path: '/repos/RevenueCat/mock-repo-name/pulls/1751',
+              http_method: http_method,
+              body: {},
+              api_token: 'mock-github-token')
+        .and_return({ body: { 'merge_commit_sha' => 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' }.to_json })
+
       expect do
         Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
           'mock-repo-name',
@@ -1413,7 +1435,7 @@ describe Fastlane::Helper::VersioningHelper do
           false,
           nil
         )
-      end.to raise_exception(StandardError)
+      end.to raise_exception(StandardError, /Multiple PRs \(#1751, #1751\) match commit 0e67cdb1c7582ce3e2fd00367acc24db6242c6d6/)
     end
 
     it 'skips if it finds commit without a pr associated' do


### PR DESCRIPTION
## Why

GitHub's `SHA:<sha>` PR-search qualifier matches **any PR whose branch contains the commit**, not just the PR that introduced it. When a stacked PR brings the base branch into its head, every commit pulled in matches that stacked PR plus its real originating PR — and `get_pr_resp_items_for_sha` returns both, so `auto_generate_changelog` and `determine_next_version_using_labels` bail out with `Multiple commits found for <sha>`. Empty `base_branch` (e.g. detached-HEAD CI on a tag) makes this strictly more likely.

Reproduced on `purchases-ios` `5.70.0` (failure [here](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/37252/workflows/a2fe4367-7a8d-41ab-a17c-de7dc83e5d04/jobs/552869), originating PR [#6693](https://github.com/RevenueCat/purchases-ios/pull/6693), spurious match [#6697](https://github.com/RevenueCat/purchases-ios/pull/6697)).

## What

When the search returns >1 PRs for the same SHA, fetch each candidate's `merge_commit_sha` (the commit GitHub leaves on the base ref — works for squash, merge-commit, and rebase merges) and keep only PRs whose merge SHA equals the queried commit. If exactly one survives, return it; otherwise return the original list so the caller errors out with an actionable message that lists the ambiguous PR numbers.

Also logs a warning when `base_branch` is empty.

Single-result happy path: zero extra API calls. Public method signatures and behavior on previously-working inputs are unchanged.

## Tests

`bundle exec rake` (rspec + rubocop): **546 examples, 0 failures, no offenses.** New positive specs in `github_helper_spec.rb` for each disambiguation branch; the existing multi-result specs in `versioning_helper_spec.rb` were updated to stub the disambiguation request and assert the new error message.