### PR TITLE
Retry pod push on any failure and log when a pod is not yet published

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/pod_push_with_error_handling.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/pod_push_with_error_handling.rb
@@ -43,21 +43,21 @@ module Fastlane
               return true
             end
 
-            output_str = e.message
-
-            if retryable_error?(output_str) && attempts <= MAX_RETRIES
+            # `pod trunk push` exits non-zero for every kind of failure, and
+            # fastlane (>= 2.237.0) omits the underlying command output from the
+            # raised error's message, so we can't reliably tell transient
+            # failures (CocoaPods 500s, GitHub timeouts, stale spec index) apart
+            # from permanent ones. Retry on any failure. A push that actually
+            # published is already short-circuited by the pod_published? check
+            # above, so retries can't turn into duplicate-entry failures.
+            if attempts <= MAX_RETRIES
               delay = INITIAL_DELAY * (2**(attempts - 1))
-              FastlaneCore::UI.important("⚠️ Retrying in #{delay} seconds... (#{attempts}/#{MAX_RETRIES})")
+              FastlaneCore::UI.important("⚠️ Pod push failed: #{e.message} Retrying in #{delay} seconds... (#{attempts}/#{MAX_RETRIES})")
               sleep(delay)
               next
             end
 
-            if attempts > MAX_RETRIES
-              FastlaneCore::UI.error("❌ Pod push failed after #{MAX_RETRIES} retries due to persistent server issues.")
-              return false
-            end
-
-            FastlaneCore::UI.error("❌ Pod push failed with an unknown error and won't retry. You can rerun this job using SSH. Error: #{e.message}")
+            FastlaneCore::UI.error("❌ Pod push failed after #{MAX_RETRIES} retries. You can rerun this job using SSH. Error: #{e.message}")
             raise PodPushUnknownError, "❌ Pod push failed: #{e.message}"
           end
         end
@@ -74,7 +74,9 @@ module Fastlane
         name, version = pod_name_and_version(path)
         return false if name.nil? || version.nil?
 
-        trunk_has_version?(name, version)
+        published = trunk_has_version?(name, version)
+        FastlaneCore::UI.message("ℹ️ #{name} #{version} is not yet published to CocoaPods trunk.") unless published
+        published
       end
 
       def self.pod_name_and_version(path)
@@ -96,14 +98,8 @@ module Fastlane
         false
       end
 
-      def self.retryable_error?(msg)
-        msg.include?("[!] Calling the GitHub commit API timed out.") ||
-          msg.include?("[!] An internal server error occurred. Please check for any known status issues at https://twitter.com/CocoaPods and try again later.") ||
-          msg.include?("None of your spec sources contain a spec satisfying the dependency")
-      end
-
       def self.description
-        'Pushes a podspec to CocoaPods with retry handling for GitHub timeouts and internal server errors.'
+        'Pushes a podspec to CocoaPods, retrying on failure and tolerating pods that are already published.'
       end
 
       def self.authors
@@ -111,11 +107,11 @@ module Fastlane
       end
 
       def self.return_value
-        'Returns true if successful. Retries up to 3 times on GitHub API timeouts and internal server errors. Returns false on persistent failure.'
+        'Returns true if the pod was pushed or is already on CocoaPods trunk. Retries up to 3 times on failure and raises PodPushUnknownError if all attempts fail.'
       end
 
       def self.details
-        'A custom Fastlane action that wraps `pod_push`, handles duplicate entry errors, and retries on GitHub API timeouts and internal server errors.'
+        'A custom Fastlane action that wraps `pod_push`, treats an already-published pod as success by checking CocoaPods trunk, and retries on any push failure.'
       end
 
       def self.is_supported?(platform)

--- a/spec/actions/pod_push_with_error_handling_action_spec.rb
+++ b/spec/actions/pod_push_with_error_handling_action_spec.rb
@@ -36,14 +36,17 @@ describe Fastlane::Actions::PodPushWithErrorHandlingAction do
       expect(FastlaneCore::UI).to have_received(:important).with("✅ Pod is already published to CocoaPods trunk. Treating the push as successful.")
     end
 
