### PR TITLE
Attribute commits from stacked PRs when generating changelogs

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/github_helper.rb
@@ -36,10 +36,14 @@ module Fastlane
         end
       end
 
-      # When +fallback_commit_message+ is nil, the search API result is returned as-is.
-      # When it is a non-nil string, and the search API returns no items, the helper
-      # attempts a fallback lookup by extracting the PR number from the commit message
-      # and fetching the PR directly via the REST API. Pass nil to disable the fallback.
+      # Resolves the pull request that put +sha+ on +base_branch+, in three steps:
+      #
+      #   1. The search API, scoped to PRs targeting +base_branch+. When it returns
+      #      several candidates they are narrowed down by `merge_commit_sha`.
+      #   2. The commit's associated PRs, which also covers PRs that targeted another
+      #      branch, such as the ones in a stack.
+      #   3. Only when +fallback_commit_message+ is a non-nil string: the PR number
+      #      parsed out of that message, fetched directly. Pass nil to opt out.
       def self.get_pr_resp_items_for_sha(sha, github_token, rate_limit_sleep, repo_name, base_branch, fallback_commit_message: nil)
         if github_token.nil? || github_token.empty?
           UI.important("No GitHub token provided, skipping PR lookup for SHA: #{sha}")
@@ -67,7 +71,57 @@ module Fastlane
         return items if items.size == 1
         return disambiguate_pr_items_by_merge_commit_sha(items, sha, github_token, rate_limit_sleep, repo_name) if items.size > 1
 
+        associated_items = lookup_pr_by_commit_association(sha, github_token, rate_limit_sleep, repo_name)
+        return associated_items unless associated_items.empty?
+
         attempt_pr_lookup_from_commit_message(sha, fallback_commit_message, github_token, rate_limit_sleep, repo_name, base_branch)
+      end
+
+      # The `base:` qualifier in the search above only finds PRs opened directly
+      # against +base_branch+. Stacked pull requests target the branch below them in
+      # the stack, so merging a stack lands one squashed commit per PR on the base
+      # branch while none of those PRs are visible to a `base:`-scoped search.
+      #
+      # `GET /repos/{owner}/{repo}/commits/{sha}/pulls` lists PRs associated with a
+      # commit no matter what they targeted. Keeping only merged PRs whose
+      # `merge_commit_sha` is the commit itself preserves the guarantee the `base:`
+      # filter provided: the commit reached the released branch because that PR merged.
+      private_class_method def self.lookup_pr_by_commit_association(sha, github_token, rate_limit_sleep, repo_name)
+        prs = fetch_prs_associated_with_commit(sha, github_token, rate_limit_sleep, repo_name)
+        # The endpoint also lists PRs that merely contain the commit, so keep only
+        # the PR GitHub merged as this exact commit.
+        matches = prs.select { |pr| pr["merged_at"] && pr["merge_commit_sha"] == sha }
+
+        if matches.size == 1
+          matched_pr = matches.first
+          UI.message("Attributed #{sha} to PR ##{matched_pr['number']} (merged into #{matched_pr.dig('base', 'ref')}).")
+          return matches
+        end
+
+        unless matches.empty?
+          pr_numbers = matches.map { |pr| "##{pr['number']}" }.join(', ')
+          UI.important("#{matches.size} merged PRs (#{pr_numbers}) claim #{sha} as their merge commit; cannot attribute it.")
+        end
+        []
+      end
+
+      private_class_method def self.fetch_prs_associated_with_commit(sha, github_token, rate_limit_sleep, repo_name)
+        if rate_limit_sleep > 0
+          sleep(rate_limit_sleep)
+        end
+
+        UI.message("Search API found no PR for #{sha}. Looking up PRs associated with the commit.")
+
+        resp = github_api_call_with_retry(server_url: 'https://api.github.com',
+                                          path: "/repos/RevenueCat/#{repo_name}/commits/#{sha}/pulls",
+                                          http_method: 'GET',
+                                          body: {},
+                                          api_token: github_token)
+        prs = JSON.parse(resp[:body])
+        prs.kind_of?(Array) ? prs : []
+      rescue StandardError => e
+        UI.important("Failed to look up PRs associated with #{sha}: #{e.message}")
+        []
       end
 
       # Fallback: extract PR number from commit message and fetch directly.

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -126,10 +126,7 @@ module Fastlane
           when 0
             unless filter_labels
               UI.important("Cannot find pull request associated to #{sha}. Using commit information and adding it to the Other section")
