### PR TITLE
Stop pr:dependencies from triggering releases on its own

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -17,8 +17,8 @@ module Fastlane
   BUMP_PER_LABEL = {
     major: %w[pr:breaking].to_set,
     minor: %w[pr:feat pr:force_minor].to_set,
-    patch: %w[pr:fix pr:dependencies pr:phc_dependencies pr:force_patch].to_set,
-    skip: %w[pr:other pr:next_release].to_set
+    patch: %w[pr:fix pr:phc_dependencies pr:force_patch].to_set,
+    skip: %w[pr:other pr:next_release pr:dependencies].to_set
   }
 
   module Helper

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -1049,6 +1049,12 @@ describe Fastlane::Helper::VersioningHelper do
     let(:get_changelog_ignore_and_other_label_commit_response) do
       { body: File.read("#{File.dirname(__FILE__)}/../test_files/changelog_ignore_and_other_get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json") }
     end
+    let(:get_dependencies_label_commit_response) do
+      { body: File.read("#{File.dirname(__FILE__)}/../test_files/dependencies_get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json") }
+    end
+    let(:get_dependencies_and_force_patch_label_commit_response) do
+      { body: File.read("#{File.dirname(__FILE__)}/../test_files/dependencies_and_force_patch_get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json") }
+    end
     let(:get_ci_commit_response) do
       { body: File.read("#{File.dirname(__FILE__)}/../test_files/get_commit_sha_819dc620db5608fb952c852038a3560554161707.json") }
     end
@@ -1240,6 +1246,46 @@ describe Fastlane::Helper::VersioningHelper do
       )
       expect(next_version).to eq("1.11.0")
       expect(type_of_bump).to eq(:skip)
+    end
+
+    it 'skips version bump if only labeled as dependencies' do
+      # Renovate PRs inherit pr:dependencies from the shared preset. On their own they should
+      # not trigger a release; only native SDK bumps (which also carry pr:force_patch/pr:force_minor) do.
+      hashes_to_responses.each_key do |key|
+        hashes_to_responses[key] = get_dependencies_label_commit_response
+      end
+      setup_commit_search_stubs(hashes_to_responses)
+      mock_commits_since_last_release('6d37c766b6da55dcab67c201c93ba3d4ca538e55', get_commits_response_patch)
+      expect_any_instance_of(Object).not_to receive(:sleep)
+      next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
+        'mock-repo-name',
+        'mock-github-token',
+        0,
+        false,
+        nil
+      )
+      expect(next_version).to eq("1.11.0")
+      expect(type_of_bump).to eq(:skip)
+    end
+
+    it 'determines next version as patch if labeled as both dependencies and force_patch' do
+      # Native dependency bumps carry both pr:dependencies (for changelog categorization) and
+      # pr:force_patch, which is what actually forces the patch release.
+      hashes_to_responses.each_key do |key|
+        hashes_to_responses[key] = get_dependencies_and_force_patch_label_commit_response
+      end
+      setup_commit_search_stubs(hashes_to_responses)
+      mock_commits_since_last_release('6d37c766b6da55dcab67c201c93ba3d4ca538e55', get_commits_response_patch)
+      expect_any_instance_of(Object).not_to receive(:sleep)
+      next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
+        'mock-repo-name',
+        'mock-github-token',
+        0,
+        false,
+        nil
+      )
+      expect(next_version).to eq("1.11.1")
+      expect(type_of_bump).to eq(:patch)
     end
 
     it 'skips next version if no release is needed' do

--- a/spec/test_files/dependencies_and_force_patch_get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json
+++ b/spec/test_files/dependencies_and_force_patch_get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json
@@ -1,0 +1,94 @@
+{
+    "total_count": 1,
+    "incomplete_results": false,
+    "items": [
+        {
+            "url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/1749",
+            "repository_url": "https://api.github.com/repos/RevenueCat/purchases-ios",
+            "labels_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/1749/labels{/name}",
+            "comments_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/1749/comments",
+            "events_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/1749/events",
+            "html_url": "https://github.com/RevenueCat/purchases-ios/pull/1749",
+            "id": 1293224494,
+            "node_id": "PR_kwDOBnB8hc46zRbP",
+            "number": 1749,
+            "title": "[AUTOMATIC] Android 10.15.0 => 10.15.1 JS 1.48.0 => 1.48.1",
+            "user": {
+                "login": "RCGitBot",
+                "id": 3922667,
+                "node_id": "MDQ6VXNlcjM5MjI2Njc=",
+                "avatar_url": "https://avatars.githubusercontent.com/u/3922667?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/RCGitBot",
+                "html_url": "https://github.com/RCGitBot",
+                "followers_url": "https://api.github.com/users/RCGitBot/followers",
+                "following_url": "https://api.github.com/users/RCGitBot/following{/other_user}",
+                "gists_url": "https://api.github.com/users/RCGitBot/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/RCGitBot/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/RCGitBot/subscriptions",
+                "organizations_url": "https://api.github.com/users/RCGitBot/orgs",
+                "repos_url": "https://api.github.com/users/RCGitBot/repos",
+                "events_url": "https://api.github.com/users/RCGitBot/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/RCGitBot/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "labels": [
+                {
+                    "id": 3165687060,
+                    "node_id": "MDU6TGFiZWwzMTY1Njg3MDYw",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/pr:dependencies",
+                    "name": "pr:dependencies",
+                    "color": "0366d6",
+                    "default": false,
+                    "description": ""
+                },
+                {
+                    "id": 4352868120,
+                    "node_id": "LA_kwDOBnB8hc8AAAACA3N_HD",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/pr:force_patch",
+                    "name": "pr:force_patch",
+                    "color": "8B3E6C",
+                    "default": false,
+                    "description": ""
+                }
+            ],
+            "state": "closed",
+            "locked": false,
+            "assignee": null,
+            "assignees": [],
+            "milestone": null,
+            "comments": 0,
+            "created_at": "2022-07-04T14:05:49Z",
+            "updated_at": "2022-07-04T14:36:42Z",
+            "closed_at": "2022-07-04T14:36:41Z",
+            "author_association": "MEMBER",
+            "active_lock_reason": null,
+            "draft": false,
+            "pull_request": {
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/pulls/1749",
+                "html_url": "https://github.com/RevenueCat/purchases-ios/pull/1749",
+                "diff_url": "https://github.com/RevenueCat/purchases-ios/pull/1749.diff",
+                "patch_url": "https://github.com/RevenueCat/purchases-ios/pull/1749.patch",
+                "merged_at": "2022-07-04T14:36:41Z"
+            },
+            "body": null,
+            "reactions": {
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/1749/reactions",
+                "total_count": 0,
+                "+1": 0,
+                "-1": 0,
+                "laugh": 0,
+                "hooray": 0,
+                "confused": 0,
+                "heart": 0,
+                "rocket": 0,
+                "eyes": 0
+            },
+            "timeline_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/1749/timeline",
+            "performed_via_github_app": null,
+            "state_reason": null,
+            "score": 1.0
+        }
+    ]
+}

