### PR TITLE
Render on-call Slack mention via Block Kit so it works on mobile

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/slack_backend_integration_test_results.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/slack_backend_integration_test_results.rb
@@ -41,15 +41,15 @@ module Fastlane
 
         post_messages(
           success: success,
-          notify_binary_solo: message_binary_solo_on_failure,
+          notify_binary_solo_on_failure: message_binary_solo_on_failure,
           feed_message: message_feed,
           fields: detail_fields,
           build_url: build_url
         )
       end
 
-      def self.post_messages(success:, notify_binary_solo:, feed_message:, fields:, build_url:)
-        if notify_binary_solo && !success
+      def self.post_messages(success:, notify_binary_solo_on_failure:, feed_message:, fields:, build_url:)
+        if notify_binary_solo_on_failure && !success
           slack_url_binary_solo = ENV.fetch("SLACK_URL_BINARY_SOLO") { UI.user_error!("Missing required SLACK_URL_BINARY_SOLO environment variable. Make sure to provide the slack-secrets CircleCI context.") }
 
           post_to_slack(slack_url_binary_solo, build_payload(feed_message, success, fields, build_url))

--- a/lib/fastlane/plugin/revenuecat_internal/actions/slack_backend_integration_test_results.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/slack_backend_integration_test_results.rb
@@ -1,5 +1,8 @@
 require 'fastlane/action'
 require 'fastlane_core/configuration/config_item'
+require 'net/http'
+require 'uri'
+require 'json'
 require_relative '../helper/revenuecat_internal_helper'
 
 module Fastlane
@@ -47,71 +50,89 @@ module Fastlane
             failure_message
           end
 
-        message_binary_solo =
-          if !success && message_binary_solo_on_failure
-            failure_message
-          end
+        detail_fields = [
+          { title: "SDK", value: repo_name },
+          { title: "SDK version", value: major_version },
+          { title: "Git branch", value: Actions.sh("git rev-parse --abbrev-ref HEAD").strip },
+          { title: "Environment", value: environment },
+          { title: "Test suite", value: ENV.fetch("CIRCLE_JOB", nil) }
+        ]
+        build_url = ENV.fetch("CIRCLE_BUILD_URL", nil)
 