-              # Most repos squash with squash_merge_commit_message=PR_BODY, making a
-              # squashed commit body the entire PR description. Keep the subject so
-              # that losing attribution cannot also mean pasting a description here.
-              message = commit["commit"]["message"].to_s.split("\n").first.to_s.strip
+              message = commit["commit"]["message"]
               name = commit["commit"]["author"]["name"]
               line = "* #{message} via #{name}"
               changelog_sections[:other].push(line)

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -126,7 +126,9 @@ module Fastlane
           when 0
             unless filter_labels
               UI.important("Cannot find pull request associated to #{sha}. Using commit information and adding it to the Other section")
-              message = commit["commit"]["message"]
+              # Only the subject line: a squashed commit body holds the whole PR
+              # description, which would otherwise land in the changelog verbatim.
+              message = commit["commit"]["message"].to_s.split("\n").first.to_s.strip
               name = commit["commit"]["author"]["name"]
               line = "* #{message} via #{name}"
               changelog_sections[:other].push(line)

--- a/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/versioning_helper.rb
@@ -126,8 +126,9 @@ module Fastlane
           when 0
             unless filter_labels
               UI.important("Cannot find pull request associated to #{sha}. Using commit information and adding it to the Other section")
-              # Only the subject line: a squashed commit body holds the whole PR
-              # description, which would otherwise land in the changelog verbatim.
+              # Most repos squash with squash_merge_commit_message=PR_BODY, making a
+              # squashed commit body the entire PR description. Keep the subject so
+              # that losing attribution cannot also mean pasting a description here.
               message = commit["commit"]["message"].to_s.split("\n").first.to_s.strip
               name = commit["commit"]["author"]["name"]
               line = "* #{message} via #{name}"

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -256,16 +256,18 @@ describe Fastlane::Helper::GitHubHelper do
         expect(items.first['number']).to eq(897)
       end
 
