### PR TITLE
Skip draft releases in get_releases_between_tags

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -320,10 +320,15 @@ module Fastlane
 
         all_releases = JSON.parse(response[:body])
 
-        # Filters releases between tags
+        # Filters releases between tags. Drafts and prereleases are excluded.
         all_releases.select do |release|
-          version = Gem::Version.new(release["tag_name"])
-          start_tag < version && version <= end_tag && !release["prerelease"]
+          next false if release["draft"] || release["prerelease"]
+
+          tag_name = release["tag_name"]
+          next false unless Gem::Version.correct?(tag_name)
+
+          version = Gem::Version.new(tag_name)
+          start_tag < version && version <= end_tag
         end
       end
 

--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -324,10 +324,7 @@ module Fastlane
         all_releases.select do |release|
           next false if release["draft"] || release["prerelease"]
 
-          tag_name = release["tag_name"]
-          next false unless Gem::Version.correct?(tag_name)
-
-          version = Gem::Version.new(tag_name)
+          version = Gem::Version.new(release["tag_name"])
           start_tag < version && version <= end_tag
         end
       end

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -427,6 +427,83 @@ describe Fastlane::Helper::GitHubHelper do
     end
   end
 
+  describe '.get_releases_between_tags' do
+    let(:server_url) { 'https://api.github.com' }
+    let(:http_method) { 'GET' }
+    let(:github_token) { 'mock-github-token' }
+    let(:repo_name) { 'mock-repo-name' }
+
+    def stub_releases_api_with(releases)
+      allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+        .with(hash_including(
+                server_url: server_url,
+                http_method: http_method,
+                path: "repos/RevenueCat/#{repo_name}/releases?per_page=50",
+                api_token: github_token
+              ))
+        .and_return(body: releases.to_json)
+    end
+
+    it 'returns published non-prerelease releases strictly above start_tag and at-or-below end_tag' do
+      stub_releases_api_with([
+                               { 'tag_name' => '1.38.0', 'draft' => false, 'prerelease' => false },
+                               { 'tag_name' => '1.37.0', 'draft' => false, 'prerelease' => false },
+                               { 'tag_name' => '1.36.0', 'draft' => false, 'prerelease' => false },
+                               { 'tag_name' => '1.35.0', 'draft' => false, 'prerelease' => false },
+                               { 'tag_name' => '1.34.0', 'draft' => false, 'prerelease' => false },
+                               { 'tag_name' => '1.39.0', 'draft' => false, 'prerelease' => false }
+                             ])
+
+      releases = Fastlane::Helper::GitHubHelper.get_releases_between_tags(
+        github_token, '1.34.0', '1.38.0', repo_name
+      )
+
+      expect(releases.map { |r| r['tag_name'] }).to eq(['1.38.0', '1.37.0', '1.36.0', '1.35.0'])
+    end
+
+    it 'excludes prereleases' do
+      stub_releases_api_with([
+                               { 'tag_name' => '1.38.0', 'draft' => false, 'prerelease' => false },
+                               { 'tag_name' => '1.38.0-rc.1', 'draft' => false, 'prerelease' => true },
+                               { 'tag_name' => '1.37.0', 'draft' => false, 'prerelease' => false }
+                             ])
+
+      releases = Fastlane::Helper::GitHubHelper.get_releases_between_tags(
+        github_token, '1.36.0', '1.38.0', repo_name
+      )
+
+      expect(releases.map { |r| r['tag_name'] }).to eq(['1.38.0', '1.37.0'])
+    end
+
+    it 'excludes draft releases (which may carry placeholder tag_name values)' do
+      stub_releases_api_with([
+                               { 'tag_name' => '1.38.0', 'draft' => false, 'prerelease' => false },
+                               { 'tag_name' => '1.37.0', 'draft' => false, 'prerelease' => false },
+                               { 'tag_name' => 'v0.0.1', 'draft' => true,  'prerelease' => true }
+                             ])
+
+      releases = Fastlane::Helper::GitHubHelper.get_releases_between_tags(
+        github_token, '1.36.0', '1.38.0', repo_name
+      )
+
+      expect(releases.map { |r| r['tag_name'] }).to eq(['1.38.0', '1.37.0'])
+    end
+
+    it 'skips releases whose tag_name is not a valid Gem::Version' do
+      stub_releases_api_with([
+                               { 'tag_name' => '1.38.0', 'draft' => false, 'prerelease' => false },
+                               { 'tag_name' => 'not-a-version', 'draft' => false, 'prerelease' => false },
+                               { 'tag_name' => '1.37.0', 'draft' => false, 'prerelease' => false }
+                             ])
+
+      releases = Fastlane::Helper::GitHubHelper.get_releases_between_tags(
+        github_token, '1.36.0', '1.38.0', repo_name
+      )
+
+      expect(releases.map { |r| r['tag_name'] }).to eq(['1.38.0', '1.37.0'])
+    end
+  end
+
   describe '.create_github_release' do
     let(:server_url) { 'https://api.github.com' }
     let(:repo_name) { 'mock-repo-name' }

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -488,20 +488,6 @@ describe Fastlane::Helper::GitHubHelper do
 
       expect(releases.map { |r| r['tag_name'] }).to eq(['1.38.0', '1.37.0'])
     end
