### PR TITLE
Add generate_mobile_app_release_notes action

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A plugin including commonly used automation logic for RevenueCat SDKs.
 - `get_latest_github_release_within_same_major`: This action will return the latest release found in github for the same major version as the one given as parameter.
 - `update_hybrids_versions_file`: This action is meant for hybrid sdks only. It will update the `VERSIONS.md` file given with a new entry including the new version if the SDK and the iOS, Android and hybrid common sdk versions.
 - `validate_version_not_in_maven_central`: This action checks if a specific version of Maven artifacts already exists in Maven Central before deployment. It prevents accidental re-releases by failing if any of the specified artifacts are already published.
+- `generate_mobile_app_release_notes`: This action generates customer-facing release notes for the RevenueCat mobile app in the on-brand voice using the Claude CLI. It takes the list of changes and the target store (`ios` or `android`, which enforces Google Play's 500 character limit) and returns the generated notes as a String.
 
 ## Example
 

--- a/lib/fastlane/plugin/revenuecat_internal/actions/generate_mobile_app_release_notes_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/generate_mobile_app_release_notes_action.rb
@@ -2,6 +2,7 @@ require 'fastlane/action'
 require 'fastlane_core/configuration/config_item'
 require 'fastlane_core/ui/ui'
 require 'open3'
+require 'timeout'
 require_relative '../helper/revenuecat_internal_helper'
 
 module Fastlane
@@ -37,7 +38,14 @@ module Fastlane
         PROMPT
 
         command = [params[:claude_binary], '-p', '--model', params[:model]]
-        stdout, stderr, status = Open3.capture3(*command, stdin_data: prompt)
+        timeout = params[:timeout]
+        begin
+          stdout, stderr, status = Timeout.timeout(timeout) do
+            Open3.capture3(*command, stdin_data: prompt)
+          end
+        rescue Timeout::Error
+          UI.user_error!("Generating release notes with '#{command.join(' ')}' timed out after #{timeout} seconds")
+        end
         UI.user_error!("Generating release notes with '#{command.join(' ')}' failed: #{stderr}") unless status.success?
 
         release_notes = stdout.strip
@@ -78,7 +86,12 @@ module Fastlane
                                        description: "Model to use for generation",
                                        optional: true,
                                        default_value: "claude-sonnet-4-6",
-                                       type: String)
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :timeout,
+                                       description: "Maximum number of seconds to wait for the Claude CLI before failing",
+                                       optional: true,
+                                       default_value: 120,
+                                       type: Integer)
         ]
       end
 

--- a/lib/fastlane/plugin/revenuecat_internal/actions/generate_mobile_app_release_notes_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/generate_mobile_app_release_notes_action.rb
@@ -1,0 +1,90 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require 'fastlane_core/ui/ui'
+require 'open3'
+require_relative '../helper/revenuecat_internal_helper'
+
+module Fastlane
+  module Actions
+    class GenerateMobileAppReleaseNotesAction < Action
+      PROMPT_PATH = File.expand_path('../assets/mobile_app_release_notes_prompt.md', __dir__)
+
+      STORE_INSTRUCTIONS = {
+        'ios' => "These notes are for the App Store \"What's New\" section.",
+        'android' => "These notes are for the Google Play \"What's new\" section. " \
+                     "The full text must not exceed 500 characters."
+      }.freeze
+
+      def self.run(params)
+        platform = params[:platform]
+        store_instructions = STORE_INSTRUCTIONS[platform]
+        if store_instructions.nil?
+          UI.user_error!("Unsupported platform '#{platform}'. Supported platforms: #{STORE_INSTRUCTIONS.keys.join(', ')}")
+        end
+
+        prompt = <<~PROMPT
+          #{File.read(PROMPT_PATH)}
+
+          ## Target store
+
+          #{store_instructions}
+
+          ## Changes in this release
+
+          #{params[:changes]}
+
+          Reply with ONLY the release notes text — no preamble, no explanation, no markdown code fences.
+        PROMPT
+
+        command = [params[:claude_binary], '-p', '--model', params[:model]]
+        stdout, stderr, status = Open3.capture3(*command, stdin_data: prompt)
+        UI.user_error!("Generating release notes with '#{command.join(' ')}' failed: #{stderr}") unless status.success?
+
+        release_notes = stdout.strip
+        UI.user_error!("Generating release notes produced empty output") if release_notes.empty?
+
+        UI.message("Generated release notes:\n#{release_notes}")
+        release_notes
+      end
+
+      def self.description
+        "Generates customer-facing release notes for the RevenueCat mobile app in the on-brand voice using the Claude CLI"
+      end
+
+      def self.return_value
+        "The generated release notes as a String"
+      end
+
+      def self.authors
+        ["Josh Holtz"]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :changes,
+                                       description: "The list of changes in this release, one per line",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :platform,
+                                       description: "Store to target: ios (App Store) or android (Google Play)",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :claude_binary,
+                                       description: "Path to the Claude CLI binary",
+                                       optional: true,
+                                       default_value: "claude",
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :model,
+                                       description: "Model to use for generation",
+                                       optional: true,
+                                       default_value: "claude-sonnet-4-6",
+                                       type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/generate_mobile_app_release_notes_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/generate_mobile_app_release_notes_action.rb
@@ -12,8 +12,14 @@ module Fastlane
 
       STORE_INSTRUCTIONS = {
         'ios' => "These notes are for the App Store \"What's New\" section.",
-        'android' => "These notes are for the Google Play \"What's new\" section. " \
-                     "The full text must not exceed 500 characters."
+        'android' => "These notes are for the Google Play \"What's new\" section."
+      }.freeze
+
+      # Store character limits for the release notes field, used as the default
+      # max length when the caller does not pass one explicitly.
+      DEFAULT_MAX_LENGTHS = {
+        'ios' => 4000,
+        'android' => 500
       }.freeze
 
       def self.run(params)
