### PR TITLE
Add app release-train actions (versioning, candidate builds, release-branch guards)

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/commit_count_build_number_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/commit_count_build_number_action.rb
@@ -1,0 +1,33 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require_relative '../helper/app_release_train_helper'
+
+module Fastlane
+  module Actions
+    class CommitCountBuildNumberAction < Action
+      def self.run(params)
+        Helper::AppReleaseTrainHelper.commit_count_build_number
+      end
+
+      def self.description
+        "Computes the build number as the commit count of HEAD (unshallowing the checkout first): monotonic, collision-free across concurrent merges, and derivable from any checkout."
+      end
+
+      def self.authors
+        ["Josh Holtz"]
+      end
+
+      def self.return_value
+        "The build number as an Integer"
+      end
+
+      def self.available_options
+        []
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/derived_app_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/derived_app_version_action.rb
@@ -1,0 +1,83 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require_relative '../helper/app_release_train_helper'
+
+module Fastlane
+  module Actions
+    class DerivedAppVersionAction < Action
+      def self.run(params)
+        Helper::AppReleaseTrainHelper.derived_version(
+          params[:checked_in_version],
+          params[:main_branch],
+          params[:repo_name],
+          params[:github_token],
+          major_bump_labels: params[:major_bump_labels],
+          minor_bump_labels: params[:minor_bump_labels],
+          patch_bump_labels: params[:patch_bump_labels],
+          changelog_ignore_label: params[:changelog_ignore_label]
+        )
+      end
+
+      def self.description
+        "Derives the app version to build: on the main branch, the next release version from PR labels (falling back to a patch bump of the released baseline on failure or non-monotonic results); off main, the checked-in version."
+      end
+
+      def self.authors
+        ["Josh Holtz"]
+      end
+
+      def self.return_value
+        "The version string to stamp on the build"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :checked_in_version,
+                                       description: "Version currently checked in to the repo (e.g. MARKETING_VERSION or versionName)",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :main_branch,
+                                       description: "Name of the trunk branch releases are derived on",
+                                       optional: true,
+                                       default_value: "main",
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :repo_name,
+                                       env_name: "RC_INTERNAL_REPO_NAME",
+                                       description: "Name of the repo of the app",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :github_token,
+                                       env_name: "GITHUB_TOKEN",
+                                       description: "Github token to use to fetch releases and PR labels",
+                                       optional: false,
+                                       sensitive: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :major_bump_labels,
+                                       description: "PR labels that force a major version bump",
+                                       optional: true,
+                                       default_value: ["pr:force_major"],
+                                       type: Array),
+          FastlaneCore::ConfigItem.new(key: :minor_bump_labels,
+                                       description: "PR labels that force a minor version bump",
+                                       optional: true,
+                                       default_value: ["pr:breaking", "pr:feat", "pr:force_minor"],
+                                       type: Array),
+          FastlaneCore::ConfigItem.new(key: :patch_bump_labels,
+                                       description: "PR labels that force a patch version bump",
+                                       optional: true,
+                                       default_value: ["pr:fix", "pr:dependencies", "pr:force_patch"],
+                                       type: Array),
+          FastlaneCore::ConfigItem.new(key: :changelog_ignore_label,
+                                       description: "PR label that excludes a PR from version calculation",
+                                       optional: true,
+                                       default_value: "pr:changelog_ignore",
+                                       type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/determine_app_release_version_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/determine_app_release_version_action.rb
@@ -1,0 +1,77 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require_relative '../helper/app_release_train_helper'
+
+module Fastlane
+  module Actions
+    class DetermineAppReleaseVersionAction < Action
+      def self.run(params)
+        Helper::AppReleaseTrainHelper.next_release_version(
+          params[:repo_name],
+          params[:github_token],
+          params[:current_version],
+          major_bump_labels: params[:major_bump_labels],
+          minor_bump_labels: params[:minor_bump_labels],
+          patch_bump_labels: params[:patch_bump_labels],
+          changelog_ignore_label: params[:changelog_ignore_label]
+        )
+      end
+
+      def self.description
+        "Determines the next app release version from the labels of PRs merged since the last published GitHub release (tagged <version>-<build>). Returns the next version string."
+      end
+
+      def self.authors
+        ["Josh Holtz"]
+      end
+
+      def self.return_value
+        "The next release version string, e.g. 1.2.3"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :repo_name,
+                                       env_name: "RC_INTERNAL_REPO_NAME",
+                                       description: "Name of the repo of the app",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :github_token,
+                                       env_name: "GITHUB_TOKEN",
+                                       description: "Github token to use to fetch releases and PR labels",
+                                       optional: false,
+                                       sensitive: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :current_version,
+                                       description: "Checked-in version to bump from when there are no published GitHub releases yet",
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :major_bump_labels,
+                                       description: "PR labels that force a major version bump",
+                                       optional: true,
+                                       default_value: ["pr:force_major"],
+                                       type: Array),
+          FastlaneCore::ConfigItem.new(key: :minor_bump_labels,
+                                       description: "PR labels that force a minor version bump",
+                                       optional: true,
+                                       default_value: ["pr:breaking", "pr:feat", "pr:force_minor"],
+                                       type: Array),
+          FastlaneCore::ConfigItem.new(key: :patch_bump_labels,
+                                       description: "PR labels that force a patch version bump",
+                                       optional: true,
+                                       default_value: ["pr:fix", "pr:dependencies", "pr:force_patch"],
+                                       type: Array),
+          FastlaneCore::ConfigItem.new(key: :changelog_ignore_label,
+                                       description: "PR label that excludes a PR from version calculation",
+                                       optional: true,
+                                       default_value: "pr:changelog_ignore",
+                                       type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/ensure_candidate_version_matches_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/ensure_candidate_version_matches_action.rb
@@ -1,0 +1,38 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require_relative '../helper/app_release_train_helper'
+
+module Fastlane
+  module Actions
+    class EnsureCandidateVersionMatchesAction < Action
+      def self.run(params)
+        Helper::AppReleaseTrainHelper.ensure_candidate_version_matches!(params[:sha], params[:version])
+      end
+
+      def self.description
+        "Fails unless a builds/<version>-<build> tag at the given commit matches the computed release version, catching derivations that drifted since the candidate uploaded (e.g. a label edited after the upload)."
+      end
+
+      def self.authors
+        ["Josh Holtz"]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :sha,
+                                       description: "SHA of the candidate commit",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       description: "Version the cut computed",
+                                       optional: false,
+                                       type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/ensure_release_branch_metadata_only_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/ensure_release_branch_metadata_only_action.rb
@@ -1,0 +1,56 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require_relative '../helper/app_release_train_helper'
+
+module Fastlane
+  module Actions
+    class EnsureReleaseBranchMetadataOnlyAction < Action
+      def self.run(params)
+        if params[:version_file] && params[:version_line_pattern].to_s.empty?
+          UI.user_error!("version_line_pattern is required when version_file is provided.")
+        end
+
+        Helper::AppReleaseTrainHelper.ensure_release_branch_is_metadata_only!(
+          params[:main_branch],
+          params[:allowed_path_prefixes],
+          params[:version_file],
+          params[:version_line_pattern]
+        )
+      end
+
+      def self.description
+        "Fails unless the release branch only changes release metadata since its fork point from main: no merge commits, only allowed path prefixes (plus the version file, whose changed lines must all match the version line pattern)."
+      end
+
+      def self.authors
+        ["Josh Holtz"]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :main_branch,
+                                       description: "Name of the trunk branch the release was cut from",
+                                       optional: true,
+                                       default_value: "main",
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :allowed_path_prefixes,
+                                       description: "Path prefixes the release branch is allowed to change, e.g. [\"fastlane/metadata/\"]",
+                                       optional: false,
+                                       type: Array),
+          FastlaneCore::ConfigItem.new(key: :version_file,
+                                       description: "Project file whose only allowed edits are version lines, e.g. \"RevenueCat.xcodeproj/project.pbxproj\"",
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :version_line_pattern,
+                                       description: "Regex (as a string) every changed line in version_file must match, e.g. \"MARKETING_VERSION\"",
+                                       optional: true,
+                                       type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/ensure_release_branch_not_stale_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/ensure_release_branch_not_stale_action.rb
@@ -1,0 +1,38 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require_relative '../helper/app_release_train_helper'
+
+module Fastlane
+  module Actions
+    class EnsureReleaseBranchNotStaleAction < Action
+      def self.run(params)
+        Helper::AppReleaseTrainHelper.ensure_release_branch_not_stale!(params[:release_branch], params[:cut_from_sha])
+      end
+
+      def self.description
+        "Fails if an existing release branch does not contain the commit the release should be cut from, or if it contains merge commits (which move the fork point)."
+      end
+
+      def self.authors
+        ["Josh Holtz"]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :release_branch,
+                                       description: "Name of the release branch, used in error messages",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :cut_from_sha,
+                                       description: "SHA of the commit the release should be cut from",
+                                       optional: false,
+                                       type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/find_release_candidate_commit_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/find_release_candidate_commit_action.rb
@@ -1,0 +1,60 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require_relative '../helper/app_release_train_helper'
+
+module Fastlane
+  module Actions
+    class FindReleaseCandidateCommitAction < Action
+      def self.run(params)
+        Helper::AppReleaseTrainHelper.find_candidate_commit(
+          params[:repo_name],
+          params[:github_token],
+          skip_label: params[:skip_label],
+          lookback: params[:lookback]
+        )
+      end
+
+      def self.description
+        "Finds the newest first-parent commit with an uploaded candidate build (a builds/* tag), walking past commits whose merged PR has the skip label, and failing on an untagged commit without it."
+      end
+
+      def self.authors
+        ["Josh Holtz"]
+      end
+
+      def self.return_value
+        "The SHA of the newest commit with a candidate build"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :repo_name,
+                                       env_name: "RC_INTERNAL_REPO_NAME",
+                                       description: "Name of the repo of the app",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :github_token,
+                                       env_name: "GITHUB_TOKEN",
+                                       description: "Github token to use to fetch PR labels",
+                                       optional: false,
+                                       sensitive: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :skip_label,
+                                       description: "PR label that marks merges which intentionally skip the candidate upload",
+                                       optional: true,
+                                       default_value: "upload:skip",
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :lookback,
+                                       description: "How many first-parent commits to walk before giving up",
+                                       optional: true,
+                                       default_value: 30,
+                                       type: Integer)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/release_candidate_build_number_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/release_candidate_build_number_action.rb
@@ -1,0 +1,43 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require_relative '../helper/app_release_train_helper'
+
+module Fastlane
+  module Actions
+    class ReleaseCandidateBuildNumberAction < Action
+      def self.run(params)
+        Helper::AppReleaseTrainHelper.release_candidate_build_number(params[:version], params[:main_branch])
+      end
+
+      def self.description
+        "Returns the build number of the candidate build for a release branch: the builds/<version>-<build> tag pointing at the merge-base of HEAD and origin/<main_branch>."
+      end
+
+      def self.authors
+        ["Josh Holtz"]
+      end
+
+      def self.return_value
+        "The candidate build number as an Integer"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       description: "Version the release is being cut as",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :main_branch,
+                                       description: "Name of the trunk branch the release was cut from",
+                                       optional: true,
+                                       default_value: "main",
+                                       type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/actions/tag_uploaded_build_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/tag_uploaded_build_action.rb
@@ -1,0 +1,38 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require_relative '../helper/app_release_train_helper'
+
+module Fastlane
+  module Actions
+    class TagUploadedBuildAction < Action
+      def self.run(params)
+        Helper::AppReleaseTrainHelper.tag_uploaded_build(params[:version], params[:build_number])
+      end
+
+      def self.description
+        "Tags HEAD as builds/<version>-<build> and pushes the tag. Best-effort: failures are logged but never raised, so tagging cannot fail an upload that already happened."
+      end
+
+      def self.authors
+        ["Josh Holtz"]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       description: "Version the build was uploaded as",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :build_number,
+                                       description: "Build number the build was uploaded as",
+                                       optional: false,
+                                       is_string: false)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/helper/app_release_train_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/app_release_train_helper.rb
@@ -1,0 +1,362 @@
+require 'fastlane_core/ui/ui'
+require 'fastlane/action'
+require 'fastlane/actions/github_api'
+require 'json'
+require_relative 'github_helper'
+
+module Fastlane
+  UI = FastlaneCore::UI unless Fastlane.const_defined?(:UI)
+
+  module Helper
+    # Release-train helpers for app repos (as opposed to SDK repos): versions are
+    # derived from PR labels and GitHub releases, builds are tagged builds/<version>-<build>,
+    # and releases are cut from an already-uploaded candidate build on the main branch.
+    class AppReleaseTrainHelper
+      # Release tags are created as "<marketing-version>-<build-number>".
+      RELEASE_TAG_PATTERN = /\A(?<version>\d+\.\d+\.\d+)-(?<build>[1-9]\d*)\z/
+
+      # Highest-versioned published GitHub release tag (incl. pre-releases, excl.
+      # drafts — drafts have no git tag yet); nil if there are none. The releases API
+      # orders by creation date, so pick the max by version-then-build to keep a
+      # late-created hotfix of an older version from becoming the baseline. API
+      # failures raise: quietly treating them as "first release" would compute the
+      # version from full history.
+      # rubocop:disable Metrics/PerceivedComplexity
+      def self.last_release_tag(repo_name, github_token)
+        response = Helper::GitHubHelper.github_api_call_with_retry(
+          server_url: 'https://api.github.com',
+          path: "/repos/RevenueCat/#{repo_name}/releases?per_page=100",
+          http_method: 'GET',
+          body: {},
+          api_token: github_token
+        )
+        releases = JSON.parse(response[:body])
+        published = releases.kind_of?(Array) ? releases.reject { |release| release["draft"] } : []
+        return nil if published.empty?
+
+        tags = published.map { |release| release["tag_name"] }
+        well_formed = tags.select { |tag| tag.to_s.match?(RELEASE_TAG_PATTERN) }
+        # No well-formed tags: return the newest so the caller's format check reports it.
+        return tags.first if well_formed.empty?
+
+        well_formed.max_by do |tag|
+          match = tag.match(RELEASE_TAG_PATTERN)
+          [Gem::Version.new(match[:version]), match[:build].to_i]
+        end
+      rescue StandardError => e
+        UI.user_error!("Could not fetch the latest GitHub release: #{e.message}")
+      end
+      # rubocop:enable Metrics/PerceivedComplexity
+
+      def self.release_version_from_tag(tag)
+        match = tag.to_s.match(RELEASE_TAG_PATTERN)
+        return match[:version] if match
+
+        UI.user_error!("Latest GitHub release tag #{tag.inspect} does not match the expected <version>-<build> format, e.g. 1.2.3-456.")
+      end
+
+      # Returns :major / :minor / :patch / nil from the labels of PRs merged since `tag`.
+      # rubocop:disable Metrics/PerceivedComplexity
+      def self.bump_type_since(tag, repo_name, github_token, major_bump_labels:, minor_bump_labels:, patch_bump_labels:, changelog_ignore_label:)
+        ensure_full_git_history
+        Actions.sh("git", "fetch", "--tags", "--force", log: false)
+        if tag && !tag_exists?(tag)
+          UI.user_error!("GitHub release tag #{tag.inspect} does not exist as a git tag; was it deleted or renamed?")
+        end
+        range = tag ? "#{tag}..HEAD" : "HEAD"
+        subjects = Actions.sh("git", "log", range, "--pretty=format:%s", log: false).split("\n")
+        pr_numbers = subjects.map { |subject| pr_number_from_subject(subject) }.compact.uniq
+        # The changelog-ignore label excludes the whole PR from version calculation.
+        labels = pr_numbers.map { |pr_number| pr_labels_for(pr_number, repo_name, github_token, strict: true) }
+                           .reject { |pr_labels| pr_labels.include?(changelog_ignore_label) }
+                           .flatten.uniq
+
+        return :major if (labels & major_bump_labels).any?
+        return :minor if (labels & minor_bump_labels).any?
+        return :patch if (labels & patch_bump_labels).any?
+
+        nil
+      end
+      # rubocop:enable Metrics/PerceivedComplexity
+
+      def self.calculate_next_version(current_version, bump)
+        major, minor, patch = current_version.split(".").map(&:to_i)
+        case bump
+        when :major then "#{major + 1}.0.0"
+        when :minor then "#{major}.#{minor + 1}.0"
+        when :patch then "#{major}.#{minor}.#{patch + 1}"
+        else UI.user_error!("Unknown bump type: #{bump}")
+        end
+      end
+
+      # Next version from PR labels merged since the last release. Uses the latest
+      # GitHub release tag so release history, not build artifacts, determines the
+      # version range.
+      def self.next_release_version(repo_name, github_token, current_version, major_bump_labels:, minor_bump_labels:, patch_bump_labels:, changelog_ignore_label:)
+        last_tag = last_release_tag(repo_name, github_token)
+        released_version = last_tag ? release_version_from_tag(last_tag) : current_version
+        if released_version.to_s.strip.empty?
+          UI.user_error!("There are no published GitHub releases and no current_version was provided to bump from.")
+        end
+        bump = bump_type_since(last_tag, repo_name, github_token,
+                               major_bump_labels: major_bump_labels,
+                               minor_bump_labels: minor_bump_labels,
+                               patch_bump_labels: patch_bump_labels,
+                               changelog_ignore_label: changelog_ignore_label)
+
+        if bump.nil?
+          all_bump_labels = (major_bump_labels + minor_bump_labels + patch_bump_labels).join(' / ')
+          UI.user_error!("No version-bumping PR labels found since #{last_tag || 'the start of history'}. " \
+                         "Nothing to release (label PRs with #{all_bump_labels}).")
+        end
+
+        # Bump from the last released version. Trunk may still show the previous
+        # checked-in version until a release PR lands.
+        next_version = calculate_next_version(released_version, bump)
+        UI.message("Version bump: #{bump} (last released #{released_version} → #{next_version})")
+        next_version
+      end
+
+      # The same GitHub-release source next_release_version derives from, so main
+      # builds and cuts can never disagree on the baseline. It also covers the
+      # window between finalizing a release and the release PR's merge, when the
+      # checked-in version still lags the shipped one.
+      def self.released_version_baseline(checked_in_version, repo_name, github_token)
+        tag = begin
+          last_release_tag(repo_name, github_token)
+        rescue StandardError => e
+          UI.important("Could not read GitHub releases (#{e.message}); baseline falls back to the checked-in version.")
+          nil
+        end
+        released = tag && tag.match(RELEASE_TAG_PATTERN) && release_version_from_tag(tag)
+        return checked_in_version unless released
+
+        [checked_in_version, released].max_by { |version| Gem::Version.new(version) }
+      end
+
+      # Derivation starts from the last GitHub release tag (next_release_version).
+      # Guards and fallbacks use released_version_baseline and must bump above it:
+      # app stores reject uploads for an already-released version.
+      def self.derived_version(checked_in_version, main_branch, repo_name, github_token, major_bump_labels:, minor_bump_labels:, patch_bump_labels:, changelog_ignore_label:)
+        unless Actions.git_branch == main_branch
+          UI.message("Using the checked-in version #{checked_in_version} (not on #{main_branch})")
+          return checked_in_version
+        end
+
+        baseline = released_version_baseline(checked_in_version, repo_name, github_token)
+
+        begin
+          derived = next_release_version(repo_name, github_token, checked_in_version,
+                                         major_bump_labels: major_bump_labels,
+                                         minor_bump_labels: minor_bump_labels,
+                                         patch_bump_labels: patch_bump_labels,
+                                         changelog_ignore_label: changelog_ignore_label)
+        rescue StandardError => e
+          fallback = calculate_next_version(baseline, :patch)
+          UI.important("Could not derive the next version from PR labels (#{e.message}); using #{fallback} (baseline #{baseline} + patch).")
+          return fallback
+        end
+
+        unless Gem::Version.new(derived) > Gem::Version.new(baseline)
+          fallback = calculate_next_version(baseline, :patch)
+          UI.important("Derived version #{derived} is not above the released baseline #{baseline}; using #{fallback}.")
+          return fallback
+        end
+
+        UI.message("Derived version #{derived} from PR labels (released baseline #{baseline})")
+        derived
+      end
+
+      # Build numbers are the commit count: monotonic, collision-free across
+      # concurrent merges (each merge commit has a distinct count), no network call,
+      # and derivable from any checkout. Nothing is committed back to the repo.
+      def self.commit_count_build_number
+        ensure_full_git_history
+        count = Actions.sh("git", "rev-list", "--count", "HEAD", log: false).strip
+        UI.user_error!("Could not compute the build number from the commit count (got #{count.inspect}).") unless count.match?(/\A[1-9]\d*\z/)
+        count.to_i
+      end
+
+      # CI checkouts can be shallow; anything that walks history (version scans,
+      # commit counts) must unshallow first or it reads a truncated log.
+      def self.ensure_full_git_history
+        shallow = Actions.sh("git", "rev-parse", "--is-shallow-repository", log: false).strip
+        Actions.sh("git", "fetch", "--unshallow", log: false) if shallow == "true"
+      end
+
+      # Namespaced under builds/ so the x.y.z-N release-tag lookups never match it,
+      # and best-effort: tagging must not fail an upload that already happened.
+      def self.tag_uploaded_build(version, build)
+        tag_name = "builds/#{version}-#{build}"
+        Actions.sh("git", "tag", tag_name)
+        Actions.sh("git", "push", "origin", "refs/tags/#{tag_name}")
+        UI.message("Tagged uploaded build as #{tag_name}")
+      rescue StandardError => e
+        UI.important("Could not tag uploaded build #{tag_name}: #{e.message}")
+      end
+
+      def self.builds_tags_at(sha)
+        Actions.sh("git", "tag", "--points-at", sha, log: false)
+               .split("\n").map(&:strip).select { |tag| tag.start_with?("builds/") }
+      end
+
+      # Newest main commit with an uploaded candidate. Skip-labeled merges never
+      # upload, so the walk passes over them; an untagged commit that should have
+      # uploaded fails the cut rather than being silently dropped from the release.
+      def self.find_candidate_commit(repo_name, github_token, skip_label:, lookback:)
+        ensure_full_git_history
+        Actions.sh("git", "fetch", "--tags", "--force", log: false)
+        shas = Actions.sh("git", "rev-list", "--first-parent", "-n", lookback.to_s, "HEAD", log: false)
+                      .split("\n").map(&:strip).reject(&:empty?)
+        shas.each do |sha|
+          return sha if builds_tags_at(sha).any?
+
+          subject = Actions.sh("git", "log", "-1", "--pretty=format:%s", sha, log: false).strip
+          pr_number = pr_number_from_subject(subject)
+          labels = pr_number ? pr_labels_for(pr_number, repo_name, github_token) : []
+          unless labels.include?(skip_label)
+            UI.user_error!("#{sha[0, 8]} (#{subject}) has no candidate build and is not #{skip_label}. " \
+                           "Its upload may still be running or may have failed — wait for it or re-run the upload on it, then re-cut.")
+          end
+          UI.message("Walking past #{sha[0, 8]} (#{skip_label} — no candidate expected)")
+        end
+        UI.user_error!("No candidate build found in the last #{lookback} commits.")
+      end
+
+      # The commit on the main branch this release branch was cut from.
+      def self.release_fork_point(main_branch)
+        ensure_full_git_history
+        Actions.sh("git", "fetch", "origin", main_branch, log: false)
+        fork_point = Actions.sh("git", "merge-base", "HEAD", "origin/#{main_branch}", log: false).strip
+        UI.user_error!("Could not determine the #{main_branch} commit this release was cut from.") if fork_point.empty?
+        fork_point
+      end
+
+      # The candidate is the main branch's build of the commit the release was cut
+      # from, located via its builds/<version>-<build> tag.
+      def self.release_candidate_build_number(version, main_branch)
+        fork_point = release_fork_point(main_branch)
+        Actions.sh("git", "fetch", "--tags", "--force", log: false)
+        tags = Actions.sh("git", "tag", "--points-at", fork_point, log: false).split("\n").map(&:strip)
+        matches = tags.map { |tag| tag.match(%r{\Abuilds/#{Regexp.escape(version)}-([1-9]\d*)\z}) }.compact
+        if matches.empty?
+          UI.user_error!("No builds/#{version}-* tag points at #{fork_point[0, 8]}, the #{main_branch} commit this release was cut from. " \
+                         "If that commit never uploaded (a skipped merge or a failed job), re-run the upload on it or re-cut from current #{main_branch}. " \
+                         "If the build was uploaded and only the best-effort tag push failed, tag it manually: " \
+                         "git tag builds/#{version}-<build> #{fork_point[0, 8]} && git push origin --tags." \
+                         "#{" Tags found there: #{tags.join(', ')}." unless tags.empty?}")
+        end
+        matches.map { |match| match[1].to_i }.max
+      end
+
+      # The build-time derivation can drift from the cut-time one (a label edited
+      # after the upload, a fallback-stamped build). Without this the mismatch
+      # surfaces only after the release notes and smoke test are already done.
+      def self.ensure_candidate_version_matches!(sha, version)
+        versions = builds_tags_at(sha)
+                   .map { |tag| tag.match(%r{\Abuilds/(\d+\.\d+\.\d+)-[1-9]\d*\z})&.captures&.first }
+                   .compact.uniq
+        return if versions.include?(version)
+
+        UI.user_error!("The candidate at #{sha[0, 8]} was uploaded as #{versions.join(', ')}, but the cut computes #{version} " \
+                       "(labels changed since the upload?). Re-run the upload on that commit, then re-cut.")
+      end
+
+      # A reused release branch that predates current main would silently drop the
+      # newly merged commits from the release.
+      def self.ensure_release_branch_not_stale!(release_branch, cut_from)
+        unless ancestor?(cut_from, "HEAD")
+          UI.user_error!("The existing #{release_branch} branch was cut from an older commit and does not contain #{cut_from[0, 8]}. " \
+                         "Delete the remote branch (and close its PR), then re-run the release cut.")
+        end
+
+        # Fail at cut time rather than later: merge commits are refused on release
+        # branches (they move the fork point).
+        merges = Actions.sh("git", "rev-list", "--merges", "#{cut_from}..HEAD", log: false).split("\n").reject(&:empty?)
+        return if merges.empty?
+
+        UI.user_error!("The existing #{release_branch} branch contains merge commits (#{merges.map { |merge| merge[0, 8] }.join(', ')}). " \
+                       "Delete the remote branch (and close its PR), then re-run the release cut.")
+      end
+
+      # Release branches ship the build cut from main, so a code change here would
+      # silently ship untested. Merge commits are refused because merging main in
+      # moves the fork point, silently changing which binary gets submitted.
+      # rubocop:disable Metrics/PerceivedComplexity
+      def self.ensure_release_branch_is_metadata_only!(main_branch, allowed_path_prefixes, version_file, version_line_pattern)
+        fork_point = release_fork_point(main_branch)
+        merges = Actions.sh("git", "rev-list", "--merges", "#{fork_point}..HEAD", log: false).split("\n").reject(&:empty?)
+        unless merges.empty?
+          UI.user_error!("The release branch contains merge commits (#{merges.map { |merge| merge[0, 8] }.join(', ')}). " \
+                         "Do not merge #{main_branch} into a release branch — to pick up new #{main_branch} commits, delete this branch, close its PR, and re-cut.")
+        end
+
+        changed = Actions.sh("git", "diff", "--name-only", "#{fork_point}..HEAD", log: false)
+                         .split("\n").map(&:strip).reject(&:empty?)
+        disallowed = changed.reject do |path|
+          allowed_path_prefixes.any? { |prefix| path.start_with?(prefix) } || path == version_file
+        end
+        unless disallowed.empty?
+          UI.user_error!("Release branches may only change release metadata; code changes require a fresh cut from #{main_branch}. " \
+                         "Unexpected changes since #{fork_point[0, 8]}: #{disallowed.join(', ')}")
+        end
+
+        return unless version_file && changed.include?(version_file)
+
+        diff_lines = Actions.sh("git", "diff", "#{fork_point}..HEAD", "--", version_file, log: false).lines
+        edits = diff_lines.grep(/\A[+-][^+-]/)
+        non_version_edits = edits.grep_v(Regexp.new(version_line_pattern.to_s))
+        return if non_version_edits.empty?
+
+        UI.user_error!("The release branch changes #{version_file} beyond lines matching #{version_line_pattern.inspect}; " \
+                       "code or project changes require a fresh cut from #{main_branch}:\n#{non_version_edits.join}")
+      end
+      # rubocop:enable Metrics/PerceivedComplexity
+
+      # Squash merges put the PR number at the end of the subject ("Title (#123)"),
+      # so prefer a trailing "(#N)" and only then a "Merge pull request #N" prefix;
+      # taking the first "(#N)" anywhere would match issue references in the title.
+      def self.pr_number_from_subject(subject)
+        trailing = subject.match(/\(#(\d+)\)\z/)
+        return trailing[1] if trailing
+
+        merge_commit = subject.match(/\AMerge pull request #(\d+)/)
+        merge_commit && merge_commit[1]
+      end
+
+      # strict: false fails open (returns []) so a label lookup failure never blocks
+      # an upload. Version calculation must use strict: true — silently missing
+      # labels there would compute a wrong version bump.
+      def self.pr_labels_for(pr_number, repo_name, github_token, strict: false)
+        response = Helper::GitHubHelper.github_api_call_with_retry(
+          server_url: 'https://api.github.com',
+          path: "/repos/RevenueCat/#{repo_name}/pulls/#{pr_number}",
+          http_method: 'GET',
+          body: {},
+          api_token: github_token
+        )
+        body = JSON.parse(response[:body])
+        ((body && body["labels"]) || []).map { |label| label["name"] }
+      rescue StandardError => e
+        raise if strict
+
+        UI.important("Could not fetch labels for PR ##{pr_number}: #{e.message}")
+        []
+      end
+
+      private_class_method def self.tag_exists?(tag)
+        Actions.sh("git", "rev-parse", "--verify", "--quiet", "refs/tags/#{tag}", log: false)
+        true
+      rescue StandardError
+        false
+      end
+
+      private_class_method def self.ancestor?(ancestor_sha, descendant_ref)
+        Actions.sh("git", "merge-base", "--is-ancestor", ancestor_sha, descendant_ref, log: false)
+        true
+      rescue StandardError
+        false
+      end
+    end
+  end
+end

--- a/spec/actions/commit_count_build_number_action_spec.rb
+++ b/spec/actions/commit_count_build_number_action_spec.rb
@@ -1,0 +1,17 @@
+describe Fastlane::Actions::CommitCountBuildNumberAction do
+  describe '#run' do
+    it 'returns the helper-computed build number' do
+      expect(Fastlane::Helper::AppReleaseTrainHelper).to receive(:commit_count_build_number)
+        .and_return(1234)
+        .once
+
+      expect(Fastlane::Actions::CommitCountBuildNumberAction.run({})).to eq(1234)
+    end
+  end
+
+  describe '#available_options' do
+    it 'has no options' do
+      expect(Fastlane::Actions::CommitCountBuildNumberAction.available_options.size).to eq(0)
+    end
+  end
+end

--- a/spec/actions/derived_app_version_action_spec.rb
+++ b/spec/actions/derived_app_version_action_spec.rb
@@ -1,0 +1,37 @@
+describe Fastlane::Actions::DerivedAppVersionAction do
+  describe '#run' do
+    it 'calls the helper with the appropriate parameters' do
+      expect(Fastlane::Helper::AppReleaseTrainHelper).to receive(:derived_version)
+        .with('1.2.0', 'main', 'mock-repo-name', 'mock-github-token',
+              major_bump_labels: ['pr:force_major'],
+              minor_bump_labels: ['pr:feat'],
+              patch_bump_labels: ['pr:fix'],
+              changelog_ignore_label: 'pr:changelog_ignore')
+        .and_return('1.3.0')
+        .once
+
+      version = Fastlane::Actions::DerivedAppVersionAction.run(
+        checked_in_version: '1.2.0',
+        main_branch: 'main',
+        repo_name: 'mock-repo-name',
+        github_token: 'mock-github-token',
+        major_bump_labels: ['pr:force_major'],
+        minor_bump_labels: ['pr:feat'],
+        patch_bump_labels: ['pr:fix'],
+        changelog_ignore_label: 'pr:changelog_ignore'
+      )
+      expect(version).to eq('1.3.0')
+    end
+  end
+
+  describe '#available_options' do
+    it 'has correct number of options' do
+      expect(Fastlane::Actions::DerivedAppVersionAction.available_options.size).to eq(8)
+    end
+
+    it 'defaults main_branch to main' do
+      option = Fastlane::Actions::DerivedAppVersionAction.available_options.find { |item| item.key == :main_branch }
+      expect(option.default_value).to eq('main')
+    end
+  end
+end

--- a/spec/actions/determine_app_release_version_action_spec.rb
+++ b/spec/actions/determine_app_release_version_action_spec.rb
@@ -1,0 +1,40 @@
+describe Fastlane::Actions::DetermineAppReleaseVersionAction do
+  describe '#run' do
+    it 'calls the helper with the appropriate parameters' do
+      expect(Fastlane::Helper::AppReleaseTrainHelper).to receive(:next_release_version)
+        .with('mock-repo-name', 'mock-github-token', '1.2.0',
+              major_bump_labels: ['pr:force_major'],
+              minor_bump_labels: ['pr:feat'],
+              patch_bump_labels: ['pr:fix'],
+              changelog_ignore_label: 'pr:changelog_ignore')
+        .and_return('1.3.0')
+        .once
+
+      version = Fastlane::Actions::DetermineAppReleaseVersionAction.run(
+        repo_name: 'mock-repo-name',
+        github_token: 'mock-github-token',
+        current_version: '1.2.0',
+        major_bump_labels: ['pr:force_major'],
+        minor_bump_labels: ['pr:feat'],
+        patch_bump_labels: ['pr:fix'],
+        changelog_ignore_label: 'pr:changelog_ignore'
+      )
+      expect(version).to eq('1.3.0')
+    end
+  end
+
+  describe '#available_options' do
+    it 'has correct number of options' do
+      expect(Fastlane::Actions::DetermineAppReleaseVersionAction.available_options.size).to eq(7)
+    end
+
+    it 'has the documented label defaults' do
+      options = Fastlane::Actions::DetermineAppReleaseVersionAction.available_options
+      defaults = options.to_h { |option| [option.key, option.default_value] }
+      expect(defaults[:major_bump_labels]).to eq(['pr:force_major'])
+      expect(defaults[:minor_bump_labels]).to eq(['pr:breaking', 'pr:feat', 'pr:force_minor'])
+      expect(defaults[:patch_bump_labels]).to eq(['pr:fix', 'pr:dependencies', 'pr:force_patch'])
+      expect(defaults[:changelog_ignore_label]).to eq('pr:changelog_ignore')
+    end
+  end
+end

--- a/spec/actions/ensure_candidate_version_matches_action_spec.rb
+++ b/spec/actions/ensure_candidate_version_matches_action_spec.rb
@@ -1,0 +1,20 @@
+describe Fastlane::Actions::EnsureCandidateVersionMatchesAction do
+  describe '#run' do
+    it 'calls the helper with the appropriate parameters' do
+      expect(Fastlane::Helper::AppReleaseTrainHelper).to receive(:ensure_candidate_version_matches!)
+        .with('abc123', '1.2.3')
+        .once
+
+      Fastlane::Actions::EnsureCandidateVersionMatchesAction.run(
+        sha: 'abc123',
+        version: '1.2.3'
+      )
+    end
+  end
+
+  describe '#available_options' do
+    it 'has correct number of options' do
+      expect(Fastlane::Actions::EnsureCandidateVersionMatchesAction.available_options.size).to eq(2)
+    end
+  end
+end

--- a/spec/actions/ensure_release_branch_metadata_only_action_spec.rb
+++ b/spec/actions/ensure_release_branch_metadata_only_action_spec.rb
@@ -1,0 +1,46 @@
+describe Fastlane::Actions::EnsureReleaseBranchMetadataOnlyAction do
+  describe '#run' do
+    it 'calls the helper with the appropriate parameters' do
+      expect(Fastlane::Helper::AppReleaseTrainHelper).to receive(:ensure_release_branch_is_metadata_only!)
+        .with('main', ['fastlane/metadata/'], 'App.xcodeproj/project.pbxproj', 'MARKETING_VERSION')
+        .once
+
+      Fastlane::Actions::EnsureReleaseBranchMetadataOnlyAction.run(
+        main_branch: 'main',
+        allowed_path_prefixes: ['fastlane/metadata/'],
+        version_file: 'App.xcodeproj/project.pbxproj',
+        version_line_pattern: 'MARKETING_VERSION'
+      )
+    end
+
+    it 'allows omitting the version file entirely' do
+      expect(Fastlane::Helper::AppReleaseTrainHelper).to receive(:ensure_release_branch_is_metadata_only!)
+        .with('main', ['fastlane/metadata/'], nil, nil)
+        .once
+
+      Fastlane::Actions::EnsureReleaseBranchMetadataOnlyAction.run(
+        main_branch: 'main',
+        allowed_path_prefixes: ['fastlane/metadata/'],
+        version_file: nil,
+        version_line_pattern: nil
+      )
+    end
+
+    it 'fails when a version file is given without a version line pattern' do
+      expect do
+        Fastlane::Actions::EnsureReleaseBranchMetadataOnlyAction.run(
+          main_branch: 'main',
+          allowed_path_prefixes: ['fastlane/metadata/'],
+          version_file: 'App.xcodeproj/project.pbxproj',
+          version_line_pattern: nil
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /version_line_pattern is required/)
+    end
+  end
+
+  describe '#available_options' do
+    it 'has correct number of options' do
+      expect(Fastlane::Actions::EnsureReleaseBranchMetadataOnlyAction.available_options.size).to eq(4)
+    end
+  end
+end

--- a/spec/actions/ensure_release_branch_not_stale_action_spec.rb
+++ b/spec/actions/ensure_release_branch_not_stale_action_spec.rb
@@ -1,0 +1,20 @@
+describe Fastlane::Actions::EnsureReleaseBranchNotStaleAction do
+  describe '#run' do
+    it 'calls the helper with the appropriate parameters' do
+      expect(Fastlane::Helper::AppReleaseTrainHelper).to receive(:ensure_release_branch_not_stale!)
+        .with('release/1.2.3', 'abc123')
+        .once
+
+      Fastlane::Actions::EnsureReleaseBranchNotStaleAction.run(
+        release_branch: 'release/1.2.3',
+        cut_from_sha: 'abc123'
+      )
+    end
+  end
+
+  describe '#available_options' do
+    it 'has correct number of options' do
+      expect(Fastlane::Actions::EnsureReleaseBranchNotStaleAction.available_options.size).to eq(2)
+    end
+  end
+end

--- a/spec/actions/find_release_candidate_commit_action_spec.rb
+++ b/spec/actions/find_release_candidate_commit_action_spec.rb
@@ -1,0 +1,31 @@
+describe Fastlane::Actions::FindReleaseCandidateCommitAction do
+  describe '#run' do
+    it 'calls the helper with the appropriate parameters' do
+      expect(Fastlane::Helper::AppReleaseTrainHelper).to receive(:find_candidate_commit)
+        .with('mock-repo-name', 'mock-github-token', skip_label: 'upload:skip', lookback: 30)
+        .and_return('abc123')
+        .once
+
+      sha = Fastlane::Actions::FindReleaseCandidateCommitAction.run(
+        repo_name: 'mock-repo-name',
+        github_token: 'mock-github-token',
+        skip_label: 'upload:skip',
+        lookback: 30
+      )
+      expect(sha).to eq('abc123')
+    end
+  end
+
+  describe '#available_options' do
+    it 'has correct number of options' do
+      expect(Fastlane::Actions::FindReleaseCandidateCommitAction.available_options.size).to eq(4)
+    end
+
+    it 'has the documented defaults' do
+      options = Fastlane::Actions::FindReleaseCandidateCommitAction.available_options
+      defaults = options.to_h { |option| [option.key, option.default_value] }
+      expect(defaults[:skip_label]).to eq('upload:skip')
+      expect(defaults[:lookback]).to eq(30)
+    end
+  end
+end

--- a/spec/actions/release_candidate_build_number_action_spec.rb
+++ b/spec/actions/release_candidate_build_number_action_spec.rb
@@ -1,0 +1,22 @@
+describe Fastlane::Actions::ReleaseCandidateBuildNumberAction do
+  describe '#run' do
+    it 'calls the helper with the appropriate parameters' do
+      expect(Fastlane::Helper::AppReleaseTrainHelper).to receive(:release_candidate_build_number)
+        .with('1.2.3', 'main')
+        .and_return(456)
+        .once
+
+      build_number = Fastlane::Actions::ReleaseCandidateBuildNumberAction.run(
+        version: '1.2.3',
+        main_branch: 'main'
+      )
+      expect(build_number).to eq(456)
+    end
+  end
+
+  describe '#available_options' do
+    it 'has correct number of options' do
+      expect(Fastlane::Actions::ReleaseCandidateBuildNumberAction.available_options.size).to eq(2)
+    end
+  end
+end

--- a/spec/actions/tag_uploaded_build_action_spec.rb
+++ b/spec/actions/tag_uploaded_build_action_spec.rb
@@ -1,0 +1,20 @@
+describe Fastlane::Actions::TagUploadedBuildAction do
+  describe '#run' do
+    it 'calls the helper with the appropriate parameters' do
+      expect(Fastlane::Helper::AppReleaseTrainHelper).to receive(:tag_uploaded_build)
+        .with('1.2.3', 456)
+        .once
+
+      Fastlane::Actions::TagUploadedBuildAction.run(
+        version: '1.2.3',
+        build_number: 456
+      )
+    end
+  end
+
+  describe '#available_options' do
+    it 'has correct number of options' do
+      expect(Fastlane::Actions::TagUploadedBuildAction.available_options.size).to eq(2)
+    end
+  end
+end

--- a/spec/contracts/helper_method_contract_spec.rb
+++ b/spec/contracts/helper_method_contract_spec.rb
@@ -8,6 +8,7 @@ require 'set'
 # Complements verify_partial_doubles (which catches test-side mock mismatches)
 # by covering the implementation side.
 HELPER_CLASSES = {
+  'AppReleaseTrainHelper' => Fastlane::Helper::AppReleaseTrainHelper,
   'GitHubHelper' => Fastlane::Helper::GitHubHelper,
   'RevenuecatInternalHelper' => Fastlane::Helper::RevenuecatInternalHelper,
   'VersioningHelper' => Fastlane::Helper::VersioningHelper,

--- a/spec/helper/app_release_train_helper_spec.rb
+++ b/spec/helper/app_release_train_helper_spec.rb
@@ -1,0 +1,641 @@
+describe Fastlane::Helper::AppReleaseTrainHelper do
+  let(:repo_name) { 'mock-repo-name' }
+  let(:github_token) { 'mock-github-token' }
+  let(:label_options) do
+    {
+      major_bump_labels: ['pr:force_major'],
+      minor_bump_labels: ['pr:breaking', 'pr:feat', 'pr:force_minor'],
+      patch_bump_labels: ['pr:fix', 'pr:dependencies', 'pr:force_patch'],
+      changelog_ignore_label: 'pr:changelog_ignore'
+    }
+  end
+
+  def stub_releases_api(body)
+    allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+      .with(server_url: 'https://api.github.com',
+            path: "/repos/RevenueCat/#{repo_name}/releases?per_page=100",
+            http_method: 'GET',
+            body: {},
+            api_token: github_token)
+      .and_return({ body: body.to_json })
+  end
+
+  def stub_pr_api(pr_number, labels)
+    allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+      .with(server_url: 'https://api.github.com',
+            path: "/repos/RevenueCat/#{repo_name}/pulls/#{pr_number}",
+            http_method: 'GET',
+            body: {},
+            api_token: github_token)
+      .and_return({ body: { "labels" => labels.map { |name| { "name" => name } } }.to_json })
+  end
+
+  describe '.last_release_tag' do
+    it 'returns nil when there are no releases' do
+      stub_releases_api([])
+      expect(described_class.last_release_tag(repo_name, github_token)).to be_nil
+    end
+
+    it 'excludes draft releases' do
+      stub_releases_api([{ "tag_name" => "2.0.0-100", "draft" => true }])
+      expect(described_class.last_release_tag(repo_name, github_token)).to be_nil
+    end
+
+    it 'picks the max by version then build, not by creation order' do
+      stub_releases_api([
+                          { "tag_name" => "1.2.4-101", "draft" => false },
+                          { "tag_name" => "1.10.0-90", "draft" => false },
+                          { "tag_name" => "1.10.0-95", "draft" => false }
+                        ])
+      expect(described_class.last_release_tag(repo_name, github_token)).to eq("1.10.0-95")
+    end
+
+    it 'ignores malformed tags when a well-formed one exists' do
+      stub_releases_api([
+                          { "tag_name" => "v2.0.0", "draft" => false },
+                          { "tag_name" => "1.2.3-45", "draft" => false }
+                        ])
+      expect(described_class.last_release_tag(repo_name, github_token)).to eq("1.2.3-45")
+    end
+
+    it 'returns the newest raw tag when no tag is well-formed, so the caller can report the format error' do
+      stub_releases_api([
+                          { "tag_name" => "v2.0.0", "draft" => false },
+                          { "tag_name" => "v1.0.0", "draft" => false }
+                        ])
+      expect(described_class.last_release_tag(repo_name, github_token)).to eq("v2.0.0")
+    end
+
+    it 'fails on API errors instead of treating them as the first release' do
+      allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+        .and_raise(StandardError.new("boom"))
+      expect do
+        described_class.last_release_tag(repo_name, github_token)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /Could not fetch the latest GitHub release: boom/)
+    end
+  end
+
+  describe '.release_version_from_tag' do
+    it 'extracts the version from a well-formed tag' do
+      expect(described_class.release_version_from_tag("1.2.3-456")).to eq("1.2.3")
+    end
+
+    it 'fails on a malformed tag' do
+      expect do
+        described_class.release_version_from_tag("v1.2.3")
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /does not match the expected <version>-<build> format/)
+    end
+
+    it 'fails on a zero build number' do
+      expect do
+        described_class.release_version_from_tag("1.2.3-0")
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /does not match the expected <version>-<build> format/)
+    end
+  end
+
+  describe '.bump_type_since' do
+    let(:tag) { '1.0.0-10' }
+
+    before do
+      allow(described_class).to receive(:ensure_full_git_history)
+      allow(Fastlane::Actions).to receive(:sh).with("git", "fetch", "--tags", "--force", log: false)
+      allow(Fastlane::Actions).to receive(:sh)
+        .with("git", "rev-parse", "--verify", "--quiet", "refs/tags/#{tag}", log: false)
+        .and_return("abc123\n")
+    end
+
+    def stub_subjects(subjects)
+      allow(Fastlane::Actions).to receive(:sh)
+        .with("git", "log", "#{tag}..HEAD", "--pretty=format:%s", log: false)
+        .and_return(subjects.join("\n"))
+    end
+
+    it 'returns :major when a merged PR has a major bump label' do
+      stub_subjects(["Big change (#12)"])
+      allow(described_class).to receive(:pr_labels_for).with("12", repo_name, github_token, strict: true).and_return(["pr:force_major"])
+      expect(described_class.bump_type_since(tag, repo_name, github_token, **label_options)).to eq(:major)
+    end
+
+    it 'prefers major over minor and patch' do
+      stub_subjects(["A (#1)", "B (#2)"])
+      allow(described_class).to receive(:pr_labels_for).with("1", repo_name, github_token, strict: true).and_return(["pr:fix"])
+      allow(described_class).to receive(:pr_labels_for).with("2", repo_name, github_token, strict: true).and_return(["pr:force_major"])
+      expect(described_class.bump_type_since(tag, repo_name, github_token, **label_options)).to eq(:major)
+    end
+
+    it 'returns :minor for minor bump labels' do
+      stub_subjects(["Feature (#3)"])
+      allow(described_class).to receive(:pr_labels_for).with("3", repo_name, github_token, strict: true).and_return(["pr:feat"])
+      expect(described_class.bump_type_since(tag, repo_name, github_token, **label_options)).to eq(:minor)
+    end
+
+    it 'returns :patch for patch bump labels' do
+      stub_subjects(["Fix (#4)"])
+      allow(described_class).to receive(:pr_labels_for).with("4", repo_name, github_token, strict: true).and_return(["pr:fix"])
+      expect(described_class.bump_type_since(tag, repo_name, github_token, **label_options)).to eq(:patch)
+    end
+
+    it 'returns nil when no PR has a bump label' do
+      stub_subjects(["Docs (#5)", "Chore without PR reference"])
+      allow(described_class).to receive(:pr_labels_for).with("5", repo_name, github_token, strict: true).and_return(["pr:other"])
+      expect(described_class.bump_type_since(tag, repo_name, github_token, **label_options)).to be_nil
+    end
+
+    it 'excludes the whole PR from version calculation when it has the changelog-ignore label' do
+      stub_subjects(["Feature flagged work (#6)"])
+      allow(described_class).to receive(:pr_labels_for).with("6", repo_name, github_token, strict: true).and_return(["pr:feat", "pr:changelog_ignore"])
+      expect(described_class.bump_type_since(tag, repo_name, github_token, **label_options)).to be_nil
+    end
+
+    it 'reads PR numbers from "Merge pull request #N" subjects too' do
+      stub_subjects(["Merge pull request #7 from RevenueCat/branch"])
+      allow(described_class).to receive(:pr_labels_for).with("7", repo_name, github_token, strict: true).and_return(["pr:fix"])
+      expect(described_class.bump_type_since(tag, repo_name, github_token, **label_options)).to eq(:patch)
+    end
+
+    it 'scans full history when there is no tag yet' do
+      allow(Fastlane::Actions).to receive(:sh)
+        .with("git", "log", "HEAD", "--pretty=format:%s", log: false)
+        .and_return("Fix (#8)")
+      allow(described_class).to receive(:pr_labels_for).with("8", repo_name, github_token, strict: true).and_return(["pr:fix"])
+      expect(described_class.bump_type_since(nil, repo_name, github_token, **label_options)).to eq(:patch)
+    end
+
+    it 'fails when the release tag does not exist as a git tag' do
+      allow(Fastlane::Actions).to receive(:sh)
+        .with("git", "rev-parse", "--verify", "--quiet", "refs/tags/#{tag}", log: false)
+        .and_raise(StandardError.new("exit 1"))
+      expect do
+        described_class.bump_type_since(tag, repo_name, github_token, **label_options)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /does not exist as a git tag/)
+    end
+
+    it 'propagates label lookup failures instead of computing a wrong bump' do
+      stub_subjects(["Fix (#9)"])
+      allow(described_class).to receive(:pr_labels_for).with("9", repo_name, github_token, strict: true).and_raise(StandardError.new("api down"))
+      expect do
+        described_class.bump_type_since(tag, repo_name, github_token, **label_options)
+      end.to raise_error(StandardError, /api down/)
+    end
+  end
+
+  describe '.calculate_next_version' do
+    it 'bumps major' do
+      expect(described_class.calculate_next_version("1.2.3", :major)).to eq("2.0.0")
+    end
+
+    it 'bumps minor' do
+      expect(described_class.calculate_next_version("1.2.3", :minor)).to eq("1.3.0")
+    end
+
+    it 'bumps patch' do
+      expect(described_class.calculate_next_version("1.2.3", :patch)).to eq("1.2.4")
+    end
+
+    it 'fails on an unknown bump type' do
+      expect do
+        described_class.calculate_next_version("1.2.3", :nope)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /Unknown bump type: nope/)
+    end
+  end
+
+  describe '.next_release_version' do
+    it 'bumps from the last released version' do
+      allow(described_class).to receive(:last_release_tag).with(repo_name, github_token).and_return("1.2.3-45")
+      allow(described_class).to receive(:bump_type_since).with("1.2.3-45", repo_name, github_token, **label_options).and_return(:minor)
+      expect(described_class.next_release_version(repo_name, github_token, "1.2.0", **label_options)).to eq("1.3.0")
+    end
+
+    it 'bootstraps from the current version when there are no releases yet' do
+      allow(described_class).to receive(:last_release_tag).with(repo_name, github_token).and_return(nil)
+      allow(described_class).to receive(:bump_type_since).with(nil, repo_name, github_token, **label_options).and_return(:patch)
+      expect(described_class.next_release_version(repo_name, github_token, "0.9.0", **label_options)).to eq("0.9.1")
+    end
+
+    it 'fails when there are no releases and no current version to bump from' do
+      allow(described_class).to receive(:last_release_tag).with(repo_name, github_token).and_return(nil)
+      expect do
+        described_class.next_release_version(repo_name, github_token, nil, **label_options)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /no current_version was provided/)
+    end
+
+    it 'fails when no version-bumping labels were found' do
+      allow(described_class).to receive(:last_release_tag).with(repo_name, github_token).and_return("1.2.3-45")
+      allow(described_class).to receive(:bump_type_since).and_return(nil)
+      expect do
+        described_class.next_release_version(repo_name, github_token, "1.2.0", **label_options)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /No version-bumping PR labels found since 1\.2\.3-45/)
+    end
+
+    it 'fails on a malformed latest release tag' do
+      allow(described_class).to receive(:last_release_tag).with(repo_name, github_token).and_return("v1.2.3")
+      expect do
+        described_class.next_release_version(repo_name, github_token, "1.2.0", **label_options)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /does not match the expected <version>-<build> format/)
+    end
+  end
+
+  describe '.released_version_baseline' do
+    it 'falls back to the checked-in version when the releases API fails' do
+      allow(described_class).to receive(:last_release_tag).and_raise(StandardError.new("api down"))
+      expect(FastlaneCore::UI).to receive(:important).with(/baseline falls back to the checked-in version/)
+      expect(described_class.released_version_baseline("1.2.0", repo_name, github_token)).to eq("1.2.0")
+    end
+
+    it 'uses the released version when it is above the checked-in one' do
+      allow(described_class).to receive(:last_release_tag).and_return("1.3.0-50")
+      expect(described_class.released_version_baseline("1.2.0", repo_name, github_token)).to eq("1.3.0")
+    end
+
+    it 'uses the checked-in version when it is above the released one' do
+      allow(described_class).to receive(:last_release_tag).and_return("1.3.0-50")
+      expect(described_class.released_version_baseline("1.10.0", repo_name, github_token)).to eq("1.10.0")
+    end
+
+    it 'ignores a malformed release tag' do
+      allow(described_class).to receive(:last_release_tag).and_return("v9.9.9")
+      expect(described_class.released_version_baseline("1.2.0", repo_name, github_token)).to eq("1.2.0")
+    end
+
+    it 'uses the checked-in version when there are no releases' do
+      allow(described_class).to receive(:last_release_tag).and_return(nil)
+      expect(described_class.released_version_baseline("1.2.0", repo_name, github_token)).to eq("1.2.0")
+    end
+  end
+
+  describe '.derived_version' do
+    def derived_version(checked_in_version)
+      described_class.derived_version(checked_in_version, "main", repo_name, github_token, **label_options)
+    end
+
+    it 'returns the checked-in version off the main branch' do
+      allow(Fastlane::Actions).to receive(:git_branch).and_return("feature/thing")
+      expect(derived_version("1.2.0")).to eq("1.2.0")
+    end
+
+    context 'on the main branch' do
+      before do
+        allow(Fastlane::Actions).to receive(:git_branch).and_return("main")
+        allow(described_class).to receive(:released_version_baseline).with("1.2.0", repo_name, github_token).and_return("1.2.3")
+      end
+
+      it 'returns the version derived from PR labels when above the baseline' do
+        allow(described_class).to receive(:next_release_version).and_return("1.3.0")
+        expect(derived_version("1.2.0")).to eq("1.3.0")
+      end
+
+      it 'falls back to a patch bump of the baseline when derivation fails' do
+        allow(described_class).to receive(:next_release_version).and_raise(StandardError.new("api down"))
+        expect(FastlaneCore::UI).to receive(:important).with(/Could not derive the next version from PR labels \(api down\); using 1\.2\.4 \(baseline 1\.2\.3 \+ patch\)/)
+        expect(derived_version("1.2.0")).to eq("1.2.4")
+      end
+
+      it 'never returns a version at or below the released baseline' do
+        allow(described_class).to receive(:next_release_version).and_return("1.2.3")
+        expect(FastlaneCore::UI).to receive(:important).with(/not above the released baseline 1\.2\.3; using 1\.2\.4/)
+        expect(derived_version("1.2.0")).to eq("1.2.4")
+      end
+
+      it 'falls back when the derived version is below the baseline' do
+        allow(described_class).to receive(:next_release_version).and_return("1.1.0")
+        expect(derived_version("1.2.0")).to eq("1.2.4")
+      end
+    end
+  end
+
+  describe '.commit_count_build_number' do
+    before do
+      allow(described_class).to receive(:ensure_full_git_history)
+    end
+
+    it 'returns the commit count as an integer' do
+      allow(Fastlane::Actions).to receive(:sh).with("git", "rev-list", "--count", "HEAD", log: false).and_return("1234\n")
+      expect(described_class.commit_count_build_number).to eq(1234)
+    end
+
+    it 'fails on non-numeric output' do
+      allow(Fastlane::Actions).to receive(:sh).with("git", "rev-list", "--count", "HEAD", log: false).and_return("fatal: bad revision")
+      expect do
+        described_class.commit_count_build_number
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /Could not compute the build number/)
+    end
+
+    it 'fails on a zero count' do
+      allow(Fastlane::Actions).to receive(:sh).with("git", "rev-list", "--count", "HEAD", log: false).and_return("0")
+      expect do
+        described_class.commit_count_build_number
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /Could not compute the build number/)
+    end
+  end
+
+  describe '.ensure_full_git_history' do
+    it 'unshallows a shallow checkout' do
+      allow(Fastlane::Actions).to receive(:sh).with("git", "rev-parse", "--is-shallow-repository", log: false).and_return("true\n")
+      expect(Fastlane::Actions).to receive(:sh).with("git", "fetch", "--unshallow", log: false).once
+      described_class.ensure_full_git_history
+    end
+
+    it 'does nothing on a full checkout' do
+      allow(Fastlane::Actions).to receive(:sh).with("git", "rev-parse", "--is-shallow-repository", log: false).and_return("false\n")
+      expect(Fastlane::Actions).not_to receive(:sh).with("git", "fetch", "--unshallow", log: false)
+      described_class.ensure_full_git_history
+    end
+  end
+
+  describe '.tag_uploaded_build' do
+    it 'creates and pushes a builds/ tag' do
+      expect(Fastlane::Actions).to receive(:sh).with("git", "tag", "builds/1.2.3-456").once
+      expect(Fastlane::Actions).to receive(:sh).with("git", "push", "origin", "refs/tags/builds/1.2.3-456").once
+      described_class.tag_uploaded_build("1.2.3", 456)
+    end
+
+    it 'warns but never raises when tagging fails' do
+      allow(Fastlane::Actions).to receive(:sh).with("git", "tag", "builds/1.2.3-456").and_raise(StandardError.new("tag exists"))
+      expect(FastlaneCore::UI).to receive(:important).with(%r{Could not tag uploaded build builds/1\.2\.3-456: tag exists})
+      expect { described_class.tag_uploaded_build("1.2.3", 456) }.not_to raise_error
+    end
+
+    it 'warns but never raises when pushing fails' do
+      allow(Fastlane::Actions).to receive(:sh).with("git", "tag", "builds/1.2.3-456")
+      allow(Fastlane::Actions).to receive(:sh).with("git", "push", "origin", "refs/tags/builds/1.2.3-456").and_raise(StandardError.new("no network"))
+      expect(FastlaneCore::UI).to receive(:important).with(%r{Could not tag uploaded build builds/1\.2\.3-456: no network})
+      expect { described_class.tag_uploaded_build("1.2.3", 456) }.not_to raise_error
+    end
+  end
+
+  describe '.builds_tags_at' do
+    it 'returns only builds/ tags pointing at the sha' do
+      allow(Fastlane::Actions).to receive(:sh).with("git", "tag", "--points-at", "abc123", log: false)
+                                              .and_return("builds/1.2.3-456\n1.2.3-456\nsome-other-tag\n")
+      expect(described_class.builds_tags_at("abc123")).to eq(["builds/1.2.3-456"])
+    end
+  end
+
+  describe '.find_candidate_commit' do
+    let(:sha_a) { 'a' * 40 }
+    let(:sha_b) { 'b' * 40 }
+
+    before do
+      allow(described_class).to receive(:ensure_full_git_history)
+      allow(Fastlane::Actions).to receive(:sh).with("git", "fetch", "--tags", "--force", log: false)
+    end
+
+    def stub_rev_list(shas)
+      allow(Fastlane::Actions).to receive(:sh)
+        .with("git", "rev-list", "--first-parent", "-n", "30", "HEAD", log: false)
+        .and_return("#{shas.join("\n")}\n")
+    end
+
+    def stub_subject(sha, subject)
+      allow(Fastlane::Actions).to receive(:sh).with("git", "log", "-1", "--pretty=format:%s", sha, log: false).and_return(subject)
+    end
+
+    it 'returns the newest commit with a builds/ tag' do
+      stub_rev_list([sha_a])
+      allow(described_class).to receive(:builds_tags_at).with(sha_a).and_return(["builds/1.2.3-456"])
+      expect(described_class.find_candidate_commit(repo_name, github_token, skip_label: "upload:skip", lookback: 30)).to eq(sha_a)
+    end
+
+    it 'walks past untagged commits whose PR has the skip label' do
+      stub_rev_list([sha_a, sha_b])
+      allow(described_class).to receive(:builds_tags_at).with(sha_a).and_return([])
+      allow(described_class).to receive(:builds_tags_at).with(sha_b).and_return(["builds/1.2.3-455"])
+      stub_subject(sha_a, "CI only change (#12)")
+      allow(described_class).to receive(:pr_labels_for).with("12", repo_name, github_token).and_return(["upload:skip"])
+      expect(described_class.find_candidate_commit(repo_name, github_token, skip_label: "upload:skip", lookback: 30)).to eq(sha_b)
+    end
+
+    it 'fails on an untagged commit without the skip label' do
+      stub_rev_list([sha_a])
+      allow(described_class).to receive(:builds_tags_at).with(sha_a).and_return([])
+      stub_subject(sha_a, "Feature (#13)")
+      allow(described_class).to receive(:pr_labels_for).with("13", repo_name, github_token).and_return(["pr:feat"])
+      expect do
+        described_class.find_candidate_commit(repo_name, github_token, skip_label: "upload:skip", lookback: 30)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /has no candidate build and is not upload:skip/)
+    end
+
+    it 'fails on an untagged commit with no PR reference in its subject' do
+      stub_rev_list([sha_a])
+      allow(described_class).to receive(:builds_tags_at).with(sha_a).and_return([])
+      stub_subject(sha_a, "Direct push without PR")
+      expect do
+        described_class.find_candidate_commit(repo_name, github_token, skip_label: "upload:skip", lookback: 30)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /has no candidate build/)
+    end
+
+    it 'fails when no candidate exists within the lookback window' do
+      stub_rev_list([sha_a, sha_b])
+      allow(described_class).to receive(:builds_tags_at).and_return([])
+      stub_subject(sha_a, "Skip one (#1)")
+      stub_subject(sha_b, "Skip two (#2)")
+      allow(described_class).to receive(:pr_labels_for).and_return(["upload:skip"])
+      expect do
+        described_class.find_candidate_commit(repo_name, github_token, skip_label: "upload:skip", lookback: 30)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /No candidate build found in the last 30 commits/)
+    end
+  end
+
+  describe '.release_fork_point' do
+    before do
+      allow(described_class).to receive(:ensure_full_git_history)
+      allow(Fastlane::Actions).to receive(:sh).with("git", "fetch", "origin", "main", log: false)
+    end
+
+    it 'returns the merge-base with the main branch' do
+      allow(Fastlane::Actions).to receive(:sh).with("git", "merge-base", "HEAD", "origin/main", log: false).and_return("abc123\n")
+      expect(described_class.release_fork_point("main")).to eq("abc123")
+    end
+
+    it 'fails when the merge-base cannot be determined' do
+      allow(Fastlane::Actions).to receive(:sh).with("git", "merge-base", "HEAD", "origin/main", log: false).and_return("")
+      expect do
+        described_class.release_fork_point("main")
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /Could not determine the main commit this release was cut from/)
+    end
+  end
+
+  describe '.release_candidate_build_number' do
+    let(:fork_point) { 'f' * 40 }
+
+    before do
+      allow(described_class).to receive(:release_fork_point).with("main").and_return(fork_point)
+      allow(Fastlane::Actions).to receive(:sh).with("git", "fetch", "--tags", "--force", log: false)
+    end
+
+    def stub_tags_at_fork_point(tags)
+      allow(Fastlane::Actions).to receive(:sh).with("git", "tag", "--points-at", fork_point, log: false).and_return(tags.join("\n"))
+    end
+
+    it 'returns the build number of the candidate tag' do
+      stub_tags_at_fork_point(["builds/1.2.3-456"])
+      expect(described_class.release_candidate_build_number("1.2.3", "main")).to eq(456)
+    end
+
+    it 'returns the max build number when multiple candidate tags exist' do
+      stub_tags_at_fork_point(["builds/1.2.3-456", "builds/1.2.3-457"])
+      expect(described_class.release_candidate_build_number("1.2.3", "main")).to eq(457)
+    end
+
+    it 'ignores tags for other versions' do
+      stub_tags_at_fork_point(["builds/1.2.4-456"])
+      expect do
+        described_class.release_candidate_build_number("1.2.3", "main")
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, %r{No builds/1\.2\.3-\* tag points at ffffffff.*Tags found there: builds/1\.2\.4-456\.}m)
+    end
+
+    it 'fails with recovery hints when the commit has no tags at all' do
+      stub_tags_at_fork_point([])
+      expect do
+        described_class.release_candidate_build_number("1.2.3", "main")
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, %r{tag it manually: git tag builds/1\.2\.3-<build> ffffffff}) do |error|
+        expect(error.message).not_to include("Tags found there")
+      end
+    end
+  end
+
+  describe '.ensure_candidate_version_matches!' do
+    let(:sha) { 'c' * 40 }
+
+    it 'passes when a candidate tag matches the computed version' do
+      allow(described_class).to receive(:builds_tags_at).with(sha).and_return(["builds/1.2.3-456"])
+      expect { described_class.ensure_candidate_version_matches!(sha, "1.2.3") }.not_to raise_error
+    end
+
+    it 'fails when the uploaded version differs from the computed one' do
+      allow(described_class).to receive(:builds_tags_at).with(sha).and_return(["builds/1.2.3-456"])
+      expect do
+        described_class.ensure_candidate_version_matches!(sha, "1.3.0")
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /was uploaded as 1\.2\.3, but the cut computes 1\.3\.0/)
+    end
+  end
+
+  describe '.ensure_release_branch_not_stale!' do
+    let(:cut_from) { 'd' * 40 }
+
+    it 'passes when the branch contains the cut commit and has no merge commits' do
+      allow(Fastlane::Actions).to receive(:sh).with("git", "merge-base", "--is-ancestor", cut_from, "HEAD", log: false)
+      allow(Fastlane::Actions).to receive(:sh).with("git", "rev-list", "--merges", "#{cut_from}..HEAD", log: false).and_return("")
+      expect { described_class.ensure_release_branch_not_stale!("release/1.2.3", cut_from) }.not_to raise_error
+    end
+
+    it 'fails when the branch does not contain the cut commit' do
+      allow(Fastlane::Actions).to receive(:sh).with("git", "merge-base", "--is-ancestor", cut_from, "HEAD", log: false)
+                                              .and_raise(StandardError.new("exit 1"))
+      expect do
+        described_class.ensure_release_branch_not_stale!("release/1.2.3", cut_from)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, %r{release/1\.2\.3 branch was cut from an older commit and does not contain dddddddd})
+    end
+
+    it 'fails when the branch contains merge commits' do
+      allow(Fastlane::Actions).to receive(:sh).with("git", "merge-base", "--is-ancestor", cut_from, "HEAD", log: false)
+      allow(Fastlane::Actions).to receive(:sh).with("git", "rev-list", "--merges", "#{cut_from}..HEAD", log: false).and_return("#{'e' * 40}\n")
+      expect do
+        described_class.ensure_release_branch_not_stale!("release/1.2.3", cut_from)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /contains merge commits \(eeeeeeee\)/)
+    end
+  end
+
+  describe '.ensure_release_branch_is_metadata_only!' do
+    let(:fork_point) { 'f' * 40 }
+    let(:allowed_prefixes) { ["fastlane/metadata/"] }
+    let(:version_file) { "App.xcodeproj/project.pbxproj" }
+    let(:version_line_pattern) { "MARKETING_VERSION" }
+
+    before do
+      allow(described_class).to receive(:release_fork_point).with("main").and_return(fork_point)
+      allow(Fastlane::Actions).to receive(:sh).with("git", "rev-list", "--merges", "#{fork_point}..HEAD", log: false).and_return("")
+    end
+
+    def stub_changed_files(paths)
+      allow(Fastlane::Actions).to receive(:sh).with("git", "diff", "--name-only", "#{fork_point}..HEAD", log: false).and_return(paths.join("\n"))
+    end
+
+    def run_check
+      described_class.ensure_release_branch_is_metadata_only!("main", allowed_prefixes, version_file, version_line_pattern)
+    end
+
+    it 'passes when only metadata changed' do
+      stub_changed_files(["fastlane/metadata/en-US/release_notes.txt"])
+      expect { run_check }.not_to raise_error
+    end
+
+    it 'fails when the branch contains merge commits' do
+      allow(Fastlane::Actions).to receive(:sh).with("git", "rev-list", "--merges", "#{fork_point}..HEAD", log: false).and_return("#{'a' * 40}\n")
+      expect { run_check }.to raise_error(FastlaneCore::Interface::FastlaneError, /contains merge commits \(aaaaaaaa\)/)
+    end
+
+    it 'fails on changes outside the allowed paths' do
+      stub_changed_files(["Sources/App/Feature.swift"])
+      expect { run_check }.to raise_error(FastlaneCore::Interface::FastlaneError, %r{Unexpected changes since ffffffff: Sources/App/Feature\.swift})
+    end
+
+    it 'allows version file edits that only touch version lines' do
+      stub_changed_files([version_file])
+      diff = <<~DIFF
+        --- a/App.xcodeproj/project.pbxproj
+        +++ b/App.xcodeproj/project.pbxproj
+        -\t\t\t\tMARKETING_VERSION = 1.2.3;
+        +\t\t\t\tMARKETING_VERSION = 1.3.0;
+      DIFF
+      allow(Fastlane::Actions).to receive(:sh).with("git", "diff", "#{fork_point}..HEAD", "--", version_file, log: false).and_return(diff)
+      expect { run_check }.not_to raise_error
+    end
+
+    it 'fails on version file edits beyond version lines' do
+      stub_changed_files([version_file])
+      diff = <<~DIFF
+        -\t\t\t\tMARKETING_VERSION = 1.2.3;
+        +\t\t\t\tMARKETING_VERSION = 1.3.0;
+        +\t\t\t\tSWIFT_VERSION = 6.0;
+      DIFF
+      allow(Fastlane::Actions).to receive(:sh).with("git", "diff", "#{fork_point}..HEAD", "--", version_file, log: false).and_return(diff)
+      expect { run_check }.to raise_error(FastlaneCore::Interface::FastlaneError, /beyond lines matching "MARKETING_VERSION"/)
+    end
+
+    it 'treats the version file as disallowed when no version file is configured' do
+      stub_changed_files(["App.xcodeproj/project.pbxproj"])
+      expect do
+        described_class.ensure_release_branch_is_metadata_only!("main", allowed_prefixes, nil, nil)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /Unexpected changes/)
+    end
+  end
+
+  describe '.pr_number_from_subject' do
+    it 'prefers a trailing (#N)' do
+      expect(described_class.pr_number_from_subject("Fix crash (#123)")).to eq("123")
+    end
+
+    it 'ignores issue references that are not trailing' do
+      expect(described_class.pr_number_from_subject("Fix crash (#123) properly")).to be_nil
+    end
+
+    it 'reads merge commit subjects' do
+      expect(described_class.pr_number_from_subject("Merge pull request #45 from RevenueCat/branch")).to eq("45")
+    end
+
+    it 'returns nil for subjects without a PR reference' do
+      expect(described_class.pr_number_from_subject("Direct commit")).to be_nil
+    end
+  end
+
+  describe '.pr_labels_for' do
+    it 'returns the label names' do
+      stub_pr_api(12, ["pr:fix", "upload:skip"])
+      expect(described_class.pr_labels_for(12, repo_name, github_token)).to eq(["pr:fix", "upload:skip"])
+    end
+
+    it 'fails open with an empty list by default' do
+      allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry).and_raise(StandardError.new("api down"))
+      expect(FastlaneCore::UI).to receive(:important).with(/Could not fetch labels for PR #12: api down/)
+      expect(described_class.pr_labels_for(12, repo_name, github_token)).to eq([])
+    end
+
+    it 'raises in strict mode' do
+      allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry).and_raise(StandardError.new("api down"))
+      expect do
+        described_class.pr_labels_for(12, repo_name, github_token, strict: true)
+      end.to raise_error(StandardError, /api down/)
+    end
+  end
+end


