### PR TITLE
Add `upload_snapshots_to_sentry` action

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/actions/upload_snapshots_to_sentry_action.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/actions/upload_snapshots_to_sentry_action.rb
@@ -1,0 +1,74 @@
+require 'fastlane/action'
+require 'fastlane_core/configuration/config_item'
+require_relative '../helper/sentry_snapshots_helper'
+
+module Fastlane
+  module Actions
+    class UploadSnapshotsToSentryAction < Action
+      def self.run(params)
+        if ENV["SENTRY_AUTH_TOKEN"].to_s.strip.empty?
+          UI.user_error!("Set SENTRY_AUTH_TOKEN to upload snapshots.")
+        end
+        ENV["SENTRY_ORG"] = params[:org]
+        ENV["SENTRY_PROJECT"] = params[:project]
+
+        Helper::SentrySnapshotsHelper.upload_snapshots(
+          export_dir: params[:export_dir],
+          app_id: params[:app_id],
+          sentry_cli: params[:sentry_cli_path],
+          min_count: params[:min_count],
+          main_branch: params[:main_branch],
+          current_branch: Actions.git_branch
+        )
+      end
+
+      def self.description
+        "Uploads a directory of snapshot images to Sentry Snapshots: refuses partial runs that would corrupt the main baseline, " \
+          "uploads only images that changed vs that baseline (Sentry bills per image), and falls back to a full upload " \
+          "when no baseline exists or the diff fails."
+      end
+
+      def self.authors
+        ["Josh Holtz"]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :export_dir,
+                                       description: "Directory of generated snapshot .png images (and optional .json sidecars)",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :app_id,
+                                       description: "Sentry Snapshots app id; must stay consistent across uploads so head and base match",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :org,
+                                       description: "Sentry organization slug",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :project,
+                                       description: "Sentry project slug",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :sentry_cli_path,
+                                       description: "Path to a sentry-cli binary with snapshots support (>= 3.5.0)",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :min_count,
+                                       description: "Fail when fewer snapshots were generated; trips on partial runs",
+                                       optional: false,
+                                       type: Integer),
+          FastlaneCore::ConfigItem.new(key: :main_branch,
+                                       description: "Branch whose uploads form the shared baseline",
+                                       optional: true,
+                                       default_value: "main",
+                                       type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/helper/sentry_snapshots_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/sentry_snapshots_helper.rb
@@ -1,0 +1,121 @@
+require 'fastlane_core/ui/ui'
+require 'fastlane/action'
+require 'fileutils'
+require 'json'
+require 'tmpdir'
+
+module Fastlane
+  UI = FastlaneCore::UI unless Fastlane.const_defined?(:UI)
+
+  module Helper
+    # Uploads a directory of snapshot images to Sentry Snapshots: refuses
+    # partial runs that would corrupt the main baseline, uploads only images
+    # that changed vs that baseline (Sentry bills per image), and falls back
+    # to a full upload when no baseline exists or the diff fails.
+    class SentrySnapshotsHelper
+      CHANGED_STATUSES = %w[changed added].freeze
+      def self.upload_snapshots(export_dir:, app_id:, sentry_cli:, min_count:, main_branch:, current_branch:)
+        ensure_min_count!(export_dir, min_count)
+        ensure_no_partial_run!(export_dir, app_id, sentry_cli, main_branch) if current_branch == main_branch
+
+        upload_dir, all_names_file = select_changed_snapshots(export_dir, app_id, sentry_cli, main_branch)
+        if upload_dir
+          changed = png_count(upload_dir)
+          UI.success("Selective upload: #{changed} changed images (of #{png_count(export_dir)})")
+          Actions.sh(sentry_cli, "snapshots", "upload", "--app-id", app_id,
+                     "--selective", "--all-image-file-names-file", all_names_file, upload_dir)
+        else
+          Actions.sh(sentry_cli, "snapshots", "upload", "--app-id", app_id, export_dir)
+        end
+      end
+
+      def self.ensure_min_count!(export_dir, min_count)
+        image_count = png_count(export_dir)
+        return if image_count >= min_count
+
+        UI.user_error!("Only #{image_count} snapshots were generated in #{export_dir} (expected at least #{min_count}). " \
+                       "A partial run uploaded as a baseline would mark the missing snapshots as removed on every open PR.")
+      end
+
+      # Only the main branch's upload replaces the shared baseline; a partial
+      # upload from any other branch affects nothing but that PR's own diff.
+      def self.ensure_no_partial_run!(export_dir, app_id, sentry_cli, main_branch)
+        return if ENV["SNAPSHOT_COUNT_OVERRIDE"] == "1"
+
+        base_dir = File.join(Dir.mktmpdir("snapshots"), "baseline-count")
+        begin
+          download_baseline(base_dir, app_id, sentry_cli, main_branch)
+        rescue StandardError => e
+          UI.user_error!("Could not download the baseline for the partial-run check (#{e.message}). " \
+                         "Refusing to upload unverified; set SNAPSHOT_COUNT_OVERRIDE=1 to bypass (e.g. the first-ever upload).")
+        end
+        baseline = png_count(base_dir)
+        return if baseline.zero?
+
+        generated = png_count(export_dir)
+        return if generated >= (baseline * 0.9).floor
+
+        UI.user_error!("Generated #{generated} snapshots; the #{main_branch} baseline has #{baseline}. " \
+                       "Refusing to upload what looks like a partial run. Set SNAPSHOT_COUNT_OVERRIDE=1 for intentional removals.")
+      end
+
+      # Stages only changed/added images (with their .json sidecars, which
+      # carry display names and tags) for a --selective upload. Returns
+      # [upload_dir, all_names_file], or nil on any failure (callers then
+      # full-upload).
+      def self.select_changed_snapshots(export_dir, app_id, sentry_cli, main_branch)
+        work_dir = Dir.mktmpdir("snapshots")
+        base_dir = File.join(work_dir, "base")
+        download_baseline(base_dir, app_id, sentry_cli, main_branch)
+        return nil if png_count(base_dir).zero?
+
+        diff_json = Actions.sh(sentry_cli, "snapshots", "diff", base_dir, export_dir, log: false)
+        results = JSON.parse(diff_json[/\{.*\}/m])
+        # The diff reports one entry per image with a status; there are no
+        # top-level changed/added arrays.
+        changed = (results["images"] || [])
+                  .select { |image| CHANGED_STATUSES.include?(image["status"]) }
+                  .map { |image| image["name"] }
+
+        upload_dir = File.join(work_dir, "changed")
+        stage_images(changed, export_dir, upload_dir)
+
+        # The complete name list lets Sentry distinguish skipped from removed.
+        all_names_file = File.join(work_dir, "snapshot-names.txt")
+        all_names = Dir.glob("#{export_dir}/**/*.png").map { |f| f.delete_prefix("#{export_dir}/") }.sort
+        File.write(all_names_file, "#{all_names.join("\n")}\n")
+
+        [upload_dir, all_names_file]
+      rescue StandardError => e
+        UI.important("Selective snapshot diff failed (#{e.message}); falling back to full upload")
+        nil
+      end
+
+      # Relative paths throughout, so nested exports survive the copy. Each
+      # image's .json sidecar (display name, tags) rides along when present.
+      def self.stage_images(changed, export_dir, upload_dir)
+        FileUtils.mkdir_p(upload_dir)
+        changed.each do |name|
+          relative = name.to_s
+          [relative, relative.sub(/\.png\z/, ".json")].each do |staged_relative|
+            source = File.join(export_dir, staged_relative)
+            next unless File.exist?(source)
+
+            destination = File.join(upload_dir, staged_relative)
+            FileUtils.mkdir_p(File.dirname(destination))
+            FileUtils.cp(source, destination)
+          end
+        end
+      end
+
+      def self.download_baseline(base_dir, app_id, sentry_cli, main_branch)
+        FileUtils.rm_rf(base_dir)
+        Actions.sh(sentry_cli, "snapshots", "download", "--app-id", app_id, "--branch", main_branch, "--output", base_dir, log: false)
+      end
+
+      def self.png_count(dir)
+        Dir.glob("#{dir}/**/*.png").count
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/revenuecat_internal/helper/sentry_snapshots_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/sentry_snapshots_helper.rb
@@ -71,6 +71,7 @@ module Fastlane
 
         diff_json = Actions.sh(sentry_cli, "snapshots", "diff", base_dir, export_dir, log: false)
         results = JSON.parse(diff_json[/\{.*\}/m])
+        log_diff_summary(results["summary"])
         # The diff reports one entry per image with a status; there are no
         # top-level changed/added arrays.
         changed = (results["images"] || [])
@@ -106,6 +107,13 @@ module Fastlane
             FileUtils.cp(source, destination)
           end
         end
+      end
+
+      def self.log_diff_summary(summary)
+        return if summary.nil?
+
+        UI.message("Snapshot diff vs baseline: #{summary['changed']} changed, #{summary['added']} added, " \
+                   "#{summary['unchanged']} unchanged, #{summary['removed']} removed")
       end
 
       def self.download_baseline(base_dir, app_id, sentry_cli, main_branch)

--- a/spec/helper/sentry_snapshots_helper_spec.rb
+++ b/spec/helper/sentry_snapshots_helper_spec.rb
@@ -1,0 +1,152 @@
+require 'fileutils'
+require 'tmpdir'
+
+describe Fastlane::Helper::SentrySnapshotsHelper do
+  let(:helper) { described_class }
+  let(:cli) { '/fake/sentry-cli' }
+  let(:app_id) { 'com.example.app' }
+  let(:export_dir) { Dir.mktmpdir('export') }
+
+  # Real output shape of `sentry-cli snapshots diff` (3.6.1): a summary block
+  # plus one entry per image with a status. Trailing human summary included.
+  let(:diff_output) do
+    <<~JSON
+      {
+        "base_dir": "base",
+        "head_dir": "head",
+        "threshold": 0.01,
+        "summary": { "total": 3, "changed": 1, "unchanged": 1, "added": 1, "removed": 0 },
+        "images": [
+          { "name": "images/unchanged.png", "status": "unchanged" },
+          { "name": "images/changed.png", "status": "changed", "diff_percentage": 12.3 },
+          { "name": "images/added.png", "status": "added" }
+        ]
+      }
+
+      Summary: 3 total, 1 changed, 1 unchanged, 1 added, 0 removed
+    JSON
+  end
+
+  def create_export_image(name, sidecar: false)
+    path = File.join(export_dir, name)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, 'png')
+    File.write(path.sub(/\.png\z/, '.json'), '{}') if sidecar
+  end
+
+  after { FileUtils.rm_rf(export_dir) }
+
+  describe '.ensure_min_count!' do
+    it 'fails when fewer images than the minimum were generated' do
+      create_export_image('images/a.png')
+      expect do
+        helper.ensure_min_count!(export_dir, 2)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /Only 1 snapshots/)
+    end
+
+    it 'passes at or above the minimum' do
+      create_export_image('images/a.png')
+      expect { helper.ensure_min_count!(export_dir, 1) }.not_to raise_error
+    end
+  end
+
+  describe '.select_changed_snapshots' do
+    before do
+      create_export_image('images/unchanged.png', sidecar: true)
+      create_export_image('images/changed.png', sidecar: true)
+      create_export_image('images/added.png', sidecar: true)
+
+      allow(Fastlane::Actions).to receive(:sh) do |*args, **_kwargs|
+        if args.include?('download')
+          base_dir = args[args.index('--output') + 1]
+          FileUtils.mkdir_p(File.join(base_dir, 'images'))
+          File.write(File.join(base_dir, 'images', 'unchanged.png'), 'png')
+          ''
+        elsif args.include?('diff')
+          diff_output
+        else
+          ''
+        end
+      end
+    end
+
+    it 'stages changed and added images with their sidecars' do
+      upload_dir, all_names_file = helper.select_changed_snapshots(export_dir, app_id, cli, 'main')
+
+      staged = Dir.glob("#{upload_dir}/**/*").select { |f| File.file?(f) }.map { |f| f.delete_prefix("#{upload_dir}/") }
+      expect(staged.sort).to eq([
+                                  'images/added.json',
+                                  'images/added.png',
+                                  'images/changed.json',
+                                  'images/changed.png'
+                                ])
+      expect(File.read(all_names_file).split("\n").sort).to eq([
+                                                                 'images/added.png',
+                                                                 'images/changed.png',
+                                                                 'images/unchanged.png'
+                                                               ])
+    end
+
+    it 'returns nil when there is no baseline' do
+      allow(Fastlane::Actions).to receive(:sh).and_return('')
+      expect(helper.select_changed_snapshots(export_dir, app_id, cli, 'main')).to be_nil
+    end
+
+    it 'returns nil when the diff fails' do
+      allow(Fastlane::Actions).to receive(:sh) do |*args, **_kwargs|
+        if args.include?('download')
+          base_dir = args[args.index('--output') + 1]
+          FileUtils.mkdir_p(base_dir)
+          File.write(File.join(base_dir, 'base.png'), 'png')
+          ''
+        else
+          raise StandardError, 'diff exploded'
+        end
+      end
+      expect(helper.select_changed_snapshots(export_dir, app_id, cli, 'main')).to be_nil
+    end
+  end
+
+  describe '.ensure_no_partial_run!' do
+    it 'is skipped by SNAPSHOT_COUNT_OVERRIDE' do
+      ENV['SNAPSHOT_COUNT_OVERRIDE'] = '1'
+      expect(Fastlane::Actions).not_to receive(:sh)
+      helper.ensure_no_partial_run!(export_dir, app_id, cli, 'main')
+    ensure
+      ENV.delete('SNAPSHOT_COUNT_OVERRIDE')
+    end
+
+    it 'fails when generated count is well below the baseline' do
+      create_export_image('images/a.png')
+      allow(Fastlane::Actions).to receive(:sh) do |*args, **_kwargs|
+        base_dir = args[args.index('--output') + 1]
+        FileUtils.mkdir_p(base_dir)
+        10.times { |i| File.write(File.join(base_dir, "b#{i}.png"), 'png') }
+        ''
+      end
+      expect do
+        helper.ensure_no_partial_run!(export_dir, app_id, cli, 'main')
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /partial run/)
+    end
+
+    it 'fails closed when the baseline download errors' do
+      allow(Fastlane::Actions).to receive(:sh).and_raise(StandardError, 'network down')
+      expect do
+        helper.ensure_no_partial_run!(export_dir, app_id, cli, 'main')
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /Refusing to upload unverified/)
+    end
+  end
+
+  describe '.upload_snapshots' do
+    it 'full-uploads on a branch with no baseline' do
+      create_export_image('images/a.png')
+      allow(Fastlane::Actions).to receive(:sh).and_return('')
+      expect(Fastlane::Actions).to receive(:sh).with(cli, 'snapshots', 'upload', '--app-id', app_id, export_dir)
+
+      helper.upload_snapshots(
+        export_dir: export_dir, app_id: app_id, sentry_cli: cli,
+        min_count: 1, main_branch: 'main', current_branch: 'feature'
+      )
+    end
+  end
+end