@@ -23,12 +29,15 @@ module Fastlane
           UI.user_error!("Unsupported platform '#{platform}'. Supported platforms: #{STORE_INSTRUCTIONS.keys.join(', ')}")
         end
 
+        max_length = params[:max_length] || DEFAULT_MAX_LENGTHS[platform]
+
         prompt = <<~PROMPT
           #{File.read(PROMPT_PATH)}
 
           ## Target store
 
           #{store_instructions}
+          The full text must not exceed #{max_length} characters.
 
           ## Changes in this release
 
@@ -50,6 +59,10 @@ module Fastlane
 
         release_notes = stdout.strip
         UI.user_error!("Generating release notes produced empty output") if release_notes.empty?
+
+        if release_notes.length > max_length
+          UI.user_error!("Generated release notes are #{release_notes.length} characters, which exceeds the #{max_length} character limit for '#{platform}'")
+        end
 
         UI.message("Generated release notes:\n#{release_notes}")
         release_notes
@@ -91,6 +104,10 @@ module Fastlane
                                        description: "Maximum number of seconds to wait for the Claude CLI before failing",
                                        optional: true,
                                        default_value: 120,
+                                       type: Integer),
+          FastlaneCore::ConfigItem.new(key: :max_length,
+                                       description: "Maximum number of characters allowed in the release notes. Injected into the prompt and enforced on the output. Defaults to the store limit (4000 for ios, 500 for android)",
+                                       optional: true,
                                        type: Integer)
         ]
       end

--- a/lib/fastlane/plugin/revenuecat_internal/assets/mobile_app_release_notes_prompt.md
+++ b/lib/fastlane/plugin/revenuecat_internal/assets/mobile_app_release_notes_prompt.md
@@ -1,0 +1,64 @@
+# RevenueCat mobile app release notes
+
+You write customer-facing "What's New" release notes for the RevenueCat mobile
+app — the app developers use to check their subscription revenue from their
+phone.
+
+Given a list of changes (features, fixes, SDK bumps), write the release notes
+following the rules below. They are derived from the RevenueCat writing style
+guide (Notion: "RevenueCat writing style guide").
+
+## Voice & tone
+
+- Friendly with genuine warmth — like a teammate excited to ship, not a
+  marketer and not chatty. Enthusiasm comes from concrete specifics, not
+  hype words.
+- Speak directly to the reader in second person: "your paywalls", "you can
+  now choose".
+- Present tense, active voice. Short, clear, direct sentences.
+- No idioms, slang, puns, or cultural references — readers are global.
+- Plain, concrete language: say exactly what changed and which part of the
+  app it lives in ("in the Overview tab", "in Settings"). Never vague filler
+  like "improvements and enhancements".
+
+## Energy budget
+
+- At most ONE exclamation mark per release, and only on a genuinely exciting
+  user-facing feature ("Custom alert sounds!"). Zero is always fine — if in
+  doubt, leave it out.
+- Never hype a bug fix, SDK update, or chore. Fixes are stated plainly and
+  specifically: "Fixed a legibility issue on a button in Settings".
+
+## Structure
+
+- Lead with the most exciting user-facing change. Features first, fixes
+  after, routine items (SDK/dependency updates) last as one plain line.
+- One bullet per change, starting with "•".
+- Bullets are 1–2 short lines. If a feature gets flair, it's a short opener
+  followed by the detail: "Custom alert sounds! Choose between a few new
+  themes for your notification sounds."
+- Keep the whole thing short: ~4 bullets for a typical release, within any
+  store-specific length limit given below.
+
+## Mechanics (style guide)
+
+- Sentence case everywhere — no Title Case
+- No periods at the end of single-sentence bullets; if any bullet runs
+  longer than one sentence, use periods on every bullet in the list
+- Oxford comma in lists
+- Em dashes with a space on each side ( — ), en dashes and hyphens without
+- "RevenueCat" is always one word with a capital R and C
+- Capitalize product names (Paywalls as a product), lowercase feature names
+- No ampersands in body copy — write "and"
+- Ellipses only for deliberate trailing effect, at most once, sparingly
+
+## Example
+
+Input changes:
+- Added a chart to the Active Users card in the Overview tab
+- Updated the RevenueCat SDK
+
+Output:
+
+• See trends at a glance! The Active Users card in the Overview tab now shows a chart
+• Updated the RevenueCat SDK