-      it 'ignores associated PRs that merely contain the commit' do
-        # The endpoint also lists PRs whose head contained the commit. Only the PR
-        # GitHub merged as this exact commit describes the change being released.
-        containing_pr = stacked_pr.merge(
+      it 'ignores associated PRs whose own merge commit is not this commit' do
+        # A PR merged into someone's feature branch is also associated with the
+        # commits of that branch, but its merge commit lives on the feature branch
+        # and gets squashed away when the outer PR merges. Only the PR GitHub merged
+        # as this exact commit belongs in the changelog.
+        pr_merged_into_a_feature_branch = stacked_pr.merge(
           'number' => 898,
           'merge_commit_sha' => 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
         )
         allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
           .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/commits/#{hash}/pulls"))
-          .and_return({ body: [containing_pr, stacked_pr].to_json })
+          .and_return({ body: [pr_merged_into_a_feature_branch, stacked_pr].to_json })
 
         items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
           hash, github_token, 0, 'mock-repo-name', 'main'

--- a/spec/helper/github_helper_spec.rb
+++ b/spec/helper/github_helper_spec.rb
@@ -9,6 +9,14 @@ describe Fastlane::Helper::GitHubHelper do
       { body: File.read("#{File.dirname(__FILE__)}/../test_files/get_commit_sha_a72c0435ecf71248f311900475e881cc07ac2eaf.json") }
     end
 
+    before do
+      # Commits with no associated PR are the default; the specs that exercise the
+      # commit-association lookup override this stub.
+      allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+        .with(hash_including(path: %r{/commits/[0-9a-f]+/pulls\z}))
+        .and_return({ body: '[]' })
+    end
+
     it 'returns items from response' do
       allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
         .with(server_url: server_url,
@@ -194,6 +202,114 @@ describe Fastlane::Helper::GitHubHelper do
         )
 
         expect(items).to eq([])
+      end
+    end
+
+    # A stacked PR targets the branch below it in the stack, so a search scoped to
+    # `base:main` never sees it even though merging the stack lands its squashed
+    # commit on main.
+    context 'when the commit came from a PR that targeted another branch' do
+      let(:empty_search_response) { { body: '{"items": []}' } }
+      let(:stacked_pr) do
+        {
+          'number' => 897,
+          'title' => 'Skip test cases list in maestro tests using launch arguments',
+          'user' => { 'login' => 'ajpallares' },
+          'labels' => [{ 'name' => 'pr:other' }],
+          'merged_at' => '2026-07-31T11:28:17Z',
+          'merge_commit_sha' => hash,
+          'base' => { 'ref' => 'add-maestro-e2e-test-ci-job' }
+        }
+      end
+
+      before do
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: %r{search/issues}))
+          .and_return(empty_search_response)
+      end
+
+      it 'attributes the commit to the PR whose merge commit it is' do
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/commits/#{hash}/pulls"))
+          .and_return({ body: [stacked_pr].to_json })
+
+        items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 0, 'mock-repo-name', 'main'
+        )
+
+        expect(items.length).to eq(1)
+        expect(items.first['number']).to eq(897)
+      end
+
+      it 'does not need a fallback_commit_message' do
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/commits/#{hash}/pulls"))
+          .and_return({ body: [stacked_pr].to_json })
+
+        expect(Fastlane::Helper::GitHubHelper).not_to receive(:github_api_call_with_retry)
+          .with(hash_including(path: %r{/pulls/\d+\z}))
+
+        items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 0, 'mock-repo-name', 'main'
+        )
+
+        expect(items.first['number']).to eq(897)
+      end
+
+      it 'ignores associated PRs that merely contain the commit' do
+        # The endpoint also lists PRs whose head contained the commit. Only the PR
+        # GitHub merged as this exact commit describes the change being released.
+        containing_pr = stacked_pr.merge(
+          'number' => 898,
+          'merge_commit_sha' => 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+        )
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/commits/#{hash}/pulls"))
+          .and_return({ body: [containing_pr, stacked_pr].to_json })
+
+        items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 0, 'mock-repo-name', 'main'
+        )
+
+        expect(items.length).to eq(1)
+        expect(items.first['number']).to eq(897)
+      end
+
+      it 'ignores associated PRs that were never merged' do
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/commits/#{hash}/pulls"))
+          .and_return({ body: [stacked_pr.merge('merged_at' => nil)].to_json })
+
+        items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 0, 'mock-repo-name', 'main'
+        )
+
+        expect(items).to eq([])
+      end
+
+      it 'returns empty when the lookup fails' do
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/commits/#{hash}/pulls"))
+          .and_raise(StandardError.new('502 Bad Gateway'))
+
+        items = Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 0, 'mock-repo-name', 'main'
+        )
+
+        expect(items).to eq([])
+      end
+
+      it 'sleeps before the lookup when rate limit sleep is set' do
+        allow(Fastlane::Helper::GitHubHelper).to receive(:github_api_call_with_retry)
+          .with(hash_including(path: "/repos/RevenueCat/mock-repo-name/commits/#{hash}/pulls"))
+          .and_return({ body: [stacked_pr].to_json })
+
+        # Once before the search, once before the commit-association lookup.
+        expect_any_instance_of(Object).to receive(:sleep).with(2).exactly(2).times
+
+        Fastlane::Helper::GitHubHelper.get_pr_resp_items_for_sha(
+          hash, github_token, 2, 'mock-repo-name', 'main'
+        )
       end
     end
 

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -12,6 +12,11 @@ AppendPhcVersionIfNecessaryParams = Struct.new(
 describe Fastlane::Helper::VersioningHelper do
   before(:each) do
     allow(Fastlane::Actions).to receive(:git_branch).and_return('main')
+    # Commits with no associated PR are the default; the specs that exercise the
+    # commit-association lookup override this stub.
+    allow(Fastlane::Actions::GithubApiAction).to receive(:run)
+      .with(hash_including(path: %r{/commits/[0-9a-f]+/pulls\z}))
+      .and_return({ body: '[]' })
   end
 
   let(:all_existing_tags) { ['0.1.0', '0.1.1', '1.11.0', '1.1.1.1', '1.1.1-alpha.1', '1.10.1'] }
@@ -917,8 +922,10 @@ describe Fastlane::Helper::VersioningHelper do
         changelog = Fastlane::Helper::VersioningHelper.auto_generate_changelog(
           'mock-repo-name', 'mock-github-token', 0, false, nil, nil, nil
         )
+        # The commit body is dropped: for a squashed commit it holds the entire PR
+        # description, which has no place in a changelog entry.
         expect(changelog).to eq("### 🔄 Other Changes\n" \
-                                "* Fix flaky race condition (#42)\n\n* inner commit details via Antonio Pallares")
+                                "* Fix flaky race condition (#42) via Antonio Pallares")
       end
 
       it 'does not hit the direct PR endpoint when enabled but commit subject has no PR reference' do