--- a/spec/helper/sentry_snapshots_helper_spec.rb
+++ b/spec/helper/sentry_snapshots_helper_spec.rb
@@ -70,6 +70,11 @@ describe Fastlane::Helper::SentrySnapshotsHelper do
       end
     end
 
+    it 'logs the diff breakdown' do
+      expect(Fastlane::UI).to receive(:message).with('Snapshot diff vs baseline: 1 changed, 1 added, 1 unchanged, 0 removed')
+      helper.select_changed_snapshots(export_dir, app_id, cli, 'main')
+    end
+
     it 'stages changed and added images with their sidecars' do
       upload_dir, all_names_file = helper.select_changed_snapshots(export_dir, app_id, cli, 'main')
 


### PR DESCRIPTION
## Problem

iOS and Android each carry their own copy of the Sentry Snapshots upload logic in their Fastfiles, and the copies have already drifted once: a diff parsing bug got fixed on the Android side while iOS still has it.

## Fix

One `upload_snapshots_to_sentry` action that owns everything after image generation. It refuses partial runs that would wreck the main baseline, uploads only the images that changed (Sentry bills per image), and falls back to a full upload when there is no baseline yet. The app repos keep their own generation (Emerge on iOS, Paparazzi on Android) and their lanes shrink to generate plus one action call.

## How was this tested?

New specs cover the guards, the selective staging, and the fallback paths against captured output from a real sentry-cli diff. Full suite passes and rubocop is clean.