-    it 'raises a PodPushUnknownError when the push errors and the pod is not on trunk' do
+    it 'retries then raises a PodPushUnknownError when the push keeps failing and the pod is not on trunk' do
       allow(Fastlane::Actions::PodPushAction).to receive(:run).and_raise(StandardError.new('Some unexpected failure'))
+      allow_any_instance_of(Object).to receive(:sleep)
 
-      expect(FastlaneCore::UI).to receive(:error).with("❌ Pod push failed with an unknown error and won't retry. You can rerun this job using SSH. Error: Some unexpected failure")
+      expect(FastlaneCore::UI).to receive(:important).with(/Retrying in \d+ seconds/).exactly(3).times
 
       expect do
         described_class.run(path: podspec_path)
       end.to raise_error(Fastlane::Actions::PodPushUnknownError, "❌ Pod push failed: Some unexpected failure")
+
+      expect(Fastlane::Actions::PodPushAction).to have_received(:run).exactly(4).times
     end
 
     it 'retries up to 3 times on GitHub API timeout' do
@@ -126,14 +129,16 @@ describe Fastlane::Actions::PodPushWithErrorHandlingAction do
       expect(result).to eq(true) # ✅ Ensure success on the 4th attempt
     end
 
-    it 'returns false after exhausting retries on a persistent retryable error' do
+    it 'raises after exhausting retries when the pod never lands on trunk' do
       allow(Fastlane::Actions::PodPushAction).to receive(:run).and_raise(StandardError.new('[!] Calling the GitHub commit API timed out.'))
       allow_any_instance_of(Object).to receive(:sleep)
 
-      result = described_class.run(path: podspec_path)
+      expect do
+        described_class.run(path: podspec_path)
+      end.to raise_error(Fastlane::Actions::PodPushUnknownError)
 
-      expect(result).to eq(false)
-      expect(FastlaneCore::UI).to have_received(:error).with("❌ Pod push failed after 3 retries due to persistent server issues.")
+      expect(Fastlane::Actions::PodPushAction).to have_received(:run).exactly(4).times
+      expect(FastlaneCore::UI).to have_received(:error).with("❌ Pod push failed after 3 retries. You can rerun this job using SSH. Error: [!] Calling the GitHub commit API timed out.")
     end
   end
 
@@ -145,6 +150,7 @@ describe Fastlane::Actions::PodPushWithErrorHandlingAction do
 
     before do
       allow(FastlaneCore::UI).to receive(:important)
+      allow(FastlaneCore::UI).to receive(:message)
     end
 
     # Stubs `read_podspec` to return a spec hash for the given name/version.
@@ -159,11 +165,12 @@ describe Fastlane::Actions::PodPushWithErrorHandlingAction do
       expect(described_class.pod_published?(podspec_path)).to eq(true)
     end
 
-    it 'returns false when the version is not listed on trunk' do
+    it 'returns false and logs when the version is not listed on trunk' do
       stub_read_podspec(name: pod_name, version: pod_version)
       stub_request(:get, trunk_url).to_return(status: 200, body: { versions: [{ name: '5.80.0' }] }.to_json)
 
       expect(described_class.pod_published?(podspec_path)).to eq(false)
+      expect(FastlaneCore::UI).to have_received(:message).with("ℹ️ #{pod_name} #{pod_version} is not yet published to CocoaPods trunk.")
     end
 
     it 'returns false when the trunk request is not successful' do


### PR DESCRIPTION
Thank you for contributing to fastlane-tools.

### Motivation
Since fastlane 2.237.0, the underlying `pod trunk push` output is omitted from the raised error message, so `retryable_error?` never matched and transient CocoaPods failures (e.g. 500s, GitHub timeouts) failed the release on the first attempt instead of retrying. Follow-up to #143.

### Description
- `pod trunk push` exits non-zero for every failure and we can no longer read *why* from the error, so retry on any failure instead of matching output strings.
- Safe because the `pod_published?` trunk check still runs first, so a push that actually published short-circuits to success and retries can't become duplicate-entry failures.
- Persistent failure now raises `PodPushUnknownError` after exhausting retries (previously returned `false`, which callers ignored).
- Log when the pod version isn't yet on trunk, so the "not published" path is visible in CI logs.

Unit tests updated.