@@ -952,6 +959,70 @@ describe Fastlane::Helper::VersioningHelper do
         )
         expect(changelog).to eq("### 🔄 Other Changes\n" \
                                 "* Direct push without PR reference via Antonio Pallares")
+      end
+    end
+
+    context 'when a commit came from a stacked PR' do
+      let(:stacked_sha) { 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' }
+      let(:commits_response) do
+        {
+          body: JSON.generate(
+            'commits' => [
+              {
+                'sha' => stacked_sha,
+                'commit' => {
+                  'author' => { 'name' => 'Antonio Pallares' },
+                  'message' => "Add maestro E2E test for purchase through paywall (#837)\n\n" \
+                               "## Summary\nA long PR description that must not reach the changelog."
+                }
+              }
+            ]
+          )
+        }
+      end
+      let(:associated_prs_response) do
+        {
+          body: JSON.generate(
+            [{
+              'number' => 837,
+              'title' => 'Add maestro E2E test for purchase through paywall',
+              'user' => { 'login' => 'ajpallares' },
+              'labels' => [{ 'name' => 'pr:feat' }],
+              'merged_at' => '2026-07-31T11:28:16Z',
+              'merge_commit_sha' => stacked_sha,
+              'base' => { 'ref' => 'e2e-tests-app' }
+            }]
+          )
+        }
+      end
+
+      before do
+        setup_tag_stubs
+        mock_commits_since_last_release(stacked_sha, commits_response)
+        allow(Fastlane::Actions::GithubApiAction).to receive(:run)
+          .with(server_url: server_url,
+                path: "/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:main+SHA:#{stacked_sha}",
+                http_method: http_method,
+                body: {},
+                api_token: 'mock-github-token')
+          .and_return({ body: JSON.generate('items' => []) })
+        allow(Fastlane::Actions::GithubApiAction).to receive(:run)
+          .with(server_url: server_url,
+                path: "/repos/RevenueCat/mock-repo-name/commits/#{stacked_sha}/pulls",
+                http_method: http_method,
+                body: {},
+                api_token: 'mock-github-token')
+          .and_return(associated_prs_response)
+      end
+
+      it 'classifies and attributes it like any other PR, without opting in' do
+        changelog = Fastlane::Helper::VersioningHelper.auto_generate_changelog(
+          'mock-repo-name', 'mock-github-token', 0, false, nil, nil, nil
+        )
+        expect(changelog).to eq("## RevenueCat SDK\n" \
+                                "### ✨ New Features\n" \
+                                "* Add maestro E2E test for purchase through paywall (#837) " \
+                                "via Antonio Pallares (@ajpallares)")
       end
     end
 
@@ -1593,6 +1664,65 @@ describe Fastlane::Helper::VersioningHelper do
         )
         expect(type_of_bump).to eq(:skip)
         expect(next_version).to eq("1.11.0")
