### PR TITLE
fix: resolve android billing client version across toml key names

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/update_hybrids_versions_file_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/update_hybrids_versions_file_helper.rb
@@ -41,9 +41,11 @@ module Fastlane
         path = 'gradle/libs.versions.toml'
         repo_name = 'purchases-android'
         contents = get_contents_file_github(path, repo_name, android_version, github_token)
-        matches = contents.match('bc8 = "(.*)"').captures
-        UI.user_error!("Could not find android billing client version in #{repo_name} in file '#{path}'") if matches.length != 1
-        matches[0]
+        # purchases-android has used different key names for the Billing Library version over time
+        # (e.g. `billingClient` on main, `bc8` while the BC7/BC8 dimension existed), so try each.
+        match = contents.match('billingClient = "(.*)"') || contents.match('bc8 = "(.*)"')
+        UI.user_error!("Could not find android billing client version in #{repo_name} in file '#{path}'") if match.nil?
+        match.captures[0]
       end
 
       private_class_method def self.get_contents_file_github(file_path, repo_name, ref = 'main', github_token = nil)


### PR DESCRIPTION
### Motivation

Hybrid version bumps crashed in `update_hybrids_versions_file` with `undefined method 'captures' for nil:NilClass` (seen in [purchases-capacitor bump](https://app.circleci.com/pipelines/github/RevenueCat/purchases-capacitor/2363/workflows/30f048a9-ff17-4dfd-b9f1-3609daf169ec/jobs/16945)). `get_android_billing_client_version` hardcoded a `bc8 = "..."` lookup in purchases-android's `gradle/libs.versions.toml`, but that key was removed when android consolidated `bc7`/`bc8` back to `billingClient` (purchases-android#3717). The failed match returned `nil`, and `.captures` raised instead of the intended error.

### Summary

- Match `billingClient` first, fall back to `bc8`, so the version resolves regardless of which key name a given android release uses.
- Guard the `nil` match so a genuinely missing key raises the intended `user_error!` instead of an opaque `NoMethodError`.