### PR TITLE
fix: retry pod push on stale CocoaPods spec index

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/pod_push_with_error_handling.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/pod_push_with_error_handling.rb
@@ -46,6 +46,7 @@ module Fastlane
               return false
             end
 
+            FastlaneCore::UI.error("❌ Pod push failed with an unknown error and won't retry. You can rerun this job using SSH. Error: #{e.message}")
             raise PodPushUnknownError, "❌ Pod push failed: #{e.message}"
           end
         end
@@ -59,7 +60,8 @@ module Fastlane
 
       def self.retryable_error?(msg)
         msg.include?("[!] Calling the GitHub commit API timed out.") ||
-          msg.include?("[!] An internal server error occurred. Please check for any known status issues at https://twitter.com/CocoaPods and try again later.")
+          msg.include?("[!] An internal server error occurred. Please check for any known status issues at https://twitter.com/CocoaPods and try again later.") ||
+          msg.include?("None of your spec sources contain a spec satisfying the dependency")
       end
 
       def self.description

--- a/spec/actions/pod_push_with_error_handling_action_spec.rb
+++ b/spec/actions/pod_push_with_error_handling_action_spec.rb
@@ -34,6 +34,8 @@ describe Fastlane::Actions::PodPushWithErrorHandlingAction do
       error_message = "Some unexpected failure"
       allow(Fastlane::Actions::PodPushAction).to receive(:run).and_raise(StandardError.new(error_message))
 
+      expect(FastlaneCore::UI).to receive(:error).with("❌ Pod push failed with an unknown error and won't retry. You can rerun this job using SSH. Error: Some unexpected failure")
+
       expect do
         Fastlane::Actions::PodPushWithErrorHandlingAction.run(path: podspec_path)
       end.to raise_error(Fastlane::Actions::PodPushUnknownError, "❌ Pod push failed: Some unexpected failure")
@@ -64,6 +66,32 @@ describe Fastlane::Actions::PodPushWithErrorHandlingAction do
       )
 
       expect(result).to eq(true) # ✅ Ensure success on the 4th attempt
+    end
+
+    it 'retries up to 3 times when spec sources do not contain a satisfying dependency' do
+      error_message = "None of your spec sources contain a spec satisfying the dependency: `PurchasesHybridCommon (= 18.2.0)`."
+      call_count = 0
+
+      allow(Fastlane::Actions::PodPushAction).to receive(:run) do
+        call_count += 1
+        raise StandardError, error_message if call_count <= 3
+
+        'Successfully pushed'
+      end
+
+      allow_any_instance_of(Object).to receive(:sleep)
+
+      expect(FastlaneCore::UI).to receive(:important).with(/Retrying in \d+ seconds/).exactly(3).times
+      expect(FastlaneCore::UI).to receive(:message).with(/Attempt \d/).exactly(4).times
+
+      result = Fastlane::Actions::PodPushWithErrorHandlingAction.run(
+        path: podspec_path,
+        synchronous: true,
+        verbose: false,
+        allow_warnings: false
+      )
+
+      expect(result).to eq(true)
     end
 
     it 'retries up to 3 times on internal server error' do


### PR DESCRIPTION
## Summary

- Adds `"None of your spec sources contain a spec satisfying the dependency"` as a retryable error in `pod_push_with_error_handling`. This handles the race condition where a dependency podspec (e.g. `PurchasesHybridCommon`) was just pushed but the CocoaPods index hasn't propagated to CI yet — causing `PurchasesHybridCommonUI` push to fail validation.
- Logs an explicit message for unknown (non-retryable) errors: `"❌ Pod push failed with an unknown error and won't retry. You can rerun this job using SSH."`
- Adds test coverage for the stale spec index retry case.

## Test plan

- [ ] All existing specs pass (`bundle exec rspec spec/actions/pod_push_with_error_handling_action_spec.rb`)
- [ ] New test covers the stale spec index retry scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)