### PR DESCRIPTION
Extracts the mobile app's release-train logic from revenuecat-mobile-ios's Fastfile into reusable plugin actions, so the Android app repo can adopt the same release flow without reimplementing it. The logic was hardened across several review rounds and a real release (1.13.0, 2026-07-10); semantics are preserved exactly — this PR only generalizes app-specific strings and makes labels/paths configurable.

## The model these actions implement

- The checked-in app version is the **last released** version; every main build derives the next version from `pr:` labels merged since the last GitHub release (`x.y.z-N` tags), guarded so no answer is ever ≤ an already-released version (stores reject those uploads).
- Build numbers are the repo's commit count — monotonic, collision-free, offline.
- Every store upload is recorded with a lightweight `builds/x.y.z-N` tag; a release ships **the already-uploaded build of the commit it was cut from** (what testers dogfooded is what ships), so release branches are metadata-only and refuse merge commits.

## Actions

| Action | Purpose |
|---|---|
| `determine_app_release_version` | Next version from GitHub releases baseline + label bumps (label sets configurable) |
| `derived_app_version` | The guarded build-time derivation with patch-bump fallbacks and monotonic guard |
| `commit_count_build_number` | Build number from `git rev-list --count HEAD` (unshallows first) |
| `tag_uploaded_build` | Best-effort `builds/x.y.z-N` tag on the built commit |
| `find_release_candidate_commit` | Newest main commit with a candidate; walks past `upload:skip` merges, hard-fails on unbuilt commits |
| `release_candidate_build_number` | Candidate build number via the fork point's `builds/*` tag |
| `ensure_candidate_version_matches` | Cut-time drift check: candidate tag version == derived version |
| `ensure_release_branch_not_stale` | Refuses reused release branches cut from older main or containing merges |
| `ensure_release_branch_metadata_only` | Diff-from-fork-point path allowlist + version-file line check (parameterized: pbxproj/`MARKETING_VERSION` for iOS, `build.gradle`/`versionName` for Android) |

All logic lives in `AppReleaseTrainHelper`; actions are thin wrappers. Full spec coverage (bootstrap, malformed tags, draft releases, API-failure fallbacks, monotonic guard, skip-walks, merge refusal, version-file violations): 665 examples green, rubocop clean.

Deliberately not extracted: store-specific code (TestFlight/deliver/Spaceship, `supply` later), release-notes generation (#141), Slack announcements, and the `cut_release` orchestration lane (repos compose these actions in their own lanes).

Companion follow-ups: revenuecat-mobile-ios migrates its Fastfile to these actions (proving the API), then the Android app adopts them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
