### PR TITLE
Check CocoaPods trunk when a pod push errors

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/pod_push_with_error_handling.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/pod_push_with_error_handling.rb
@@ -2,6 +2,10 @@ require 'fastlane/action'
 require 'fastlane_core/ui/ui'
 require 'fastlane_core/configuration/config_item'
 require 'fastlane/actions/pod_push'
+require 'open3'
+require 'net/http'
+require 'json'
+require 'uri'
 
 module Fastlane
   module Actions
@@ -10,6 +14,7 @@ module Fastlane
     class PodPushWithErrorHandlingAction < Action
       MAX_RETRIES = 3
       INITIAL_DELAY = 5
+      TRUNK_BASE_URL = 'https://trunk.cocoapods.org/api/v1/pods'
 
       def self.run(params)
         attempts = 0
@@ -27,12 +32,18 @@ module Fastlane
             )
             return true
           rescue StandardError => e
-            output_str = e.message
-
-            if duplicate_entry?(output_str)
-              FastlaneCore::UI.error("⚠️ Duplicate entry detected. Skipping push.")
+            # The push reported an error, but the pod may actually have been
+            # published: it was already on trunk from a previous run, or this
+            # push succeeded and only reported an error afterwards. `pod trunk
+            # push` surfaces "duplicate entry" only in its output, which fastlane
+            # truncates and omits from the raised error message when stdout is a
+            # TTY (>= 2.237.0), so the message is unreliable. Ask trunk directly.
+            if pod_published?(params[:path])
+              FastlaneCore::UI.important("✅ Pod is already published to CocoaPods trunk. Treating the push as successful.")
               return true
             end
+
+            output_str = e.message
 
             if retryable_error?(output_str) && attempts <= MAX_RETRIES
               delay = INITIAL_DELAY * (2**(attempts - 1))
@@ -54,8 +65,38 @@ module Fastlane
         false
       end
 
-      def self.duplicate_entry?(msg)
-        msg.include?("[!] Unable to accept duplicate entry for:")
+      # Returns true if the podspec's version is already published to CocoaPods
+      # trunk. Used to recover from a push that failed but nonetheless published
+      # the pod (or was already published). Any lookup failure returns false so
+      # the caller keeps treating the push as failed rather than silently
+      # swallowing a real error.
+      def self.pod_published?(path)
+        name, version = pod_name_and_version(path)
+        return false if name.nil? || version.nil?
+
+        trunk_has_version?(name, version)
+      end
+
+      def self.pod_name_and_version(path)
+        output, _error, status = Open3.capture3('pod', 'ipc', 'spec', path.to_s)
+        return [nil, nil] unless status.success?
+
+        spec = JSON.parse(output)
+        [spec['name'], spec['version']]
+      rescue StandardError => e
+        FastlaneCore::UI.important("⚠️ Could not read pod name/version from #{path}: #{e.message}")
+        [nil, nil]
+      end
+
+      def self.trunk_has_version?(name, version)
+        response = Net::HTTP.get_response(URI("#{TRUNK_BASE_URL}/#{name}"))
+        return false unless response.kind_of?(Net::HTTPSuccess)
+
+        versions = JSON.parse(response.body).fetch('versions', [])
+        versions.any? { |entry| entry['name'] == version }
+      rescue StandardError => e
+        FastlaneCore::UI.important("⚠️ Could not verify whether #{name} #{version} is on CocoaPods trunk: #{e.message}")
+        false
       end
 
       def self.retryable_error?(msg)

--- a/lib/fastlane/plugin/revenuecat_internal/actions/pod_push_with_error_handling.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/pod_push_with_error_handling.rb
@@ -2,7 +2,7 @@ require 'fastlane/action'
 require 'fastlane_core/ui/ui'
 require 'fastlane_core/configuration/config_item'
 require 'fastlane/actions/pod_push'
-require 'open3'
+require 'fastlane/actions/read_podspec'
 require 'net/http'
 require 'json'
 require 'uri'
@@ -78,10 +78,7 @@ module Fastlane
       end
 
       def self.pod_name_and_version(path)