--- a/spec/test_files/dependencies_get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json
+++ b/spec/test_files/dependencies_get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json
@@ -1,0 +1,85 @@
+{
+    "total_count": 1,
+    "incomplete_results": false,
+    "items": [
+        {
+            "url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/1749",
+            "repository_url": "https://api.github.com/repos/RevenueCat/purchases-ios",
+            "labels_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/1749/labels{/name}",
+            "comments_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/1749/comments",
+            "events_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/1749/events",
+            "html_url": "https://github.com/RevenueCat/purchases-ios/pull/1749",
+            "id": 1293224494,
+            "node_id": "PR_kwDOBnB8hc46zRbP",
+            "number": 1749,
+            "title": "[RENOVATE] Update dependency revenuecat to v4.5.1",
+            "user": {
+                "login": "RCGitBot",
+                "id": 3922667,
+                "node_id": "MDQ6VXNlcjM5MjI2Njc=",
+                "avatar_url": "https://avatars.githubusercontent.com/u/3922667?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/RCGitBot",
+                "html_url": "https://github.com/RCGitBot",
+                "followers_url": "https://api.github.com/users/RCGitBot/followers",
+                "following_url": "https://api.github.com/users/RCGitBot/following{/other_user}",
+                "gists_url": "https://api.github.com/users/RCGitBot/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/RCGitBot/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/RCGitBot/subscriptions",
+                "organizations_url": "https://api.github.com/users/RCGitBot/orgs",
+                "repos_url": "https://api.github.com/users/RCGitBot/repos",
+                "events_url": "https://api.github.com/users/RCGitBot/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/RCGitBot/received_events",
+                "type": "User",
+                "site_admin": false
+            },
+            "labels": [
+                {
+                    "id": 3165687060,
+                    "node_id": "MDU6TGFiZWwzMTY1Njg3MDYw",
+                    "url": "https://api.github.com/repos/RevenueCat/purchases-ios/labels/pr:dependencies",
+                    "name": "pr:dependencies",
+                    "color": "0366d6",
+                    "default": false,
+                    "description": ""
+                }
+            ],
+            "state": "closed",
+            "locked": false,
+            "assignee": null,
+            "assignees": [],
+            "milestone": null,
+            "comments": 0,
+            "created_at": "2022-07-04T14:05:49Z",
+            "updated_at": "2022-07-04T14:36:42Z",
+            "closed_at": "2022-07-04T14:36:41Z",
+            "author_association": "MEMBER",
+            "active_lock_reason": null,
+            "draft": false,
+            "pull_request": {
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/pulls/1749",
+                "html_url": "https://github.com/RevenueCat/purchases-ios/pull/1749",
+                "diff_url": "https://github.com/RevenueCat/purchases-ios/pull/1749.diff",
+                "patch_url": "https://github.com/RevenueCat/purchases-ios/pull/1749.patch",
+                "merged_at": "2022-07-04T14:36:41Z"
+            },
+            "body": null,
+            "reactions": {
+                "url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/1749/reactions",
+                "total_count": 0,
+                "+1": 0,
+                "-1": 0,
+                "laugh": 0,
+                "hooray": 0,
+                "confused": 0,
+                "heart": 0,
+                "rocket": 0,
+                "eyes": 0
+            },
+            "timeline_url": "https://api.github.com/repos/RevenueCat/purchases-ios/issues/1749/timeline",
+            "performed_via_github_app": null,
+            "state_reason": null,
+            "score": 1.0
+        }
+    ]
+}


### PR DESCRIPTION
### Motivation
Renovate PRs inherit `pr:dependencies` from the shared Renovate preset, and that label currently forces a patch release. So pure CI/build-tooling bumps trigger automatic SDK releases (e.g. a CircleCI orb bump caused a purchases-hybrid-common release). Only real dependency bumps should release.

### Summary
- Move `pr:dependencies` from the `:patch` set to the `:skip` set in `BUMP_PER_LABEL`, so a bare `pr:dependencies` no longer triggers a release.
- `pr:phc_dependencies` still triggers a patch; automated native dependency bumps now rely on `pr:force_patch` / `pr:force_minor` (alongside `pr:dependencies`) to release.

### Notes
- Behavior change for all consumers: a lone `pr:dependencies` PR is now release-neutral. Companion PR updates the purchases-hybrid-common native bump lane to add `pr:force_patch`: RevenueCat/purchases-hybrid-common#1781.