--- a/spec/actions/generate_mobile_app_release_notes_action_spec.rb
+++ b/spec/actions/generate_mobile_app_release_notes_action_spec.rb
@@ -64,6 +64,17 @@ describe Fastlane::Actions::GenerateMobileAppReleaseNotesAction do
       end.to raise_exception(FastlaneCore::Interface::FastlaneError, /failed: boom/)
     end
 
+    it 'fails when the claude cli times out' do
+      allow(Open3).to receive(:capture3).and_raise(Timeout::Error)
+      expect do
+        Fastlane::Actions::GenerateMobileAppReleaseNotesAction.run(
+          changes: changes,
+          platform: 'ios',
+          timeout: 5
+        )
+      end.to raise_exception(FastlaneCore::Interface::FastlaneError, /timed out after 5 seconds/)
+    end
+
     it 'fails when the output is empty' do
       allow(Open3).to receive(:capture3).and_return(["\n", '', success_status])
       expect do

--- a/spec/actions/generate_mobile_app_release_notes_action_spec.rb
+++ b/spec/actions/generate_mobile_app_release_notes_action_spec.rb
@@ -23,13 +23,49 @@ describe Fastlane::Actions::GenerateMobileAppReleaseNotesAction do
     it 'includes the google play length limit for android' do
       expect(Open3).to receive(:capture3) do |*_command, stdin_data:|
         expect(stdin_data).to include("Google Play")
-        expect(stdin_data).to include("500 characters")
+        expect(stdin_data).to include("must not exceed 500 characters")
         ['• Generated notes', '', success_status]
       end
       Fastlane::Actions::GenerateMobileAppReleaseNotesAction.run(
         changes: changes,
         platform: 'android'
       )
+    end
+
+    it 'includes the app store length limit for ios' do
+      expect(Open3).to receive(:capture3) do |*_command, stdin_data:|
+        expect(stdin_data).to include("App Store")
+        expect(stdin_data).to include("must not exceed 4000 characters")
+        ['• Generated notes', '', success_status]
+      end
+      Fastlane::Actions::GenerateMobileAppReleaseNotesAction.run(
+        changes: changes,
+        platform: 'ios'
+      )
+    end
+
+    it 'uses a custom max_length in the prompt and enforces it on the output' do
+      expect(Open3).to receive(:capture3) do |*_command, stdin_data:|
+        expect(stdin_data).to include("must not exceed 20 characters")
+        ['this is way too long to fit in twenty characters', '', success_status]
+      end
+      expect do
+        Fastlane::Actions::GenerateMobileAppReleaseNotesAction.run(
+          changes: changes,
+          platform: 'ios',
+          max_length: 20
+        )
+      end.to raise_exception(FastlaneCore::Interface::FastlaneError, /exceeds the 20 character limit for 'ios'/)
+    end
+
+    it 'fails when the output exceeds the store limit' do
+      allow(Open3).to receive(:capture3).and_return(['x' * 501, '', success_status])
+      expect do
+        Fastlane::Actions::GenerateMobileAppReleaseNotesAction.run(
+          changes: changes,
+          platform: 'android'
+        )
+      end.to raise_exception(FastlaneCore::Interface::FastlaneError, /501 characters, which exceeds the 500 character limit for 'android'/)
     end
 
     it 'uses the given claude binary and model' do