-        output, _error, status = Open3.capture3('pod', 'ipc', 'spec', path.to_s)
-        return [nil, nil] unless status.success?
-
-        spec = JSON.parse(output)
+        spec = Fastlane::Actions::ReadPodspecAction.run(path: path)
         [spec['name'], spec['version']]
       rescue StandardError => e
         FastlaneCore::UI.important("⚠️ Could not read pod name/version from #{path}: #{e.message}")

--- a/spec/actions/pod_push_with_error_handling_action_spec.rb
+++ b/spec/actions/pod_push_with_error_handling_action_spec.rb
@@ -147,43 +147,41 @@ describe Fastlane::Actions::PodPushWithErrorHandlingAction do
       allow(FastlaneCore::UI).to receive(:important)
     end
 
-    # Stubs `pod ipc spec <path>` to return a spec JSON for the given name/version.
-    def stub_pod_ipc_spec(name:, version:, success: true)
-      status = instance_double(Process::Status, success?: success)
-      body = success ? { name: name, version: version }.to_json : ''
-      allow(Open3).to receive(:capture3).with('pod', 'ipc', 'spec', podspec_path).and_return([body, '', status])
+    # Stubs `read_podspec` to return a spec hash for the given name/version.
+    def stub_read_podspec(name:, version:)
+      allow(Fastlane::Actions::ReadPodspecAction).to receive(:run).with(path: podspec_path).and_return('name' => name, 'version' => version)
     end
 
     it 'returns true when the version is listed on trunk' do
-      stub_pod_ipc_spec(name: pod_name, version: pod_version)
+      stub_read_podspec(name: pod_name, version: pod_version)
       stub_request(:get, trunk_url).to_return(status: 200, body: { versions: [{ name: '5.80.0' }, { name: pod_version }] }.to_json)
 
       expect(described_class.pod_published?(podspec_path)).to eq(true)
     end
 
     it 'returns false when the version is not listed on trunk' do
-      stub_pod_ipc_spec(name: pod_name, version: pod_version)
+      stub_read_podspec(name: pod_name, version: pod_version)
       stub_request(:get, trunk_url).to_return(status: 200, body: { versions: [{ name: '5.80.0' }] }.to_json)
 
       expect(described_class.pod_published?(podspec_path)).to eq(false)
     end
 
     it 'returns false when the trunk request is not successful' do
-      stub_pod_ipc_spec(name: pod_name, version: pod_version)
+      stub_read_podspec(name: pod_name, version: pod_version)
       stub_request(:get, trunk_url).to_return(status: 404, body: '')
 
       expect(described_class.pod_published?(podspec_path)).to eq(false)
     end
 
     it 'returns false when the trunk request raises' do
-      stub_pod_ipc_spec(name: pod_name, version: pod_version)
+      stub_read_podspec(name: pod_name, version: pod_version)
       stub_request(:get, trunk_url).to_raise(SocketError.new('no connection'))
 
       expect(described_class.pod_published?(podspec_path)).to eq(false)
     end
 
     it 'returns false when reading the podspec fails' do
-      stub_pod_ipc_spec(name: pod_name, version: pod_version, success: false)
+      allow(Fastlane::Actions::ReadPodspecAction).to receive(:run).with(path: podspec_path).and_raise(StandardError.new('cannot read podspec'))
 
       expect(described_class.pod_published?(podspec_path)).to eq(false)
     end

--- a/spec/actions/pod_push_with_error_handling_action_spec.rb
+++ b/spec/actions/pod_push_with_error_handling_action_spec.rb
@@ -8,36 +8,41 @@ describe Fastlane::Actions::PodPushWithErrorHandlingAction do
     before do
       allow(FastlaneCore::UI).to receive(:message)
       allow(FastlaneCore::UI).to receive(:error)
+      allow(FastlaneCore::UI).to receive(:success)
+      allow(FastlaneCore::UI).to receive(:important)
       allow(FastlaneCore::UI).to receive(:user_error!)
+
+      # Default: the pod is not on trunk. Individual tests override as needed.
+      allow(described_class).to receive(:pod_published?).and_return(false)
     end
 
