### PR TITLE
Stop (double) requesting reviewers for PHC bump PRs

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/bump_phc_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/bump_phc_version_action.rb
@@ -124,7 +124,7 @@ module Fastlane
           pr_title = "[AUTOMATIC BUMP] #{pr_title}"
         end
 
-        Helper::RevenuecatInternalHelper.create_pr(pr_title, body, repo_name, base_branch, new_branch_name, github_pr_token, labels: labels, enable_auto_merge: enable_auto_merge || false, slack_url: slack_url)
+        Helper::RevenuecatInternalHelper.create_pr(pr_title, body, repo_name, base_branch, new_branch_name, github_pr_token, labels: labels, team_reviewers: [], enable_auto_merge: enable_auto_merge || false, slack_url: slack_url)
       end
     end
   end

--- a/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/revenuecat_internal_helper.rb
@@ -173,8 +173,8 @@ module Fastlane
         Actions::PushToGitRemoteAction.run(remote: 'origin')
       end
 
-      def self.create_pr(title, body, repo_name, base_branch, head_branch, github_pr_token, labels: [], enable_auto_merge: false, slack_url: nil)
-        pr_url = Actions::CreatePullRequestAction.run(
+      def self.create_pr(title, body, repo_name, base_branch, head_branch, github_pr_token, labels: [], team_reviewers: ['coresdk'], enable_auto_merge: false, slack_url: nil)
+        options = {
           api_token: github_pr_token,
           title: title,
           base: base_branch,
@@ -182,9 +182,11 @@ module Fastlane
           repo: "RevenueCat/#{repo_name}",
           head: head_branch,
           api_url: 'https://api.github.com',
-          labels: labels,
-          team_reviewers: ['coresdk']
-        )
+          labels: labels
+        }
+        options[:team_reviewers] = team_reviewers unless team_reviewers.empty?
+
+        pr_url = Actions::CreatePullRequestAction.run(**options)
 
         return unless enable_auto_merge
 

--- a/spec/actions/bump_phc_version_action_spec.rb
+++ b/spec/actions/bump_phc_version_action_spec.rb
@@ -50,7 +50,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         .once
       message = "Updates purchases-hybrid-common to 1.13.0"
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr)
-        .with(message, message, mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, labels: labels, enable_auto_merge: false, slack_url: nil)
+        .with(message, message, mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, labels: labels, team_reviewers: [], enable_auto_merge: false, slack_url: nil)
         .once
 
       Fastlane::Actions::BumpPhcVersionAction.run(
@@ -98,7 +98,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
 
       message = "Updates purchases-hybrid-common to 1.13.0"
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr)
-        .with("[AUTOMATIC BUMP] #{message}", "**This is an automatic bump.**\n\n#{message}", mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, labels: labels, enable_auto_merge: false, slack_url: nil)
+        .with("[AUTOMATIC BUMP] #{message}", "**This is an automatic bump.**\n\n#{message}", mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, labels: labels, team_reviewers: [], enable_auto_merge: false, slack_url: nil)
 
       Fastlane::Actions::BumpPhcVersionAction.run(
         current_version: current_version,
@@ -117,7 +117,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
 
       message = "Updates purchases-hybrid-common to 1.13.0"
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr)
-        .with("[AUTOMATIC BUMP] #{message}", "**This is an automatic bump.**\n\n#{message}", mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, labels: labels, enable_auto_merge: true, slack_url: nil)
+        .with("[AUTOMATIC BUMP] #{message}", "**This is an automatic bump.**\n\n#{message}", mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, labels: labels, team_reviewers: [], enable_auto_merge: true, slack_url: nil)
 
       Fastlane::Actions::BumpPhcVersionAction.run(
         current_version: current_version,
@@ -178,7 +178,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         .once
       message = "Updates purchases-hybrid-common to #{new_version}"
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr)
-        .with(message, message, mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, labels: labels, enable_auto_merge: false, slack_url: nil)
+        .with(message, message, mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, labels: labels, team_reviewers: [], enable_auto_merge: false, slack_url: nil)
         .once
 
       Fastlane::Actions::BumpPhcVersionAction.run(
@@ -213,7 +213,7 @@ describe Fastlane::Actions::BumpPhcVersionAction do
         .once
       message = "Updates purchases-hybrid-common to 1.12.1"
       expect(Fastlane::Helper::RevenuecatInternalHelper).to receive(:create_pr)
-        .with(message, message, mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, labels: ['pr:phc_dependencies'], enable_auto_merge: false, slack_url: nil)
+        .with(message, message, mock_repo_name, base_branch, new_branch_name, mock_github_pr_token, labels: ['pr:phc_dependencies'], team_reviewers: [], enable_auto_merge: false, slack_url: nil)
         .once
 
       Fastlane::Actions::BumpPhcVersionAction.run(

--- a/spec/helper/revenuecat_internal_helper_spec.rb
+++ b/spec/helper/revenuecat_internal_helper_spec.rb
@@ -918,6 +918,22 @@ describe Fastlane::Helper::RevenuecatInternalHelper do
         Fastlane::Helper::RevenuecatInternalHelper.create_pr('fake-title', 'fake-changelog', 'fake-repo-name', 'main', 'fake-branch', 'fake-github-pr-token', labels: ['label_1', 'label_2'], enable_auto_merge: true)
       end.not_to raise_error
     end
+
+    it 'creates pr with explicit reviewers when provided' do
+      expect(Fastlane::Actions::CreatePullRequestAction).to receive(:run)
+        .with(
+          api_token: 'fake-github-pr-token',
+          title: 'fake-title',
+          base: 'main',
+          body: 'fake-changelog',
+          repo: 'RevenueCat/fake-repo-name',
+          head: 'fake-branch',
+          api_url: 'https://api.github.com',
+          labels: ['label_1', 'label_2'],
+          team_reviewers: ['team1', 'team2']
+        ).once
+      Fastlane::Helper::RevenuecatInternalHelper.create_pr('fake-title', 'fake-changelog', 'fake-repo-name', 'main', 'fake-branch', 'fake-github-pr-token', labels: ['label_1', 'label_2'], team_reviewers: ['team1', 'team2'])
+    end
   end
 
   describe '.create_pr_if_necessary' do


### PR DESCRIPTION
As our team is already listed in the codeowners files we were getting duplicate review requests. NABD but this should no longer request our team's review specifically as well.