### PR TITLE
Use hex attachment colors so the status bar renders on all Slack clients

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/slack_backend_integration_test_results.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/slack_backend_integration_test_results.rb
@@ -10,6 +10,9 @@ module Fastlane
     class SlackBackendIntegrationTestResultsAction < Action
       ON_CALL_SDK_MENTION = "<!subteam^S0939BTV0SY|oncall-sdk>"
 
+      SUCCESS_COLOR = "#36A64F"
+      FAILURE_COLOR = "#D00000"
+
       def self.run(params)
         return unless should_send_notification?
 
@@ -124,7 +127,7 @@ module Fastlane
           ],
           attachments: [
             {
-              color: success ? "good" : "danger",
+              color: success ? SUCCESS_COLOR : FAILURE_COLOR,
               blocks: detail_blocks
             }
           ]

--- a/spec/actions/slack_backend_integration_test_results_action_spec.rb
+++ b/spec/actions/slack_backend_integration_test_results_action_spec.rb
@@ -61,7 +61,7 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
           expect(url).to eq(slack_url_feed)
           expect(payload[:text]).to eq(expected_message)
           expect(headline_text(payload)).to eq(expected_message)
-          expect(attachment(payload)[:color]).to eq('good')
+          expect(attachment(payload)[:color]).to eq('#36A64F')
         end
 
         action_instance.run(
@@ -107,7 +107,7 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
           expect(url).to eq(slack_url_feed)
           expect(payload[:text]).to eq(expected_feed_message)
           expect(headline_text(payload)).to eq(expected_feed_message)
-          expect(attachment(payload)[:color]).to eq('danger')
+          expect(attachment(payload)[:color]).to eq('#D00000')
         end
 
         action_instance.run(
@@ -142,7 +142,7 @@ describe Fastlane::Actions::SlackBackendIntegrationTestResultsAction do
       it 'defaults to failure when success parameter is not provided' do
         expect(action_instance).to receive(:post_to_slack).once do |url, payload|
           expect(url).to eq(slack_url_feed)
-          expect(attachment(payload)[:color]).to eq('danger')
+          expect(attachment(payload)[:color]).to eq('#D00000')
         end
 
         action_instance.run(


### PR DESCRIPTION
### Motivation
Follow-up to #139. After the notification details moved into a Block Kit attachment, the colored status bar stopped rendering correctly on failure: grey on desktop and blue on iOS, instead of red.

### Summary
- Slack only honors named colors (`good`/`danger`) on legacy attachments; once an attachment carries blocks, hex codes are required.
- Use `#36A64F` (success) and `#D00000` (failure) for the attachment bar.
- Spec updated to assert the hex values.

Verified by triggering the failure path in purchases-ios CI: the bar now renders red on both desktop and iOS (https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/40066) Slack message: https://revenuecat.slack.com/archives/C051D1QC3LM/p1782742146259439