-    it 'returns true when pod push succeeds' do
-      allow(Fastlane::Actions::PodPushAction).to receive(:run).and_return("Successfully pushed")
+    it 'returns true when pod push succeeds and does not check trunk' do
+      allow(Fastlane::Actions::PodPushAction).to receive(:run).and_return('Successfully pushed')
 
-      result = Fastlane::Actions::PodPushWithErrorHandlingAction.run(path: podspec_path)
+      result = described_class.run(path: podspec_path)
 
       expect(result).to eq(true)
       expect(Fastlane::Actions::PodPushAction).to have_received(:run).once
+      expect(described_class).not_to have_received(:pod_published?)
     end
 
-    it 'catches duplicate entry error and returns true' do
-      error_message = "[!] Unable to accept duplicate entry for: RevenueCat"
-      allow(Fastlane::Actions::PodPushAction).to receive(:run).and_raise(StandardError.new(error_message))
+    it 'treats the push as successful when it errors but the pod is on trunk' do
+      allow(Fastlane::Actions::PodPushAction).to receive(:run).and_raise(StandardError.new('Exit status of command was 1 instead of 0.'))
+      allow(described_class).to receive(:pod_published?).with(podspec_path).and_return(true)
 
-      result = Fastlane::Actions::PodPushWithErrorHandlingAction.run(path: podspec_path)
+      result = described_class.run(path: podspec_path)
 
       expect(result).to eq(true)
-      expect(FastlaneCore::UI).to have_received(:error).with("⚠️ Duplicate entry detected. Skipping push.")
+      expect(FastlaneCore::UI).to have_received(:important).with("✅ Pod is already published to CocoaPods trunk. Treating the push as successful.")
     end
 
-    it 'raises a PodPushUnknownError for other failures' do
-      error_message = "Some unexpected failure"
-      allow(Fastlane::Actions::PodPushAction).to receive(:run).and_raise(StandardError.new(error_message))
+    it 'raises a PodPushUnknownError when the push errors and the pod is not on trunk' do
+      allow(Fastlane::Actions::PodPushAction).to receive(:run).and_raise(StandardError.new('Some unexpected failure'))
 
       expect(FastlaneCore::UI).to receive(:error).with("❌ Pod push failed with an unknown error and won't retry. You can rerun this job using SSH. Error: Some unexpected failure")
 
       expect do
-        Fastlane::Actions::PodPushWithErrorHandlingAction.run(path: podspec_path)
+        described_class.run(path: podspec_path)
       end.to raise_error(Fastlane::Actions::PodPushUnknownError, "❌ Pod push failed: Some unexpected failure")
     end
 
@@ -58,7 +63,7 @@ describe Fastlane::Actions::PodPushWithErrorHandlingAction do
       expect(FastlaneCore::UI).to receive(:important).with(/Retrying in \d+ seconds/).exactly(3).times
       expect(FastlaneCore::UI).to receive(:message).with(/Attempt \d/).exactly(4).times # 3 failures + 1 success
 
