### PR TITLE
Add allow_unbuilt mode to find_release_candidate_commit

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/find_release_candidate_commit_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/find_release_candidate_commit_action.rb
@@ -10,12 +10,13 @@ module Fastlane
           params[:repo_name],
           params[:github_token],
           skip_label: params[:skip_label],
-          lookback: params[:lookback]
+          lookback: params[:lookback],
+          allow_unbuilt: params[:allow_unbuilt]
         )
       end
 
       def self.description
-        "Finds the newest first-parent commit with an uploaded candidate build (a builds/* tag), walking past commits whose merged PR has the skip label, and failing on an untagged commit without it."
+        "Finds the newest first-parent commit with an uploaded candidate build (a builds/* tag). Untagged commits fail the walk unless their merged PR has the skip label, or allow_unbuilt is set (for repos that upload on a schedule rather than per merge)."
       end
 
       def self.authors
@@ -48,7 +49,12 @@ module Fastlane
                                        description: "How many first-parent commits to walk before giving up",
                                        optional: true,
                                        default_value: 30,
-                                       type: Integer)
+                                       type: Integer),
+          FastlaneCore::ConfigItem.new(key: :allow_unbuilt,
+                                       description: "Treat untagged commits as normal (uploads happen on a schedule, not per merge) instead of failing without the skip label",
+                                       optional: true,
+                                       default_value: false,
+                                       type: Boolean)
         ]
       end
 

--- a/lib/fastlane/plugin/revenuecat_internal/helper/app_release_train_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/app_release_train_helper.rb
@@ -200,28 +200,45 @@ module Fastlane
                .split("\n").map(&:strip).select { |tag| tag.start_with?("builds/") }
       end
 
-      # Newest main commit with an uploaded candidate. Skip-labeled merges never
-      # upload, so the walk passes over them; an untagged commit that should have
-      # uploaded fails the cut rather than being silently dropped from the release.
-      def self.find_candidate_commit(repo_name, github_token, skip_label:, lookback:)
+      # Newest main commit with an uploaded candidate.
+      #
+      # With allow_unbuilt: false (per-merge uploads), an untagged commit is only
+      # expected when its merged PR carries the skip label; anything else fails the
+      # cut rather than being silently dropped from the release.
+      # With allow_unbuilt: true (scheduled uploads), untagged commits are the
+      # normal state between builds; the walk passes over them and reports how
+      # many will not be in the release.
+      # rubocop:disable Metrics/PerceivedComplexity
+      def self.find_candidate_commit(repo_name, github_token, skip_label:, lookback:, allow_unbuilt: false)
         ensure_full_git_history
         Actions.sh("git", "fetch", "--tags", "--force", log: false)
         shas = Actions.sh("git", "rev-list", "--first-parent", "-n", lookback.to_s, "HEAD", log: false)
                       .split("\n").map(&:strip).reject(&:empty?)
+        walked = 0
         shas.each do |sha|
-          return sha if builds_tags_at(sha).any?
-
-          subject = Actions.sh("git", "log", "-1", "--pretty=format:%s", sha, log: false).strip
-          pr_number = pr_number_from_subject(subject)
-          labels = pr_number ? pr_labels_for(pr_number, repo_name, github_token) : []
-          unless labels.include?(skip_label)
-            UI.user_error!("#{sha[0, 8]} (#{subject}) has no candidate build and is not #{skip_label}. " \
-                           "Its upload may still be running or may have failed — wait for it or re-run the upload on it, then re-cut.")
+          if builds_tags_at(sha).any?
+            if walked > 0 && allow_unbuilt
+              UI.important("#{walked} newer commit(s) have no candidate build yet and will not be in this release. " \
+                           "To include them, trigger an upload and re-cut.")
+            end
+            return sha
           end
-          UI.message("Walking past #{sha[0, 8]} (#{skip_label} — no candidate expected)")
+
+          unless allow_unbuilt
+            subject = Actions.sh("git", "log", "-1", "--pretty=format:%s", sha, log: false).strip
+            pr_number = pr_number_from_subject(subject)
+            labels = pr_number ? pr_labels_for(pr_number, repo_name, github_token) : []
+            unless labels.include?(skip_label)
+              UI.user_error!("#{sha[0, 8]} (#{subject}) has no candidate build and is not #{skip_label}. " \
+                             "Its upload may still be running or may have failed — wait for it or re-run the upload on it, then re-cut.")
+            end
+            UI.message("Walking past #{sha[0, 8]} (#{skip_label} — no candidate expected)")
+          end
+          walked += 1
         end
         UI.user_error!("No candidate build found in the last #{lookback} commits.")
       end