--- a/spec/actions/generate_mobile_app_release_notes_action_spec.rb
+++ b/spec/actions/generate_mobile_app_release_notes_action_spec.rb
@@ -1,0 +1,77 @@
+describe Fastlane::Actions::GenerateMobileAppReleaseNotesAction do
+  describe '#run' do
+    let(:changes) { "- Added a chart to the Active Users card\n- Updated the RevenueCat SDK" }
+    let(:success_status) { instance_double(Process::Status, success?: true) }
+    let(:failure_status) { instance_double(Process::Status, success?: false) }
+
+    it 'sends the prompt with the changes to the claude cli and returns the output' do
+      expect(Open3).to receive(:capture3) do |*command, stdin_data:|
+        expect(command).to eq(['claude', '-p', '--model', 'claude-sonnet-4-6'])
+        expect(stdin_data).to include(changes)
+        expect(stdin_data).to include("App Store")
+        ["• Generated notes\n", '', success_status]
+      end
+      result = Fastlane::Actions::GenerateMobileAppReleaseNotesAction.run(
+        changes: changes,
+        platform: 'ios',
+        claude_binary: 'claude',
+        model: 'claude-sonnet-4-6'
+      )
+      expect(result).to eq('• Generated notes')
+    end
+
+    it 'includes the google play length limit for android' do
+      expect(Open3).to receive(:capture3) do |*_command, stdin_data:|
+        expect(stdin_data).to include("Google Play")
+        expect(stdin_data).to include("500 characters")
+        ['• Generated notes', '', success_status]
+      end
+      Fastlane::Actions::GenerateMobileAppReleaseNotesAction.run(
+        changes: changes,
+        platform: 'android'
+      )
+    end
+
+    it 'uses the given claude binary and model' do
+      expect(Open3).to receive(:capture3) do |*command, stdin_data:|
+        expect(command).to eq(['/usr/local/bin/claude', '-p', '--model', 'claude-fable-5'])
+        ['• Generated notes', '', success_status]
+      end
+      Fastlane::Actions::GenerateMobileAppReleaseNotesAction.run(
+        changes: changes,
+        platform: 'ios',
+        claude_binary: '/usr/local/bin/claude',
+        model: 'claude-fable-5'
+      )
+    end
+
+    it 'fails for an unsupported platform' do
+      expect do
+        Fastlane::Actions::GenerateMobileAppReleaseNotesAction.run(
+          changes: changes,
+          platform: 'roku'
+        )
+      end.to raise_exception(FastlaneCore::Interface::FastlaneError, /Unsupported platform 'roku'/)
+    end
+
+    it 'fails when the claude cli fails' do
+      allow(Open3).to receive(:capture3).and_return(['', 'boom', failure_status])
+      expect do
+        Fastlane::Actions::GenerateMobileAppReleaseNotesAction.run(
+          changes: changes,
+          platform: 'ios'
+        )
+      end.to raise_exception(FastlaneCore::Interface::FastlaneError, /failed: boom/)
+    end
+
+    it 'fails when the output is empty' do
+      allow(Open3).to receive(:capture3).and_return(["\n", '', success_status])
+      expect do
+        Fastlane::Actions::GenerateMobileAppReleaseNotesAction.run(
+          changes: changes,
+          platform: 'ios'
+        )
+      end.to raise_exception(FastlaneCore::Interface::FastlaneError, /empty output/)
+    end
+  end
+end


### PR DESCRIPTION
## Description

Adds a `generate_mobile_app_release_notes` action that generates **customer-facing release notes for the RevenueCat mobile apps** (App Store "What's New" / Google Play "What's new") — this is specifically for the internal mobile app store listings, not SDK changelogs.

### How it works

- The on-brand prompt lives in `lib/.../assets/mobile_app_release_notes_prompt.md`, derived from the [RevenueCat writing style guide](https://app.notion.com/p/revenuecat/RevenueCat-writing-style-guide-264cb1a108b08000b511f52688d00ace) (voice/tone, one-exclamation-max energy budget, bullet punctuation rules, etc.)
- The action feeds the prompt + a list of changes to the Claude CLI (`claude -p`) and returns the generated notes
- `platform: 'ios'` targets the App Store; `platform: 'android'` targets Google Play and enforces its 500-character limit in the prompt

### Usage

```ruby
notes = generate_mobile_app_release_notes(
  changes: "- Added a chart to the Active Users card\n- Updated the RevenueCat SDK",
  platform: 'ios'
)
```

Living here so both `revenuecat-mobile-ios` and `revenuecat-mobile-android` CI share one source of truth for the prompt.

Draft — open questions:
- [ ] `claude -p` vs calling the Anthropic API directly on CI
- [ ] default model choice
- [ ] whether the changes list should be derived automatically (e.g. from merged PR titles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)