### PR TITLE
Ping SDK on-call in integration test feed channel on failure

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/slack_backend_integration_test_results.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/slack_backend_integration_test_results.rb
@@ -5,6 +5,8 @@ require_relative '../helper/revenuecat_internal_helper'
 module Fastlane
   module Actions
     class SlackBackendIntegrationTestResultsAction < Action
+      ON_CALL_SDK_MENTION = "<!subteam^S0939BTV0SY|oncall-sdk>"
+
       # rubocop:disable Metrics/PerceivedComplexity
       def self.run(params)
         if ENV["CI"] != "true"
@@ -18,7 +20,7 @@ module Fastlane
 
         environment = params[:environment]
         success = params[:success] || false
-        message_binary_solo_on_failure = params[:message_binary_solo_on_failure] != false
+        message_binary_solo_on_failure = params[:message_binary_solo_on_failure] == true
 
         version = params[:version] || begin
           File.readlines(File.expand_path('.version', Dir.pwd)).first&.strip
@@ -35,18 +37,19 @@ module Fastlane
                                         end
 
         slack_url_feed = ENV.fetch("SLACK_URL_BACKEND_INTEGRATION_TESTS") { UI.user_error!("Missing required SLACK_URL_BACKEND_INTEGRATION_TESTS environment variable. Make sure to provide the slack-secrets CircleCI context.") }
-        slack_url_binary_solo = ENV.fetch("SLACK_URL_BINARY_SOLO") { UI.user_error!("Missing required SLACK_URL_BINARY_SOLO environment variable. Make sure to provide the slack-secrets CircleCI context.") }
+
+        failure_message = "#{ON_CALL_SDK_MENTION} #{platform} backend integration tests failed."
 
         message_feed =
           if success
             "#{platform} backend integration tests finished successfully."
           else
-            "#{platform} backend integration tests failed. On-call is pinged in <#CL407G2QL|binary-solo>."
+            failure_message
           end
 
         message_binary_solo =
-          unless success
-            "<!subteam^S0939BTV0SY|oncall-sdk> #{platform} backend integration tests failed."
+          if !success && message_binary_solo_on_failure
+            failure_message
           end
 
         slack_options = {
@@ -90,7 +93,9 @@ module Fastlane
           }
         }
 
-        if message_binary_solo && message_binary_solo_on_failure
+        if message_binary_solo
+          slack_url_binary_solo = ENV.fetch("SLACK_URL_BINARY_SOLO") { UI.user_error!("Missing required SLACK_URL_BINARY_SOLO environment variable. Make sure to provide the slack-secrets CircleCI context.") }
+
           other_action.slack(
             slack_options.merge(
               message: message_binary_solo,
@@ -136,9 +141,9 @@ module Fastlane
                                        optional: true,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :message_binary_solo_on_failure,
-                                       description: "Whether to ping the binary-solo / on-call group when tests fail",
+                                       description: "Whether to also notify binary-solo when tests fail. On-call is always pinged in the backend integration tests feed channel on failure",
                                        optional: true,
-                                       default_value: true,
+                                       default_value: false,
                                        is_string: false)
         ]
       end

--- a/spec/actions/slack_backend_integration_test_results_action_spec.rb
+++ b/spec/actions/slack_backend_integration_test_results_action_spec.rb
@@ -98,27 +98,18 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
     end
 
     describe 'when tests fail' do
-      it 'sends failure messages to both feed and binary-solo channels' do
-        expected_binary_solo_message = "<!subteam^S0939BTV0SY|oncall-sdk> #{platform} backend integration tests failed."
-        expected_feed_message = "#{platform} backend integration tests failed. On-call is pinged in <#CL407G2QL|binary-solo>."
+      it 'pings on-call in the feed channel by default' do
+        expected_feed_message = "<!subteam^S0939BTV0SY|oncall-sdk> #{platform} backend integration tests failed."
 