+      end
+    end
+
+    context 'when a commit came from a stacked PR' do
+      let(:stacked_sha) { 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' }
+      let(:commits_response) do
+        {
+          body: JSON.generate(
+            'commits' => [
+              {
+                'sha' => stacked_sha,
+                'commit' => {
+                  'author' => { 'name' => 'Antonio Pallares' },
+                  'message' => 'Add maestro E2E test for purchase through paywall (#837)'
+                }
+              }
+            ]
+          )
+        }
+      end
+
+      before do
+        setup_tag_stubs
+        mock_commits_since_last_release(stacked_sha, commits_response)
+        allow(Fastlane::Actions::GithubApiAction).to receive(:run)
+          .with(server_url: server_url,
+                path: "/search/issues?q=repo:RevenueCat/mock-repo-name+is:pr+base:main+SHA:#{stacked_sha}",
+                http_method: http_method,
+                body: {},
+                api_token: 'mock-github-token')
+          .and_return({ body: JSON.generate('items' => []) })
+      end
+
+      it 'uses the PR labels to determine the bump, without opting in' do
+        allow(Fastlane::Actions::GithubApiAction).to receive(:run)
+          .with(server_url: server_url,
+                path: "/repos/RevenueCat/mock-repo-name/commits/#{stacked_sha}/pulls",
+                http_method: http_method,
+                body: {},
+                api_token: 'mock-github-token')
+          .and_return({
+                        body: JSON.generate(
+                          [{
+                            'number' => 837,
+                            'title' => 'Add maestro E2E test for purchase through paywall',
+                            'user' => { 'login' => 'ajpallares' },
+                            'labels' => [{ 'name' => 'pr:feat' }],
+                            'merged_at' => '2026-07-31T11:28:16Z',
+                            'merge_commit_sha' => stacked_sha,
+                            'base' => { 'ref' => 'e2e-tests-app' }
+                          }]
+                        )
+                      })
+
+        next_version, type_of_bump = Fastlane::Helper::VersioningHelper.determine_next_version_using_labels(
+          'mock-repo-name', 'mock-github-token', 0, false, nil
+        )
+        expect(type_of_bump).to eq(:minor)
+        expect(next_version).to eq("1.12.0")
       end
     end
   end

--- a/spec/helper/versioning_helper_spec.rb
+++ b/spec/helper/versioning_helper_spec.rb
@@ -922,10 +922,8 @@ describe Fastlane::Helper::VersioningHelper do
         changelog = Fastlane::Helper::VersioningHelper.auto_generate_changelog(
           'mock-repo-name', 'mock-github-token', 0, false, nil, nil, nil
         )
-        # The commit body is dropped: for a squashed commit it holds the entire PR
-        # description, which has no place in a changelog entry.
         expect(changelog).to eq("### 🔄 Other Changes\n" \
-                                "* Fix flaky race condition (#42) via Antonio Pallares")
+                                "* Fix flaky race condition (#42)\n\n* inner commit details via Antonio Pallares")
       end
 
       it 'does not hit the direct PR endpoint when enabled but commit subject has no PR reference' do


### PR DESCRIPTION
### Motivation
The PR search is scoped to `base:<branch>`, so it never matches a PR that targeted another branch — every PR in a stack except the bottom one, and PRs merged into a long-lived dev branch. Merging a stack lands one squashed commit per PR on the base branch, and each fell through to the "no PR found" path: no author, no labels, and (in repos that squash with `PR_BODY`) the whole PR description copied into the changelog. Losing the labels also meant those PRs were ignored when determining the next version, so a stacked `pr:feat` would ship as a patch. Reported in [#sdk-team](https://revenuecat.slack.com/archives/C03HPN9UE80/p1785507590109059) after a stack landed in purchases-unity and the changelog had to be [fixed by hand](https://github.com/RevenueCat/purchases-unity/pull/1034/commits/0a280fab0a533bdd042d2f002440b93d1716f392).

### Summary
- When the search finds nothing, look up the commit's associated PRs and keep only merged PRs whose `merge_commit_sha` is the commit itself.

### Notes
- That filter is what keeps a PR merged into someone's feature branch out of the changelog: its merge commit is squashed away and never reaches main. Verified against five such PRs across three repos.
- Applies with no opt-in, unlike `fallback_pr_lookup`, which stays for merge-queue commits.
- Verified against the four real purchases-unity stack commits, which now resolve to #836–#897 with their labels.