-        slack_options = {
-          success: success,
-          default_payloads: [],
-          attachment_properties: {
-            actions: [
+        if !success && message_binary_solo_on_failure
+          slack_url_binary_solo = ENV.fetch("SLACK_URL_BINARY_SOLO") { UI.user_error!("Missing required SLACK_URL_BINARY_SOLO environment variable. Make sure to provide the slack-secrets CircleCI context.") }
+
+          post_to_slack(slack_url_binary_solo, build_payload(failure_message, success, detail_fields, build_url))
+        end
+
+        post_to_slack(slack_url_feed, build_payload(message_feed, success, detail_fields, build_url))
+      end
+      # rubocop:enable Metrics/PerceivedComplexity
+
+      # Builds a Block Kit message payload.
+      #
+      # The headline (which carries the on-call mention on failure) is placed in a top-level
+      # `blocks` section so it renders consistently across all Slack clients, including mobile.
+      # Legacy secondary attachments render mentions unreliably (they can show up as
+      # "@[group unavailable]" on mobile), so we only use an attachment to keep the colored
+      # status bar, and put its secondary content (the run details) in Block Kit blocks too.
+      # See https://docs.slack.dev/messaging/migrating-outmoded-message-compositions-to-blocks
+      def self.build_payload(message, success, fields, build_url)
+        detail_blocks = [
+          {
+            type: "section",
+            fields: fields.map do |field|
+              { type: "mrkdwn", text: "*#{field[:title]}*\n#{field[:value]}" }
+            end
+          }
+        ]
+
+        unless build_url.to_s.empty?
+          detail_blocks << {
+            type: "actions",
+            elements: [
               {
                 type: "button",
-                text: "View CircleCI logs",
-                url: ENV.fetch("CIRCLE_BUILD_URL", nil)
-              }
-            ],
-            fields: [
-              {
-                title: "SDK",
-                value: repo_name,
-                short: true
-              },
-              {
-                title: "SDK version",
-                value: major_version,
-                short: true
-              },
-              {
-                title: "Git branch",
-                value: Actions.sh("git rev-parse --abbrev-ref HEAD"),
-                short: true
-              },
-              {
-                title: "Environment",
-                value: environment,
-                short: true
-              },
-              {
-                title: "Test suite",
-                value: ENV.fetch("CIRCLE_JOB", nil),
-                short: false
+                text: { type: "plain_text", text: "View CircleCI logs" },
+                url: build_url
               }
             ]
           }
-        }
-
-        if message_binary_solo
-          slack_url_binary_solo = ENV.fetch("SLACK_URL_BINARY_SOLO") { UI.user_error!("Missing required SLACK_URL_BINARY_SOLO environment variable. Make sure to provide the slack-secrets CircleCI context.") }
-
-          other_action.slack(
-            slack_options.merge(
-              message: message_binary_solo,
-              slack_url: slack_url_binary_solo
-            )
-          )
         end
 
-        other_action.slack(
-          slack_options.merge(
-            message: message_feed,
-            slack_url: slack_url_feed
-          )
-        )
+        {
+          text: message,
+          blocks: [
+            {
+              type: "section",
+              text: { type: "mrkdwn", text: message }
+            }
+          ],
+          attachments: [
+            {
+              color: success ? "good" : "danger",
+              blocks: detail_blocks
+            }
+          ]
+        }
       end
-      # rubocop:enable Metrics/PerceivedComplexity
+
+      def self.post_to_slack(slack_url, payload)
+        uri = URI.parse(slack_url)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == "https"
+
+        request = Net::HTTP::Post.new(uri.request_uri, "Content-Type" => "application/json")
+        request.body = payload.to_json
+
+        response = http.request(request)
+
+        unless response.kind_of?(Net::HTTPSuccess)
+          UI.user_error!("Error sending Slack notification: #{response.code} #{response.body}")
+        end
+
+        UI.success("Successfully sent Slack notification")
+      end
 
       def self.description
         "Sends backend integration test results to Slack channels with detailed CircleCI context"

--- a/lib/fastlane/plugin/revenuecat_internal/actions/slack_backend_integration_test_results.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/slack_backend_integration_test_results.rb
@@ -69,14 +69,6 @@ module Fastlane
       end
       # rubocop:enable Metrics/PerceivedComplexity
 
-      # Builds a Block Kit message payload.
-      #
-      # The headline (which carries the on-call mention on failure) is placed in a top-level
-      # `blocks` section so it renders consistently across all Slack clients, including mobile.
-      # Legacy secondary attachments render mentions unreliably (they can show up as
-      # "@[group unavailable]" on mobile), so we only use an attachment to keep the colored
-      # status bar, and put its secondary content (the run details) in Block Kit blocks too.
-      # See https://docs.slack.dev/messaging/migrating-outmoded-message-compositions-to-blocks
       def self.build_payload(message, success, fields, build_url)
         detail_blocks = [
           {

--- a/lib/fastlane/plugin/revenuecat_internal/actions/slack_backend_integration_test_results.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/slack_backend_integration_test_results.rb
@@ -10,36 +10,16 @@ module Fastlane
     class SlackBackendIntegrationTestResultsAction < Action
       ON_CALL_SDK_MENTION = "<!subteam^S0939BTV0SY|oncall-sdk>"
 
-      # rubocop:disable Metrics/PerceivedComplexity
       def self.run(params)
-        if ENV["CI"] != "true"
-          UI.message("Not running in CI environment, skipping slack notification.")
-          return
-        end
-        unless ENV["CIRCLE_PULL_REQUEST"].to_s.empty?
-          UI.message("Running in pull request context, skipping slack notification.")
-          return
-        end
+        return unless should_send_notification?
 
         environment = params[:environment]
         success = params[:success] || false
         message_binary_solo_on_failure = params[:message_binary_solo_on_failure] == true
 
-        version = params[:version] || begin
-          File.readlines(File.expand_path('.version', Dir.pwd)).first&.strip
-        rescue StandardError
-          nil
-        end || UI.user_error!("Missing version parameter")
-
-        major_version = version.split('.')[0]
         repo_name = ENV.fetch("CIRCLE_PROJECT_REPONAME", nil)
-        platform = params[:platform] || case repo_name
-                                        when "purchases-android" then "Android"
-                                        when "purchases-ios" then "iOS"
-                                        else UI.user_error!("Missing platform parameter")
-                                        end
-
-        slack_url_feed = ENV.fetch("SLACK_URL_BACKEND_INTEGRATION_TESTS") { UI.user_error!("Missing required SLACK_URL_BACKEND_INTEGRATION_TESTS environment variable. Make sure to provide the slack-secrets CircleCI context.") }
+        major_version = resolve_version(params).split('.')[0]
+        platform = resolve_platform(params, repo_name)
 
         failure_message = "#{ON_CALL_SDK_MENTION} #{platform} backend integration tests failed."
 
@@ -59,15 +39,57 @@ module Fastlane
         ]
         build_url = ENV.fetch("CIRCLE_BUILD_URL", nil)
 
-        if !success && message_binary_solo_on_failure
+        post_messages(
+          success: success,
+          notify_binary_solo: message_binary_solo_on_failure,
+          feed_message: message_feed,
+          fields: detail_fields,
+          build_url: build_url
+        )
+      end
+
+      def self.post_messages(success:, notify_binary_solo:, feed_message:, fields:, build_url:)
+        if notify_binary_solo && !success
           slack_url_binary_solo = ENV.fetch("SLACK_URL_BINARY_SOLO") { UI.user_error!("Missing required SLACK_URL_BINARY_SOLO environment variable. Make sure to provide the slack-secrets CircleCI context.") }
 
-          post_to_slack(slack_url_binary_solo, build_payload(failure_message, success, detail_fields, build_url))
+          post_to_slack(slack_url_binary_solo, build_payload(feed_message, success, fields, build_url))
         end
 
-        post_to_slack(slack_url_feed, build_payload(message_feed, success, detail_fields, build_url))
+        slack_url_feed = ENV.fetch("SLACK_URL_BACKEND_INTEGRATION_TESTS") { UI.user_error!("Missing required SLACK_URL_BACKEND_INTEGRATION_TESTS environment variable. Make sure to provide the slack-secrets CircleCI context.") }
+
+        post_to_slack(slack_url_feed, build_payload(feed_message, success, fields, build_url))
       end
-      # rubocop:enable Metrics/PerceivedComplexity
+
+      def self.should_send_notification?
+        if ENV["CI"] != "true"
+          UI.message("Not running in CI environment, skipping slack notification.")
+          return false
+        end
+        unless ENV["CIRCLE_PULL_REQUEST"].to_s.empty?
+          UI.message("Running in pull request context, skipping slack notification.")
+          return false
+        end
+
+        true
+      end
+
+      def self.resolve_version(params)
+        version = params[:version] || begin
+          File.readlines(File.expand_path('.version', Dir.pwd)).first&.strip
+        rescue StandardError
+          nil
+        end
+
+        version || UI.user_error!("Missing version parameter")
+      end
+
+      def self.resolve_platform(params, repo_name)
+        params[:platform] || case repo_name
+                             when "purchases-android" then "Android"
+                             when "purchases-ios" then "iOS"
+                             else UI.user_error!("Missing platform parameter")
+                             end
+      end
 
       def self.build_payload(message, success, fields, build_url)
         detail_blocks = [

--- a/spec/actions/slack_backend_integration_test_results_action_spec.rb
+++ b/spec/actions/slack_backend_integration_test_results_action_spec.rb
@@ -10,8 +10,6 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
     let(:repo_name) { 'purchases-ios' }
     let(:git_branch) { 'main' }
     let(:action_instance) { Fastlane::Actions::SlackBackendIntegrationTestResultsAction }
-    let(:mock_runner) { double('Runner') }
-    let(:mock_other_action) { double('OtherAction') }
 
     before(:each) do
       ENV['CI'] = 'true'
@@ -27,11 +25,7 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
       allow(Fastlane::Actions).to receive(:sh)
         .with("git rev-parse --abbrev-ref HEAD")
         .and_return(git_branch)
-      allow(mock_other_action).to receive(:slack)
-      allow(mock_other_action).to receive(:runner).and_return(mock_runner)
-      allow(mock_runner).to receive(:trigger_action_by_name)
-      allow(action_instance).to receive(:runner).and_return(mock_runner)
-      allow(action_instance).to receive(:other_action).and_return(mock_other_action)
+      allow(action_instance).to receive(:post_to_slack)
     end
 
     after(:each) do
@@ -44,17 +38,31 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
       ENV['CIRCLE_PULL_REQUEST'] = @backup_circle_pull_request if @backup_circle_pull_request
     end
 
+    # Returns the headline text rendered in the top-level section block, which is where the
+    # on-call mention lives so it renders reliably on every Slack client (including mobile).
+    def headline_text(payload)
+      payload[:blocks].first[:text][:text]
+    end
+
+    def attachment(payload)
+      payload[:attachments].first
+    end
+
+    def field_values(payload)
+      attachment(payload)[:blocks].first[:fields].map { |field| field[:text] }
+    end
+
     describe 'when tests succeed' do
       it 'sends success message to feed channel only' do
         expected_message = "#{platform} backend integration tests finished successfully."
 
-        expect(mock_other_action).to receive(:slack).once.with(
-          hash_including(
-            message: expected_message,
-            slack_url: slack_url_feed,
-            success: true
-          )
-        )
+        expect(action_instance).not_to receive(:post_to_slack).with(slack_url_binary_solo, anything)
+        expect(action_instance).to receive(:post_to_slack).once do |url, payload|
+          expect(url).to eq(slack_url_feed)
+          expect(payload[:text]).to eq(expected_message)
+          expect(headline_text(payload)).to eq(expected_message)
+          expect(attachment(payload)[:color]).to eq('good')
+        end
 
         action_instance.run(
           environment: environment,
@@ -64,29 +72,22 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
         )
       end
 
-      it 'includes correct attachment fields' do
-        expect(mock_other_action).to receive(:slack).once.with(
-          hash_including(
-            success: true,
-            default_payloads: [],
-            attachment_properties: hash_including(
-              fields: array_including(
-                hash_including(title: 'SDK', value: repo_name, short: true),
-                hash_including(title: 'SDK version', value: '8', short: true),
-                hash_including(title: 'Git branch', value: git_branch, short: true),
-                hash_including(title: 'Environment', value: environment, short: true),
-                hash_including(title: 'Test suite', value: circle_job, short: false)
-              ),
-              actions: array_including(
-                hash_including(
-                  type: 'button',
-                  text: 'View CircleCI logs',
-                  url: circle_build_url
-                )
-              )
-            )
+      it 'includes correct details and CircleCI logs button' do
+        expect(action_instance).to receive(:post_to_slack).once do |_url, payload|
+          expect(field_values(payload)).to include(
+            "*SDK*\n#{repo_name}",
+            "*SDK version*\n8",
+            "*Git branch*\n#{git_branch}",
+            "*Environment*\n#{environment}",
+            "*Test suite*\n#{circle_job}"
           )
-        )
+
+          actions_block = attachment(payload)[:blocks].find { |block| block[:type] == 'actions' }
+          expect(actions_block).not_to be_nil
+          button = actions_block[:elements].first
+          expect(button[:text][:text]).to eq('View CircleCI logs')
+          expect(button[:url]).to eq(circle_build_url)
+        end
 
         action_instance.run(
           environment: environment,
@@ -101,15 +102,13 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
       it 'pings on-call in the feed channel by default' do
         expected_feed_message = "<!subteam^S0939BTV0SY|oncall-sdk> #{platform} backend integration tests failed."
 
-        expect(mock_other_action).not_to receive(:slack).with(hash_including(slack_url: slack_url_binary_solo))
-
-        expect(mock_other_action).to receive(:slack).once.with(
-          hash_including(
-            message: expected_feed_message,
-            slack_url: slack_url_feed,
-            success: false
-          )
-        )
+        expect(action_instance).not_to receive(:post_to_slack).with(slack_url_binary_solo, anything)
+        expect(action_instance).to receive(:post_to_slack).once do |url, payload|
+          expect(url).to eq(slack_url_feed)
+          expect(payload[:text]).to eq(expected_feed_message)
+          expect(headline_text(payload)).to eq(expected_feed_message)
+          expect(attachment(payload)[:color]).to eq('danger')
+        end
 
         action_instance.run(
           environment: environment,
@@ -122,21 +121,14 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
       it 'also notifies binary-solo when message_binary_solo_on_failure is explicitly true' do
         expected_message = "<!subteam^S0939BTV0SY|oncall-sdk> #{platform} backend integration tests failed."
 
-        expect(mock_other_action).to receive(:slack).once.with(
-          hash_including(
-            message: expected_message,
-            slack_url: slack_url_binary_solo,
-            success: false
-          )
-        ).ordered
-
-        expect(mock_other_action).to receive(:slack).once.with(
-          hash_including(
-            message: expected_message,
-            slack_url: slack_url_feed,
-            success: false
-          )
-        ).ordered
+        expect(action_instance).to receive(:post_to_slack).once.ordered do |url, payload|
+          expect(url).to eq(slack_url_binary_solo)
+          expect(headline_text(payload)).to eq(expected_message)
+        end
+        expect(action_instance).to receive(:post_to_slack).once.ordered do |url, payload|
+          expect(url).to eq(slack_url_feed)
+          expect(headline_text(payload)).to eq(expected_message)
+        end
 
         action_instance.run(
           environment: environment,
@@ -148,7 +140,10 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
       end
 
       it 'defaults to failure when success parameter is not provided' do
-        expect(mock_other_action).to receive(:slack).once
+        expect(action_instance).to receive(:post_to_slack).once do |url, payload|
+          expect(url).to eq(slack_url_feed)
+          expect(attachment(payload)[:color]).to eq('danger')
+        end
 
         action_instance.run(
           environment: environment,
@@ -160,7 +155,7 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
 
     describe 'version handling' do
       it 'uses provided version parameter' do
-        expect(mock_other_action).to receive(:slack).once
+        expect(action_instance).to receive(:post_to_slack).once
 
         action_instance.run(
           environment: environment,
@@ -175,15 +170,9 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
           .with(File.expand_path('.version', Dir.pwd))
           .and_return(["10.0.0\n"])
 
-        expect(mock_other_action).to receive(:slack).once.with(
-          hash_including(
-            attachment_properties: hash_including(
-              fields: array_including(
-                hash_including(title: 'SDK version', value: '10')
-              )
-            )
-          )
-        )
+        expect(action_instance).to receive(:post_to_slack).once do |_url, payload|
+          expect(field_values(payload)).to include("*SDK version*\n10")
+        end
 
         action_instance.run(
           environment: environment,
@@ -197,15 +186,9 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
           .with(File.expand_path('.version', Dir.pwd))
           .and_return(["  11.0.0  \n"])
 
-        expect(mock_other_action).to receive(:slack).once.with(
-          hash_including(
-            attachment_properties: hash_including(
-              fields: array_including(
-                hash_including(title: 'SDK version', value: '11')
-              )
-            )
-          )
-        )
+        expect(action_instance).to receive(:post_to_slack).once do |_url, payload|
+          expect(field_values(payload)).to include("*SDK version*\n11")
+        end
 
         action_instance.run(
           environment: environment,
@@ -237,11 +220,9 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
       it 'infers iOS from purchases-ios repo name' do
         ENV['CIRCLE_PROJECT_REPONAME'] = 'purchases-ios'
 
-        expect(mock_other_action).to receive(:slack).once.with(
-          hash_including(
-            message: 'iOS backend integration tests finished successfully.'
-          )
-        )
+        expect(action_instance).to receive(:post_to_slack).once do |_url, payload|
+          expect(headline_text(payload)).to eq('iOS backend integration tests finished successfully.')
+        end
 
         action_instance.run(
           environment: environment,
@@ -253,11 +234,9 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
       it 'infers Android from purchases-android repo name' do
         ENV['CIRCLE_PROJECT_REPONAME'] = 'purchases-android'
 
-        expect(mock_other_action).to receive(:slack).once.with(
-          hash_including(
-            message: 'Android backend integration tests finished successfully.'
-          )
-        )
+        expect(action_instance).to receive(:post_to_slack).once do |_url, payload|
+          expect(headline_text(payload)).to eq('Android backend integration tests finished successfully.')
+        end
 
         action_instance.run(
           environment: environment,
@@ -269,11 +248,9 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
       it 'uses explicit platform parameter over inferred value' do
         ENV['CIRCLE_PROJECT_REPONAME'] = 'purchases-android'
 
-        expect(mock_other_action).to receive(:slack).once.with(
-          hash_including(
-            message: 'iOS backend integration tests finished successfully.'
-          )
-        )
+        expect(action_instance).to receive(:post_to_slack).once do |_url, payload|
+          expect(headline_text(payload)).to eq('iOS backend integration tests finished successfully.')
+        end
 
         action_instance.run(
           environment: environment,
@@ -286,11 +263,9 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
       it 'succeeds when platform is explicitly provided despite unknown repo name' do
         ENV['CIRCLE_PROJECT_REPONAME'] = 'unknown-repo'
 
-        expect(mock_other_action).to receive(:slack).once.with(
-          hash_including(
-            message: 'Android backend integration tests finished successfully.'
-          )
-        )
+        expect(action_instance).to receive(:post_to_slack).once do |_url, payload|
+          expect(headline_text(payload)).to eq('Android backend integration tests finished successfully.')
+        end
 
         action_instance.run(
           environment: environment,
@@ -324,8 +299,7 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
         expect(Fastlane::UI).to receive(:message)
           .with('Not running in CI environment, skipping slack notification.')
 
-        # Should not call slack
-        expect(mock_other_action).not_to receive(:slack)
+        expect(action_instance).not_to receive(:post_to_slack)
 
         action_instance.run(
           environment: environment,
@@ -341,7 +315,7 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
         expect(Fastlane::UI).to receive(:message)
           .with('Not running in CI environment, skipping slack notification.')
 
-        expect(mock_other_action).not_to receive(:slack)
+        expect(action_instance).not_to receive(:post_to_slack)
 
         action_instance.run(
           environment: environment,
@@ -359,7 +333,7 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
         expect(Fastlane::UI).to receive(:message)
           .with('Running in pull request context, skipping slack notification.')
 
-        expect(mock_other_action).not_to receive(:slack)
+        expect(action_instance).not_to receive(:post_to_slack)
 
         action_instance.run(
           environment: environment,
@@ -372,7 +346,7 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
       it 'continues normally when CIRCLE_PULL_REQUEST is not set' do
         ENV.delete('CIRCLE_PULL_REQUEST')
 
-        expect(mock_other_action).to receive(:slack).once
+        expect(action_instance).to receive(:post_to_slack).once
 
         action_instance.run(
           environment: environment,
@@ -385,7 +359,7 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
       it 'continues normally when CIRCLE_PULL_REQUEST is set to empty string' do
         ENV['CIRCLE_PULL_REQUEST'] = ''
 
-        expect(mock_other_action).to receive(:slack).once
+        expect(action_instance).to receive(:post_to_slack).once
 
         action_instance.run(
           environment: environment,
@@ -435,7 +409,7 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
       it 'does not require SLACK_URL_BINARY_SOLO when binary-solo notifications are disabled' do
         ENV.delete('SLACK_URL_BINARY_SOLO')
 
-        expect(mock_other_action).to receive(:slack).once
+        expect(action_instance).to receive(:post_to_slack).once
 
         action_instance.run(
           environment: environment,
@@ -448,15 +422,9 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
 
     describe 'major version extraction' do
       it 'extracts major version from semantic version' do
-        expect(mock_other_action).to receive(:slack).once.with(
-          hash_including(
-            attachment_properties: hash_including(
-              fields: array_including(
-                hash_including(title: 'SDK version', value: '12')
-              )
-            )
-          )
-        )
+        expect(action_instance).to receive(:post_to_slack).once do |_url, payload|
+          expect(field_values(payload)).to include("*SDK version*\n12")
+        end
 
         action_instance.run(
           environment: environment,


### PR DESCRIPTION
### Motivation

The integration-test feed alert pings the SDK on-call group, but on the Slack iOS app the mention shows as `@[group unavailable]` (it only resolves on desktop). Root cause: fastlane's `slack` action posts the message inside a [legacy secondary attachment](https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments), where Slack renders mentions unreliably and content "may be wrapped, truncated, or hidden" by clients. Slack [recommends migrating to Block Kit](https://docs.slack.dev/messaging/migrating-outmoded-message-compositions-to-blocks/).

### Summary

- Post a Block Kit payload to the webhook directly instead of via `other_action.slack`.
- Headline + on-call mention now live in a top-level block (renders reliably on mobile); run details stay in a Block-Kit-based colored attachment.
- No public API change — same action parameters and options.