-        # Expect call to binary-solo (with on-call ping)
-        expect(mock_other_action).to receive(:slack).once.with(
-          hash_including(
-            message: expected_binary_solo_message,
-            slack_url: slack_url_binary_solo,
-            success: false
-          )
-        ).ordered
+        expect(mock_other_action).not_to receive(:slack).with(hash_including(slack_url: slack_url_binary_solo))
 
-        # Expect call to feed channel
         expect(mock_other_action).to receive(:slack).once.with(
           hash_including(
             message: expected_feed_message,
             slack_url: slack_url_feed,
             success: false
           )
-        ).ordered
+        )
 
         action_instance.run(
           environment: environment,
@@ -128,32 +119,36 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
         )
       end
 
-      it 'does not notify binary-solo when message_binary_solo_on_failure is explicitly false' do
-        expected_feed_message = "#{platform} backend integration tests failed. On-call is pinged in <#CL407G2QL|binary-solo>."
+      it 'also notifies binary-solo when message_binary_solo_on_failure is explicitly true' do
+        expected_message = "<!subteam^S0939BTV0SY|oncall-sdk> #{platform} backend integration tests failed."
 
-        # Expect no binary-solo call
-        expect(mock_other_action).not_to receive(:slack).with(hash_including(slack_url: slack_url_binary_solo))
-
-        # Expect feed channel only
         expect(mock_other_action).to receive(:slack).once.with(
           hash_including(
-            message: expected_feed_message,
+            message: expected_message,
+            slack_url: slack_url_binary_solo,
+            success: false
+          )
+        ).ordered
+
+        expect(mock_other_action).to receive(:slack).once.with(
+          hash_including(
+            message: expected_message,
             slack_url: slack_url_feed,
             success: false
           )
-        )
+        ).ordered
 
         action_instance.run(
           environment: environment,
           success: false,
           version: version,
           platform: platform,
-          message_binary_solo_on_failure: false
+          message_binary_solo_on_failure: true
         )
       end
 
-      it 'defaults to false when success parameter is not provided' do
-        expect(mock_other_action).to receive(:slack).twice
+      it 'defaults to failure when success parameter is not provided' do
+        expect(mock_other_action).to receive(:slack).once
 
         action_instance.run(
           environment: environment,
@@ -419,7 +414,7 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
         end.to raise_error(FastlaneCore::Interface::FastlaneError)
       end
 
-      it 'fails when SLACK_URL_BINARY_SOLO is missing' do
+      it 'fails when SLACK_URL_BINARY_SOLO is missing and binary-solo notifications are enabled' do
         ENV.delete('SLACK_URL_BINARY_SOLO')
 
         expect(FastlaneCore::UI).to receive(:user_error!)
@@ -429,11 +424,25 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
         expect do
           action_instance.run(
             environment: environment,
-            success: true,
+            success: false,
             version: version,
-            platform: platform
+            platform: platform,
+            message_binary_solo_on_failure: true
           )
         end.to raise_error(FastlaneCore::Interface::FastlaneError)
+      end
+
+      it 'does not require SLACK_URL_BINARY_SOLO when binary-solo notifications are disabled' do
+        ENV.delete('SLACK_URL_BINARY_SOLO')
+
+        expect(mock_other_action).to receive(:slack).once
+
+        action_instance.run(
+          environment: environment,
+          success: true,
+          version: version,
+          platform: platform
+        )
       end
     end
 


### PR DESCRIPTION
## Summary
- Ping `@oncall-sdk` directly in `#feed-sdk-backend-integration-tests` when backend integration tests fail
- Remove the misleading "On-call is pinged in #binary-solo" feed message
- Make `#binary-solo` failure notifications opt-in via `message_binary_solo_on_failure: true`

## Test plan
- [x] `bundle exec rspec spec/actions/slack_backend_integration_test_results_action_spec.rb`


Made with [Cursor](https://cursor.com)