+      # rubocop:enable Metrics/PerceivedComplexity
 
       # The commit on the main branch this release branch was cut from.
       def self.release_fork_point(main_branch)

--- a/spec/actions/find_release_candidate_commit_action_spec.rb
+++ b/spec/actions/find_release_candidate_commit_action_spec.rb
@@ -2,7 +2,7 @@ describe Fastlane::Actions::FindReleaseCandidateCommitAction do
   describe '#run' do
     it 'calls the helper with the appropriate parameters' do
       expect(Fastlane::Helper::AppReleaseTrainHelper).to receive(:find_candidate_commit)
-        .with('mock-repo-name', 'mock-github-token', skip_label: 'upload:skip', lookback: 30)
+        .with('mock-repo-name', 'mock-github-token', skip_label: 'upload:skip', lookback: 30, allow_unbuilt: false)
         .and_return('abc123')
         .once
 
@@ -10,7 +10,8 @@ describe Fastlane::Actions::FindReleaseCandidateCommitAction do
         repo_name: 'mock-repo-name',
         github_token: 'mock-github-token',
         skip_label: 'upload:skip',
-        lookback: 30
+        lookback: 30,
+        allow_unbuilt: false
       )
       expect(sha).to eq('abc123')
     end
@@ -18,7 +19,7 @@ describe Fastlane::Actions::FindReleaseCandidateCommitAction do
 
   describe '#available_options' do
     it 'has correct number of options' do
-      expect(Fastlane::Actions::FindReleaseCandidateCommitAction.available_options.size).to eq(4)
+      expect(Fastlane::Actions::FindReleaseCandidateCommitAction.available_options.size).to eq(5)
     end
 
     it 'has the documented defaults' do
@@ -26,6 +27,7 @@ describe Fastlane::Actions::FindReleaseCandidateCommitAction do
       defaults = options.to_h { |option| [option.key, option.default_value] }
       expect(defaults[:skip_label]).to eq('upload:skip')
       expect(defaults[:lookback]).to eq(30)
+      expect(defaults[:allow_unbuilt]).to eq(false)
     end
   end
 end

--- a/spec/helper/app_release_train_helper_spec.rb
+++ b/spec/helper/app_release_train_helper_spec.rb
@@ -434,6 +434,34 @@ describe Fastlane::Helper::AppReleaseTrainHelper do
         described_class.find_candidate_commit(repo_name, github_token, skip_label: "upload:skip", lookback: 30)
       end.to raise_error(FastlaneCore::Interface::FastlaneError, /No candidate build found in the last 30 commits/)
     end
+
+    context 'with allow_unbuilt: true' do
+      it 'walks past untagged commits without fetching labels and warns how many were skipped' do
+        stub_rev_list([sha_a, sha_b])
+        allow(described_class).to receive(:builds_tags_at).with(sha_a).and_return([])
+        allow(described_class).to receive(:builds_tags_at).with(sha_b).and_return(["builds/1.2.3-455"])
+        expect(described_class).not_to receive(:pr_labels_for)
+        expect(FastlaneCore::UI).to receive(:important).with(/1 newer commit\(s\) have no candidate build/)
+        result = described_class.find_candidate_commit(repo_name, github_token, skip_label: "upload:skip", lookback: 30, allow_unbuilt: true)
+        expect(result).to eq(sha_b)
+      end
+
+      it 'does not warn when the newest commit has a candidate' do
+        stub_rev_list([sha_a])
+        allow(described_class).to receive(:builds_tags_at).with(sha_a).and_return(["builds/1.2.3-456"])
+        expect(FastlaneCore::UI).not_to receive(:important)
+        result = described_class.find_candidate_commit(repo_name, github_token, skip_label: "upload:skip", lookback: 30, allow_unbuilt: true)
+        expect(result).to eq(sha_a)
+      end
+
+      it 'fails when no candidate exists within the lookback window' do
+        stub_rev_list([sha_a, sha_b])
+        allow(described_class).to receive(:builds_tags_at).and_return([])
+        expect do
+          described_class.find_candidate_commit(repo_name, github_token, skip_label: "upload:skip", lookback: 30, allow_unbuilt: true)
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, /No candidate build found in the last 30 commits/)
+      end
+    end
   end
 
   describe '.release_fork_point' do


### PR DESCRIPTION
## Problem

`find_release_candidate_commit` assumes candidates upload on every merge: an untagged commit fails the walk unless its PR carries the skip label. The iOS app now uploads nightly (revenuecat-mobile-ios #921), so untagged commits are the normal state between builds and the cut would fail on any of them.

## Fix

New `allow_unbuilt` option (default false, existing behavior unchanged). When set, the walk passes over untagged commits without any label lookups and warns how many newer commits will not be in the release. Specs cover both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)