### PR TITLE
Guard snapshots on sentry-cli >= 3.6.0 and surface download errors

### DIFF
--- a/lib/fastlane/plugin/revenuecat_internal/helper/sentry_snapshots_helper.rb
+++ b/lib/fastlane/plugin/revenuecat_internal/helper/sentry_snapshots_helper.rb
@@ -16,7 +16,11 @@ module Fastlane
       # layout_changed is sentry-cli's status for an odiff dimension change; it is
       # a real change and must be uploaded like changed/added, not skipped.
       CHANGED_STATUSES = %w[changed layout_changed added].freeze
+      # 3.5.x resolves the baseline but 404s downloading it (fixed in 3.6.0), which
+      # silently degrades every run to a full upload. Require the fixed line.
+      MIN_SENTRY_CLI_VERSION = "3.6.0".freeze
       def self.upload_snapshots(export_dir:, app_id:, sentry_cli:, min_count:, main_branch:, current_branch:)
+        ensure_sentry_cli_version!(sentry_cli)
         ensure_min_count!(export_dir, min_count)
         ensure_no_partial_run!(export_dir, app_id, sentry_cli, main_branch) if current_branch == main_branch
 
@@ -39,6 +43,17 @@ module Fastlane
         else
           Actions.sh(sentry_cli, "snapshots", "upload", "--app-id", app_id, export_dir)
         end
+      end
+
+      # Fail loudly on an old sentry-cli instead of silently falling back to a
+      # full upload (which is how a 3.5.x download 404 hid itself for weeks).
+      def self.ensure_sentry_cli_version!(sentry_cli)
+        version = Actions.sh(sentry_cli, "--version", log: false)[/\d+\.\d+\.\d+/]
+        UI.user_error!("Could not read the sentry-cli version from '#{sentry_cli}'.") if version.nil?
+        return if Gem::Version.new(version) >= Gem::Version.new(MIN_SENTRY_CLI_VERSION)
+
+        UI.user_error!("sentry-cli #{version} is too old for snapshots; #{MIN_SENTRY_CLI_VERSION}+ is required " \
+                       "(3.5.x returns 404 from `snapshots download`). Bump fastlane-plugin-sentry.")
       end
 
       def self.ensure_min_count!(export_dir, min_count)
@@ -130,7 +145,9 @@ module Fastlane
 
       def self.download_baseline(base_dir, app_id, sentry_cli, main_branch)
         FileUtils.rm_rf(base_dir)
-        Actions.sh(sentry_cli, "snapshots", "download", "--app-id", app_id, "--branch", main_branch, "--output", base_dir, log: false)
+        # No log: false here on purpose: if the download fails, its output (e.g. a
+        # 404) must reach the CI log instead of being swallowed behind a bare exit code.
+        Actions.sh(sentry_cli, "snapshots", "download", "--app-id", app_id, "--branch", main_branch, "--output", base_dir)
       end
 
       def self.png_count(dir)

--- a/spec/helper/sentry_snapshots_helper_spec.rb
+++ b/spec/helper/sentry_snapshots_helper_spec.rb
@@ -150,6 +150,7 @@ describe Fastlane::Helper::SentrySnapshotsHelper do
   describe '.upload_snapshots' do
     it 'full-uploads on a branch with no baseline' do
       create_export_image('images/a.png')
+      allow(helper).to receive(:ensure_sentry_cli_version!)
       allow(Fastlane::Actions).to receive(:sh).and_return('')
       expect(Fastlane::Actions).to receive(:sh).with(cli, 'snapshots', 'upload', '--app-id', app_id, export_dir)
 
@@ -163,6 +164,7 @@ describe Fastlane::Helper::SentrySnapshotsHelper do
     # would produce no snapshot at all; the lane skips it instead.
     it 'skips the upload when nothing changed vs the baseline' do
       create_export_image('images/a.png', sidecar: true)
+      allow(helper).to receive(:ensure_sentry_cli_version!)
       upload_called = false
       allow(Fastlane::Actions).to receive(:sh) do |*args, **_kwargs|
         upload_called = true if args.include?('upload')
@@ -184,6 +186,20 @@ describe Fastlane::Helper::SentrySnapshotsHelper do
         min_count: 1, main_branch: 'main', current_branch: 'feature'
       )
       expect(upload_called).to be(false)
+    end
+  end
+
+  describe '.ensure_sentry_cli_version!' do
+    it 'passes on 3.6.0 or newer' do
+      allow(Fastlane::Actions).to receive(:sh).and_return('sentry-cli 3.6.2')
+      expect { helper.ensure_sentry_cli_version!(cli) }.not_to raise_error
+    end
+
+    it 'fails loudly on 3.5.x (the version that 404s on download)' do
+      allow(Fastlane::Actions).to receive(:sh).and_return('sentry-cli 3.5.0')
+      expect do
+        helper.ensure_sentry_cli_version!(cli)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /too old/)
     end
   end
 end


### PR DESCRIPTION
## Problem

When sentry-cli's `snapshots download` fails, the snapshot flow degrades silently: `select_changed_snapshots` catches the error and falls back to a full upload, and the download runs with `log: false`, so the real cause never reaches the log. That masked a real bug: sentry-cli 3.5.x resolves the baseline but 404s downloading it (fixed in 3.6.0), so on 3.5.x every run quietly fell back to a full upload and the main partial-run gate hard-failed with only a bare exit code to go on.

## Fix

- Require sentry-cli >= 3.6.0 up front (`ensure_sentry_cli_version!`) and fail with a clear message, instead of degrading silently on an old CLI.
- Stop swallowing the baseline download output so a failure (like the 404) reaches the CI log.

<details>
<summary>Details</summary>

### Testing

`bundle exec rspec spec/helper/sentry_snapshots_helper_spec.rb` (13 examples, 0 failures). Added cases for the version guard passing on 3.6.0+ and failing on 3.5.x.

### Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [ ] Breaking changes documented

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