-      result = Fastlane::Actions::PodPushWithErrorHandlingAction.run(
+      result = described_class.run(
         path: podspec_path,
         synchronous: true,
         verbose: false,
@@ -84,7 +89,7 @@ describe Fastlane::Actions::PodPushWithErrorHandlingAction do
       expect(FastlaneCore::UI).to receive(:important).with(/Retrying in \d+ seconds/).exactly(3).times
       expect(FastlaneCore::UI).to receive(:message).with(/Attempt \d/).exactly(4).times
 
-      result = Fastlane::Actions::PodPushWithErrorHandlingAction.run(
+      result = described_class.run(
         path: podspec_path,
         synchronous: true,
         verbose: false,
@@ -111,7 +116,7 @@ describe Fastlane::Actions::PodPushWithErrorHandlingAction do
       expect(FastlaneCore::UI).to receive(:important).with(/Retrying in \d+ seconds/).exactly(3).times
       expect(FastlaneCore::UI).to receive(:message).with(/Attempt \d/).exactly(4).times # 3 failures + 1 success
 
-      result = Fastlane::Actions::PodPushWithErrorHandlingAction.run(
+      result = described_class.run(
         path: podspec_path,
         synchronous: true,
         verbose: false,
@@ -119,6 +124,68 @@ describe Fastlane::Actions::PodPushWithErrorHandlingAction do
       )
 
       expect(result).to eq(true) # ✅ Ensure success on the 4th attempt
+    end
+
+    it 'returns false after exhausting retries on a persistent retryable error' do
+      allow(Fastlane::Actions::PodPushAction).to receive(:run).and_raise(StandardError.new('[!] Calling the GitHub commit API timed out.'))
+      allow_any_instance_of(Object).to receive(:sleep)
+
+      result = described_class.run(path: podspec_path)
+
+      expect(result).to eq(false)
+      expect(FastlaneCore::UI).to have_received(:error).with("❌ Pod push failed after 3 retries due to persistent server issues.")
+    end
+  end
+
+  describe '#pod_published?' do
+    let(:podspec_path) { 'RevenueCat.podspec' }
+    let(:pod_name) { 'RevenueCat' }
+    let(:pod_version) { '5.81.0' }
+    let(:trunk_url) { "https://trunk.cocoapods.org/api/v1/pods/#{pod_name}" }
+
+    before do
+      allow(FastlaneCore::UI).to receive(:important)
+    end
+
+    # Stubs `pod ipc spec <path>` to return a spec JSON for the given name/version.
+    def stub_pod_ipc_spec(name:, version:, success: true)
+      status = instance_double(Process::Status, success?: success)
+      body = success ? { name: name, version: version }.to_json : ''
+      allow(Open3).to receive(:capture3).with('pod', 'ipc', 'spec', podspec_path).and_return([body, '', status])
+    end
+
+    it 'returns true when the version is listed on trunk' do
+      stub_pod_ipc_spec(name: pod_name, version: pod_version)
+      stub_request(:get, trunk_url).to_return(status: 200, body: { versions: [{ name: '5.80.0' }, { name: pod_version }] }.to_json)
+
+      expect(described_class.pod_published?(podspec_path)).to eq(true)
+    end
+
+    it 'returns false when the version is not listed on trunk' do
+      stub_pod_ipc_spec(name: pod_name, version: pod_version)
+      stub_request(:get, trunk_url).to_return(status: 200, body: { versions: [{ name: '5.80.0' }] }.to_json)
+
+      expect(described_class.pod_published?(podspec_path)).to eq(false)
+    end
+
+    it 'returns false when the trunk request is not successful' do
+      stub_pod_ipc_spec(name: pod_name, version: pod_version)
+      stub_request(:get, trunk_url).to_return(status: 404, body: '')
+
+      expect(described_class.pod_published?(podspec_path)).to eq(false)
+    end
+
+    it 'returns false when the trunk request raises' do
+      stub_pod_ipc_spec(name: pod_name, version: pod_version)
+      stub_request(:get, trunk_url).to_raise(SocketError.new('no connection'))
+
+      expect(described_class.pod_published?(podspec_path)).to eq(false)
+    end
+
+    it 'returns false when reading the podspec fails' do
+      stub_pod_ipc_spec(name: pod_name, version: pod_version, success: false)
+
+      expect(described_class.pod_published?(podspec_path)).to eq(false)
     end
   end
 


### PR DESCRIPTION
### What & why
`pod_push_with_error_handling` detected an already-published pod by matching `[!] Unable to accept duplicate entry for:` against the raised error's message. Since fastlane 2.237.0, `sh` truncates command output and omits it from `FastlaneShellError` messages when stdout is a TTY, so that string is no longer present — an already-published pod (e.g. re-running a release after a partial failure) now fails the job.

This queries CocoaPods trunk directly instead: on a push error, if the podspec's version is already published, the push is treated as successful. Successful pushes skip the check. The transient-error retry path is unchanged.

Note: this fixes the "already published" case only. Reliable retry-classification for transient errors (also affected by the same 2.237.0 change) is a separate follow-up.

- [x] Unit tests