-
-    it 'skips releases whose tag_name is not a valid Gem::Version' do
-      stub_releases_api_with([
-                               { 'tag_name' => '1.38.0', 'draft' => false, 'prerelease' => false },
-                               { 'tag_name' => 'not-a-version', 'draft' => false, 'prerelease' => false },
-                               { 'tag_name' => '1.37.0', 'draft' => false, 'prerelease' => false }
-                             ])
-
-      releases = Fastlane::Helper::GitHubHelper.get_releases_between_tags(
-        github_token, '1.36.0', '1.38.0', repo_name
-      )
-
-      expect(releases.map { |r| r['tag_name'] }).to eq(['1.38.0', '1.37.0'])
-    end
   end
 
   describe '.create_github_release' do


### PR DESCRIPTION
## Why

`automatic_bump` for `react-native-purchases` failed in [job 32418](https://app.circleci.com/pipelines/github/RevenueCat/react-native-purchases/6812/workflows/dd8ea081-601f-429e-ac19-777d3545ac0c/jobs/32418):

```
Malformed version number string v0.0.1 (ArgumentError)
  from .../github_helper.rb:325:in `block in get_releases_between_tags'
```

`get_releases_between_tags` lists `repos/RevenueCat/<repo>/releases?per_page=50` and filters only by `!prerelease`. The GitHub API also returns **draft** releases to tokens that can see them, and a draft's `tag_name` is whatever was typed in the UI — it doesn't have to be a real git tag. `purchases-js` has [a leftover "First Release" draft](https://github.com/RevenueCat/purchases-js/releases/tag/untagged-425640d847a3f8dc47b7) from November 2023 with `tag_name: "v0.0.1"` and no underlying ref (`html_url` is `releases/tag/untagged-425640d847a3f8dc47b7`, `git/refs/tags/v0.0.1` → 404). `Gem::Version.new("v0.0.1")` raises and aborts the whole `select`, taking `auto_generate_changelog` and the release with it.

This will hit any hybrid that opts into `include_purchases_js: true` on the next PHC-bump release (today `react-native-purchases`; soon `purchases-flutter` and `purchases-capacitor`).

## What

Skip drafts alongside prereleases in `get_releases_between_tags`. Drafts shouldn't show up in user-facing changelogs anyway. Tag names that don't parse as `Gem::Version` are still left as a hard error as those would be real, published releases and we want to know.

## Tests

`bundle exec rake` (rspec + rubocop): **550 examples, 0 failures, no offenses.** New `describe '.get_releases_between_tags'` block covers the in-range happy path, prerelease exclusion, and draft exclusion using the `v0.0.1` placeholder shape.